### PR TITLE
Add environment support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Deprecated
+
+- `luau-lsp.types.definitionFiles` has been deprecated in favour of environment support. Instead, create an environment in `luau-lsp.types.environments` and then assign a glob "\*" to your environment.
+
+### Added
+
+- Added support for environments. You can now configure environments with definition files attached to them, then assign a glob pattern an environment, using `luau-lsp.types.environments` and `luau-lsp.types.environmentGlobs`. For example, adding an environment "testez" pointing to a testez definitions file, then globbing "\*.spec.lua" to "testez". This deprecates global definitions configuration `luau-lsp.types.definitionFiles`
+
 ### Changed
 
 - Sync to upstream Luau 0.537

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -149,6 +149,7 @@
                 },
                 "luau-lsp.types.definitionFiles": {
                     "markdownDescription": "A list of paths to definition files to load in to the type checker. Note that definition file syntax is currently unstable and may change at any time",
+                    "markdownDeprecationMessage": "**Deprecated**: Please use `#luau-lsp.types.builtinDefinitions#` and `#luau-lsp.types.environments#` instead.",
                     "type": "array",
                     "default": [],
                     "items": {
@@ -159,6 +160,24 @@
                     "markdownDescription": "Load in and automatically update Roblox type definitions for the type checker",
                     "type": "boolean",
                     "default": true
+                },
+                "luau-lsp.types.environments": {
+                    "markdownDescription": "A map between environment names and a path to a definition file to register. See `#luau-lsp.types.environmentGlobs#` for applying an environment to a file",
+                    "type": "object",
+                    "default": {},
+                    "additionalProperties": {
+                        "type": "string",
+                        "description": "A path to a definitions file"
+                    }
+                },
+                "luau-lsp.types.environmentGlobs": {
+                    "markdownDescription": "A map between globs and the environment they are registered too. Only one environment can be applied per file: ensure globs are uniqued as the order applied is indeterminate",
+                    "type": "object",
+                    "default": {},
+                    "additionalProperties": {
+                        "type": "string",
+                        "description": "An environment name to link to"
+                    }
                 }
             }
         }

--- a/src/AnalyzeCli.cpp
+++ b/src/AnalyzeCli.cpp
@@ -190,8 +190,7 @@ int startAnalyze(int argc, char** argv)
     Luau::FrontendOptions frontendOptions;
     frontendOptions.retainFullTypeGraphs = annotate;
 
-    WorkspaceFileResolver fileResolver;
-    fileResolver.rootUri = Uri::file(std::filesystem::current_path());
+    WorkspaceFileResolver fileResolver(Uri::file(std::filesystem::current_path()));
     Luau::Frontend frontend(&fileResolver, &fileResolver, frontendOptions);
 
     if (sourcemapPath)

--- a/src/LanguageServer.cpp
+++ b/src/LanguageServer.cpp
@@ -12,7 +12,6 @@ using json = nlohmann::json;
 using namespace json_rpc;
 using Response = json;
 using WorkspaceFolderPtr = std::shared_ptr<WorkspaceFolder>;
-using ClientPtr = std::shared_ptr<Client>;
 
 #define REQUIRED_PARAMS(params, method) \
     !params ? throw json_rpc::JsonRpcException(lsp::ErrorCode::InvalidParams, "params not provided for " method) : params.value()

--- a/src/WorkspaceFileResolver.cpp
+++ b/src/WorkspaceFileResolver.cpp
@@ -1,6 +1,7 @@
 #include <optional>
 #include <unordered_map>
 #include <iostream>
+#include "glob/glob.hpp"
 #include "Luau/Ast.h"
 #include "LSP/WorkspaceFileResolver.hpp"
 #include "LSP/Utils.hpp"
@@ -245,6 +246,27 @@ std::string WorkspaceFileResolver::getHumanReadableModuleName(const Luau::Module
     {
         return name;
     }
+}
+
+std::optional<std::string> WorkspaceFileResolver::getEnvironmentForModule(const Luau::ModuleName& name) const
+{
+    if (!client)
+        return std::nullopt;
+
+    auto path = resolveToRealPath(name);
+    if (!path)
+        return std::nullopt;
+
+    // We want to test globs against a relative path to workspace, since thats what makes most sense
+    auto relativePath = path->lexically_relative(rootUri.fsPath()).generic_string(); // HACK: we convert to generic string so we get '/' separators
+
+    auto config = client->getConfiguration(rootUri);
+    for (auto& [glob, environment] : config.types.environmentGlobs)
+    {
+        if (glob::fnmatch_case(relativePath, glob))
+            return environment;
+    }
+    return std::nullopt;
 }
 
 const Luau::Config& WorkspaceFileResolver::getConfig(const Luau::ModuleName& name) const

