### PR TITLE
Add support for registering definition files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Added predicate logic to `EnumItem:IsA("Type")` so it will now narrow the type of an EnumItem when used as a predicate
 - Added setting to configure whether all Luau FFlags are enabled by default. This can be configured using `luau-lsp.fflags.enableByDefault` or `--no-flags-enabled` command line option. Currently, all FFlags are enabled by default, but you can manually sync/override them.
+- Added support for adding extra definition files to load using `luau-lsp.types.definitionFiles`
+- Roblox definitions can now be disabled using `luau-lsp.types.roblox`
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -11,12 +11,14 @@ Install the extension from the marketplace: https://marketplace.visualstudio.com
 The langauge server should be immediately usable for general Luau code after installation.
 String require support is provided for relative module paths, using `require("../module")`.
 
+Type definitions can be provided by configuring `luau-lsp.types.definitionFiles`.
+
 If there are specific features you require in the language server for your use case, feel free to open an issue.
 
 ### For Rojo Users
 
 Rojo instance tree and requiring support is provided by default, and the language server should be able to directly emulate Studio.
-The extension will automatically populate the latest API types and documentation.
+The extension will automatically populate the latest API types and documentation (which can be disabled by configuring `luau-lsp.types.roblox`).
 
 To resolve your instance tree and provide module resolution, the language server uses Rojo sourcemaps.
 The language server will automatically create a `sourcemap.json` in your workspace root on startup and whenever files are added/created/renamed.

--- a/editors/code/package-lock.json
+++ b/editors/code/package-lock.json
@@ -1,16 +1,17 @@
 {
     "name": "luau-lsp",
-    "version": "0.2.0",
+    "version": "1.4.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "luau-lsp",
-            "version": "0.2.0",
+            "version": "1.4.0",
             "license": "MIT",
             "dependencies": {
                 "node-fetch": "^3.2.4",
-                "vscode-languageclient": "^7.0.0"
+                "vscode-languageclient": "^7.0.0",
+                "vscode-uri": "^3.0.3"
             },
             "devDependencies": {
                 "@types/glob": "^7.2.0",
@@ -3461,6 +3462,11 @@
             "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
             "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
         },
+        "node_modules/vscode-uri": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.3.tgz",
+            "integrity": "sha512-EcswR2S8bpR7fD0YPeS7r2xXExrScVMxg4MedACaWHEtx9ftCF/qHG1xGkolzTPcEmjTavCQgbVzHUIdTMzFGA=="
+        },
         "node_modules/watchpack": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.3.1.tgz",
@@ -6260,6 +6266,11 @@
             "version": "3.16.0",
             "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
             "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
+        },
+        "vscode-uri": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.3.tgz",
+            "integrity": "sha512-EcswR2S8bpR7fD0YPeS7r2xXExrScVMxg4MedACaWHEtx9ftCF/qHG1xGkolzTPcEmjTavCQgbVzHUIdTMzFGA=="
         },
         "watchpack": {
             "version": "2.3.1",

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -122,6 +122,19 @@
                     "markdownDescription": "Compute diagnostics for the whole workspace",
                     "type": "boolean",
                     "default": false
+                },
+                "luau-lsp.types.definitionFiles": {
+                    "markdownDescription": "A list of paths to definition files to load in to the type checker. Note that definition file syntax is currently unstable and may change at any time",
+                    "type": "array",
+                    "default": [],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "luau-lsp.types.roblox": {
+                    "markdownDescription": "Load in and automatically update Roblox type definitions for the type checker",
+                    "type": "boolean",
+                    "default": true
                 }
             }
         }
@@ -157,6 +170,7 @@
     },
     "dependencies": {
         "node-fetch": "^3.2.4",
-        "vscode-languageclient": "^7.0.0"
+        "vscode-languageclient": "^7.0.0",
+        "vscode-uri": "^3.0.3"
     }
 }

--- a/src/include/LSP/Client.hpp
+++ b/src/include/LSP/Client.hpp
@@ -16,7 +16,7 @@ public:
     lsp::ClientCapabilities capabilities;
     lsp::TraceValue traceMode = lsp::TraceValue::Off;
     /// A registered definitions file passed by the client
-    std::optional<std::filesystem::path> definitionsFile = std::nullopt;
+    std::vector<std::filesystem::path> definitionsFiles;
     /// A registered documentation file passed by the client
     std::optional<std::filesystem::path> documentationFile = std::nullopt;
     /// Parsed documentation database

--- a/src/include/LSP/LanguageServer.hpp
+++ b/src/include/LSP/LanguageServer.hpp
@@ -24,10 +24,10 @@ public:
     std::vector<WorkspaceFolderPtr> workspaceFolders;
     ClientPtr client;
 
-    LanguageServer(std::optional<std::filesystem::path> definitionsFile, std::optional<std::filesystem::path> documentationFile)
+    LanguageServer(std::vector<std::filesystem::path> definitionsFiles, std::optional<std::filesystem::path> documentationFile)
         : client(std::make_shared<Client>())
     {
-        client->definitionsFile = definitionsFile;
+        client->definitionsFiles = definitionsFiles;
         client->documentationFile = documentationFile;
         parseDocumentation(documentationFile, client->documentation, client);
         nullWorkspace = std::make_shared<WorkspaceFolder>(client, "$NULL_WORKSPACE", Uri());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -120,13 +120,13 @@ int startLanguageServer(int argc, char** argv)
     _setmode(_fileno(stdout), _O_BINARY);
 #endif
 
-    std::optional<std::filesystem::path> definitionsFile;
+    std::vector<std::filesystem::path> definitionsFiles;
     std::optional<std::filesystem::path> documentationFile;
     for (int i = 1; i < argc; i++)
     {
         if (strncmp(argv[i], "--definitions=", 14) == 0)
         {
-            definitionsFile = std::filesystem::path(argv[i] + 14);
+            definitionsFiles.emplace_back(argv[i] + 14);
         }
         else if (strncmp(argv[i], "--docs=", 7) == 0)
         {
@@ -134,7 +134,7 @@ int startLanguageServer(int argc, char** argv)
         }
     }
 
-    LanguageServer server(definitionsFile, documentationFile);
+    LanguageServer server(definitionsFiles, documentationFile);
 
     // Begin input loop
     server.processInputLoop();


### PR DESCRIPTION
Paths to definition files can be added in `luau-lsp.types.definitionFiles`
Roblox types can be disabled using `luau-lsp.types.roblox`

Part of #29 
Also related to #40 