### PR TITLE
Update release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
         run: |
           mkdir -p ./dist
           mkdir -p editors/code/bin
-          if [ "${{ matrix.host }}" = "windows" ]; then
+          if [ "${{ matrix.os }}" = "windows-latest" ]; then
             cp build/Release/luau-lsp.exe editors/code/bin/server.exe
           else
             cp build/luau-lsp editors/code/bin/server
@@ -76,7 +76,7 @@ jobs:
         shell: bash
         run: |
           mkdir staging
-          if [ "${{ matrix.host }}" = "windows" ]; then
+          if [ "${{ matrix.os }}" = "windows-latest" ]; then
             cp "build/Release/luau-lsp.exe" staging/
             cd staging
             7z a ../dist/server.zip *

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,9 +104,9 @@ jobs:
         working-directory: editors/code
         run: npx vsce package -o "../../dist/luau-lsp-${{ matrix.code-target }}.vsix" --target ${{ matrix.code-target }}
 
-      - name: Publish Extension
-        working-directory: editors/code
-        run: npx vsce publish --pat ${{ secrets.MARKETPLACE_TOKEN }} --packagePath ../../dist/luau-lsp-*.vsix
+      # - name: Publish Extension
+      #   working-directory: editors/code
+      #   run: npx vsce publish --pat ${{ secrets.MARKETPLACE_TOKEN }} --packagePath ../../dist/luau-lsp-*.vsix
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,7 +108,7 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v1
         with:
-          name: dist-${{ matrix.code-target }}
+          name: dist-${{ matrix.artifact-name }}
           path: ./dist
 
       - name: Upload Server to Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,11 +99,11 @@ jobs:
 
       - name: Package Extension
         working-directory: editors/code
-        run: npx vsce package -o "../../dist/luau-lsp-${{ matrix.code-target }}.vsix" --target ${{ join(matrix.code-target, ' ') }}
+        run: npx vsce package -o "../../dist/extension.vsix" --target ${{ join(matrix.code-target, ' ') }}
 
       # - name: Publish Extension
       #   working-directory: editors/code
-      #   run: npx vsce publish --pat ${{ secrets.MARKETPLACE_TOKEN }} --packagePath ../../dist/luau-lsp-*.vsix
+      #   run: npx vsce publish --pat ${{ secrets.MARKETPLACE_TOKEN }} --packagePath ../../dist/extension.vsix
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v1
@@ -127,6 +127,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.create-release.outputs.upload_url }}
-          asset_path: ./dist/luau-lsp-${{ matrix.code-target }}.vsix
-          asset_name: luau-lsp-${{ matrix.code-target }}.vsix
+          asset_path: ./dist/extension.vsix
+          asset_name: ${{ matrix.artifact-name }}.vsix
           asset_content_type: application/octet-stream

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,17 +94,6 @@ jobs:
           rm -f editors/code/CHANGELOG.md
           cp CHANGELOG.md editors/code/CHANGELOG.md
 
-      - run: npm ci
-        working-directory: editors/code
-
-      - name: Package Extension
-        working-directory: editors/code
-        run: npx vsce package -o "../../dist/extension.vsix" --target ${{ join(matrix.code-target, ' ') }}
-
-      # - name: Publish Extension
-      #   working-directory: editors/code
-      #   run: npx vsce publish --pat ${{ secrets.MARKETPLACE_TOKEN }} --packagePath ../../dist/extension.vsix
-
       - name: Upload artifacts
         uses: actions/upload-artifact@v1
         with:
@@ -121,12 +110,9 @@ jobs:
           asset_name: ${{ matrix.artifact-name }}.zip
           asset_content_type: application/octet-stream
 