--- a/src/include/LSP/Client.hpp
+++ b/src/include/LSP/Client.hpp
@@ -15,8 +15,10 @@ class Client
 public:
     lsp::ClientCapabilities capabilities;
     lsp::TraceValue traceMode = lsp::TraceValue::Off;
-    /// A registered definitions file passed by the client
-    std::vector<std::filesystem::path> definitionsFiles;
+    /// [DEPRECATED] A registered definitions file passed by the client
+    std::vector<std::filesystem::path> definitionsFiles_DEPRECATED;
+    std::unordered_map<std::string, std::filesystem::path> environments;
+
     /// A registered documentation file passed by the client
     std::optional<std::filesystem::path> documentationFile = std::nullopt;
     /// Parsed documentation database
@@ -73,3 +75,5 @@ public:
 private:
     void sendRawMessage(const json& message);
 };
+
+using ClientPtr = std::shared_ptr<Client>;

--- a/src/include/LSP/ClientConfiguration.hpp
+++ b/src/include/LSP/ClientConfiguration.hpp
@@ -28,10 +28,12 @@ struct ClientTypesConfiguration
 {
     /// Whether Roblox-related definitions should be supported
     bool roblox = true;
-    /// Any definition files to load globally
+    /// [DEPRECATED] Any definition files to load globally
     std::vector<std::filesystem::path> definitionFiles;
+    /// A map between globs and the environment they are registered too
+    std::unordered_map<std::string, std::string> environmentGlobs;
 };
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(ClientTypesConfiguration, roblox, definitionFiles);
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(ClientTypesConfiguration, roblox, definitionFiles, environmentGlobs);
 
 // These are the passed configuration options by the client, prefixed with `luau-lsp.`
 // Here we also define the default settings

--- a/src/include/LSP/LanguageServer.hpp
+++ b/src/include/LSP/LanguageServer.hpp
@@ -12,7 +12,6 @@ using json = nlohmann::json;
 using namespace json_rpc;
 using Response = json;
 using WorkspaceFolderPtr = std::shared_ptr<WorkspaceFolder>;
-using ClientPtr = std::shared_ptr<Client>;
 
 class LanguageServer
 {
@@ -24,12 +23,9 @@ public:
     std::vector<WorkspaceFolderPtr> workspaceFolders;
     ClientPtr client;
 
-    LanguageServer(std::vector<std::filesystem::path> definitionsFiles, std::optional<std::filesystem::path> documentationFile)
-        : client(std::make_shared<Client>())
+    LanguageServer(ClientPtr client)
+        : client(client)
     {
-        client->definitionsFiles = definitionsFiles;
-        client->documentationFile = documentationFile;
-        parseDocumentation(documentationFile, client->documentation, client);
         nullWorkspace = std::make_shared<WorkspaceFolder>(client, "$NULL_WORKSPACE", Uri());
     }
 

--- a/src/include/LSP/Workspace.hpp
+++ b/src/include/LSP/Workspace.hpp
@@ -21,7 +21,7 @@
 class WorkspaceFolder
 {
 public:
-    std::shared_ptr<Client> client;
+    ClientPtr client;
     std::string name;
     lsp::DocumentUri rootUri;
     WorkspaceFileResolver fileResolver;
@@ -32,10 +32,9 @@ public:
         : client(client)
         , name(name)
         , rootUri(uri)
-        , fileResolver(WorkspaceFileResolver())
+        , fileResolver(WorkspaceFileResolver(client, rootUri))
         , frontend(Luau::Frontend(&fileResolver, &fileResolver, {true}))
     {
-        fileResolver.rootUri = uri;
     }
 
     // Initialises the workspace folder


### PR DESCRIPTION
Adds support for type environments.

Environments can now be configured using `luau-lsp.types.environments` and `luau-lsp.types.environmentGlobs`.
You can create an environment name and point it to a definitions file, then assign an environment to a glob.

This is useful e.g. by creating a "testez" environment, only applicable to "*.spec.lua". TestEZ related global types will then only be available in those particular files, and will not pollute the global types.

In future, the environment name will be used for documentation parsing.

This extends onwards from #29 

`luau-lsp.types.definitionFiles` has been deprecated in favour of environments. Assign the glob "*" to a global environment.

Blocked on https://github.com/Roblox/luau/pull/610