-      - name: Upload Extension to Release
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create-release.outputs.upload_url }}
-          asset_path: ./dist/extension.vsix
-          asset_name: ${{ matrix.artifact-name }}.vsix
-          asset_content_type: application/octet-stream
+      - run: npm ci
+        working-directory: editors/code
+
+      - name: Publish Extension
+        working-directory: editors/code
+        run: npx vsce publish --pat ${{ secrets.MARKETPLACE_TOKEN }} --target ${{ join(matrix.code-target, ' ') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
             artifact-name: luau-lsp-macos
             code-target: [darwin-x64, darwin-arm64]
 
-    name: ${{ matrix.os }} - ${{ matrix.code-target }}
+    name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,16 +29,13 @@ jobs:
         include:
           - os: windows-latest
             artifact-name: luau-lsp-win64
-            code-target: win32-x64
+            code-target: [win32-x64]
           - os: ubuntu-latest
             artifact-name: luau-lsp-linux
-            code-target: linux-x64
+            code-target: [linux-x64]
           - os: macos-latest
             artifact-name: luau-lsp-macos
-            code-target: darwin-x64
-          - os: macos-latest
-            artifact-name: luau-lsp-macos-aarch64
-            code-target: darwin-arm64 # TODO: we should try and merge this with above, because it runs the exact same steps
+            code-target: [darwin-x64, darwin-arm64]
 
     name: ${{ matrix.os }} - ${{ matrix.code-target }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,17 +6,38 @@ on:
   workflow_dispatch:
 
 jobs:
+  create-release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    outputs:
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
+    steps:
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          draft: true
+
   dist:
+    needs: ["create-release"]
     strategy:
       matrix:
         include:
           - os: windows-latest
+            artifact-name: luau-lsp-win64
             code-target: win32-x64
           - os: ubuntu-latest
+            artifact-name: luau-lsp-linux
             code-target: linux-x64
           - os: macos-latest
+            artifact-name: luau-lsp-macos
             code-target: darwin-x64
           - os: macos-latest
+            artifact-name: luau-lsp-macos-aarch64
             code-target: darwin-arm64 # TODO: we should try and merge this with above, because it runs the exact same steps
 
     name: ${{ matrix.os }} - ${{ matrix.code-target }}
@@ -32,7 +53,7 @@ jobs:
         with:
           node-version: 14.x
 
-      - name: Dist
+      - name: Build Server
         run: |
           mkdir build && cd build
           cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON
@@ -42,25 +63,31 @@ jobs:
         if: matrix.os == 'macos-latest'
         run: lipo -archs build/luau-lsp
 
-      - name: Move Build + Copy into Extension
-        if: matrix.os == 'windows-latest'
+      - name: Copy Build into Extension
         shell: bash
         run: |
           mkdir -p ./dist
-          mv build/Release/luau-lsp.exe ./dist/luau-lsp.exe
           mkdir -p editors/code/bin
-          cp ./dist/luau-lsp.exe editors/code/bin/server.exe
-          mv ./dist/luau-lsp.exe ./dist/luau-lsp-${{ matrix.code-target }}.exe
+          if [ "${{ matrix.host }}" = "windows" ]; then
+            cp build/Release/luau-lsp.exe editors/code/bin/server.exe
+          else
+            cp build/luau-lsp editors/code/bin/server
+            chmod 777 editors/code/bin/server
+          fi
 
-      - name: Move Build
-        if: matrix.os != 'windows-latest'
+      - name: Create Release Archive
+        shell: bash
         run: |
-          mkdir -p ./dist
-          mv build/luau-lsp ./dist/luau-lsp
-          mkdir -p editors/code/bin
-          cp ./dist/luau-lsp editors/code/bin/server
-          chmod 777 editors/code/bin/server
-          mv ./dist/luau-lsp ./dist/luau-lsp-${{ matrix.code-target }}
+          mkdir staging
+          if [ "${{ matrix.host }}" = "windows" ]; then
+            cp "build/Release/luau-lsp.exe" staging/
+            cd staging
+            7z a ../dist/server.zip *
+          else
+            cp "build/luau-lsp" staging/
+            cd staging
+            zip ../dist/server.zip *
+          fi
 
       - name: Copy README and CHANGELOG
         shell: bash
@@ -73,9 +100,13 @@ jobs:
       - run: npm ci
         working-directory: editors/code
 
-      - name: Package Extension (release)
-        run: npx vsce package -o "../../dist/luau-lsp-${{ matrix.code-target }}.vsix" --target ${{ matrix.code-target }}
+      - name: Package Extension
         working-directory: editors/code
+        run: npx vsce package -o "../../dist/luau-lsp-${{ matrix.code-target }}.vsix" --target ${{ matrix.code-target }}
+
+      - name: Publish Extension
+        working-directory: editors/code
+        run: npx vsce publish --pat ${{ secrets.MARKETPLACE_TOKEN }} --packagePath ../../dist/luau-lsp-*.vsix
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v1
@@ -83,51 +114,22 @@ jobs:
           name: dist-${{ matrix.code-target }}
           path: ./dist
 
-  publish:
-    name: publish
-    runs-on: ubuntu-latest
-    needs: ["dist"]
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-
-      - name: Install Nodejs
-        uses: actions/setup-node@v1
-        with:
-          node-version: 14.x
-
-      - uses: actions/download-artifact@v1
-        with:
-          name: dist-darwin-x64
-          path: dist
-      - uses: actions/download-artifact@v1
-        with:
-          name: dist-linux-x64
-          path: dist
-      - uses: actions/download-artifact@v1
-        with:
-          name: dist-win32-x64
-          path: dist
-      - uses: actions/download-artifact@v1
-        with:
-          name: dist-darwin-arm64
-          path: dist
-      - run: ls -al ./dist
-
-      - name: Publish Release
-        uses: ncipollo/release-action@v1
+      - name: Upload Server to Release
+        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          # tag: ${{ github.event.inputs.version }}
-          # name: ${{ github.event.inputs.version }}
-          draft: true
-          token: ${{ secrets.GITHUB_TOKEN }}
-          artifacts: "dist/*"
+          upload_url: ${{ needs.create-release.outputs.upload_url }}
+          asset_path: ./dist/server.zip
+          asset_name: ${{ matrix.artifact-name }}.zip
+          asset_content_type: application/octet-stream
 
-      - run: npm ci
-        working-directory: editors/code
-
-      - name: Publish Extension
-        working-directory: editors/code
-        run: npx vsce publish --pat ${{ secrets.MARKETPLACE_TOKEN }} --packagePath ../../dist/luau-lsp-*.vsix
+      - name: Upload Extension to Release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create-release.outputs.upload_url }}
+          asset_path: ./dist/luau-lsp-${{ matrix.code-target }}.vsix
+          asset_name: luau-lsp-${{ matrix.code-target }}.vsix
+          asset_content_type: application/octet-stream

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,7 +99,7 @@ jobs:
 
       - name: Package Extension
         working-directory: editors/code
-        run: npx vsce package -o "../../dist/luau-lsp-${{ matrix.code-target }}.vsix" --target ${{ matrix.code-target }}
+        run: npx vsce package -o "../../dist/luau-lsp-${{ matrix.code-target }}.vsix" --target ${{ join(matrix.code-target, ' ') }}
 
       # - name: Publish Extension
       #   working-directory: editors/code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,13 +86,15 @@ jobs:
             zip ../dist/server.zip *
           fi
 
-      - name: Copy README and CHANGELOG
+      - name: Copy README, CHANGELOG, LICENSE
         shell: bash
         run: |
           rm -f editors/code/README.md
           cp README.md editors/code/README.md
           rm -f editors/code/CHANGELOG.md
           cp CHANGELOG.md editors/code/CHANGELOG.md
+          rm -f editors/code/LICENSE.md
+          cp LICENSE.md editors/code/LICENSE
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v1

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -14,6 +14,9 @@
     "bugs": {
         "url": "https://github.com/JohnnyMorganz/luau-lsp/issues"
     },
+    "sponsor": {
+        "url": "https://github.com/sponsors/JohnnyMorganz"
+    },
     "version": "1.4.0",
     "engines": {
         "vscode": "^1.67.0"


### PR DESCRIPTION
- Use zip for binaries
- Skip packaging extensions, instead publish directly
- Copy LICENSE into extension
- Remove need to build macos binary twice, now only built once with 2 targets specified