### PR TITLE
More type improvements

### DIFF
--- a/scripts/dumpRobloxTypes.py
+++ b/scripts/dumpRobloxTypes.py
@@ -342,7 +342,7 @@ EXTRA_MEMBERS = {
         "function GetPlayers(self): { Player }"
     ],
     "Camera": [
-        "CameraSubject: Instance | BasePart | nil",
+        "CameraSubject: Humanoid | BasePart | nil",
         "function GetPartsObscuringTarget(self, castPoints: { Vector3 }, ignoreList: { Instance }): { BasePart }",
     ]
 }

--- a/scripts/dumpRobloxTypes.py
+++ b/scripts/dumpRobloxTypes.py
@@ -167,7 +167,6 @@ IGNORED_MEMBERS = {
         "UnionAsync",
     ],
     "Team": ["GetPlayers"],
-    "Teams": ["GetTeams"],
     "Camera": [
         "CameraSubject",
         "GetPartsObscuringTarget",
@@ -341,9 +340,6 @@ EXTRA_MEMBERS = {
     ],
     "Team": [
         "function GetPlayers(self): { Player }"
-    ],
-    "Teams": [
-        "function GetTeams(self): { Team }"
     ],
     "Camera": [
         "CameraSubject: Instance | BasePart | nil",

--- a/scripts/dumpRobloxTypes.py
+++ b/scripts/dumpRobloxTypes.py
@@ -347,7 +347,7 @@ EXTRA_MEMBERS = {
     ],
     "Camera": [
         "CameraSubject: Instance | BasePart | nil",
-	    "function GetPartsObscuringTarget(self, castPoints: { Vector3 }, ignoreList: { Instance }): { BasePart }",
+        "function GetPartsObscuringTarget(self, castPoints: { Vector3 }, ignoreList: { Instance }): { BasePart }",
     ]
 }
 
@@ -364,13 +364,13 @@ type RotationCurveKey = any
 type Instance = any
 
 declare class Enum
-	function GetEnumItems(self): { any }
+    function GetEnumItems(self): { any }
 end
 
 declare class EnumItem
-	Name: string
-	Value: number
-	EnumType: Enum
+    Name: string
+    Value: number
+    EnumType: Enum
     function IsA(self, enumName: string): boolean
 end
 
@@ -450,8 +450,8 @@ declare class GlobalSettings extends GenericSettings
     Physics: PhysicsSettings
     Rendering: RenderSettings
     Diagnostics: DebugSettings
-	function GetFFlag(self, name: string): boolean
-	function GetFVariable(self, name: string): string
+    function GetFFlag(self, name: string): boolean
+    function GetFVariable(self, name: string): string
 end
 
 declare game: DataModel

--- a/scripts/dumpRobloxTypes.py
+++ b/scripts/dumpRobloxTypes.py
@@ -158,7 +158,9 @@ IGNORED_MEMBERS = {
         "GetTouchingParts",
         "SubtractAsync",
         "UnionAsync",
-    ]
+    ],
+    "Team": ["GetPlayers"],
+    "Teams": ["GetTeams"],
 }
 
 # Extra members to add in to classes, commonly used to add in metamethods, and add corrections
@@ -320,7 +322,13 @@ EXTRA_MEMBERS = {
         "function GetTouchingParts(self): { BasePart }",
         "function SubtractAsync(self, parts: { BasePart }, collisionfidelity: EnumCollisionFidelity?, renderFidelity: EnumRenderFidelity?): UnionOperation",
         "function UnionAsync(self, parts: { BasePart }, collisionfidelity: EnumCollisionFidelity?, renderFidelity: EnumRenderFidelity?): UnionOperation",
-    ]
+    ],
+    "Team": [
+        "function GetPlayers(self): { Player }"
+    ],
+    "Teams": [
+        "function GetTeams(self): { Team }"
+    ],
 }
 
 # Hardcoded types

--- a/scripts/dumpRobloxTypes.py
+++ b/scripts/dumpRobloxTypes.py
@@ -103,7 +103,14 @@ IGNORED_MEMBERS = {
     ],
     "Players": ["GetPlayers"],
     "ContextActionService": ["BindAction", "BindActionAtPriority"],
-    "WorldRoot": ["Raycast"],
+    "WorldRoot": [
+        "Raycast",
+        "ArePartsTouchingOthers",
+        "BulkMoveTo",
+        "GetPartBoundsInBox",
+        "GetPartBoundsInRadius",
+        "GetPartsInPart",
+    ],
     "HttpService": ["RequestAsync"],
     "HumanoidDescription": [
         "GetAccessories",
@@ -262,7 +269,12 @@ EXTRA_MEMBERS = {
         "function CreateButton(self, id: string, toolTip: string, iconAsset: string, text: string?): PluginToolbarButton",
     ],
     "WorldRoot": [
-        "function Raycast(self, origin: Vector3, direction: Vector3, raycastParams: RaycastParams?): RaycastResult?"
+        "function Raycast(self, origin: Vector3, direction: Vector3, raycastParams: RaycastParams?): RaycastResult?",
+        "function ArePartsTouchingOthers(self, partList: { BasePart }, overlapIgnored: number?): boolean",
+        "function BulkMoveTo(self, partList: { BasePart }, cframeList: { CFrame }, eventMode: EnumBulkMoveMode?): nil",
+        "function GetPartBoundsInBox(self, cframe: CFrame, size: Vector3, overlapParams: OverlapParams?): { BasePart }",
+        "function GetPartBoundsInRadius(self, position: Vector3, radius: number, overlapParams: OverlapParams?): { BasePart }",
+        "function GetPartsInPart(self, part: BasePart, overlapParams: OverlapParams?): { BasePart }",
     ],
     "HttpService": [
         "function RequestAsync(self, options: HttpRequestOptions): HttpResponseData",

--- a/scripts/dumpRobloxTypes.py
+++ b/scripts/dumpRobloxTypes.py
@@ -168,6 +168,10 @@ IGNORED_MEMBERS = {
     ],
     "Team": ["GetPlayers"],
     "Teams": ["GetTeams"],
+    "Camera": [
+        "CameraSubject",
+        "GetPartsObscuringTarget",
+    ],
 }
 
 # Extra members to add in to classes, commonly used to add in metamethods, and add corrections
@@ -341,6 +345,10 @@ EXTRA_MEMBERS = {
     "Teams": [
         "function GetTeams(self): { Team }"
     ],
+    "Camera": [
+        "CameraSubject: Instance | BasePart | nil",
+	    "function GetPartsObscuringTarget(self, castPoints: { Vector3 }, ignoreList: { Instance }): { BasePart }",
+    ]
 }
 
 # Hardcoded types

--- a/scripts/globalTypes.d.lua
+++ b/scripts/globalTypes.d.lua
@@ -4823,7 +4823,7 @@ end
 
 declare class Camera extends Instance
 	CFrame: CFrame
-	CameraSubject: Instance
+	CameraSubject: Instance | BasePart | nil
 	CameraType: EnumCameraType
 	DiagonalFieldOfView: number
 	FieldOfView: number
@@ -4837,7 +4837,7 @@ declare class Camera extends Instance
 	NearPlaneZ: number
 	ViewportSize: Vector2
 	function GetPanSpeed(self): number
-	function GetPartsObscuringTarget(self, castPoints: { any }, ignoreList: { Instance }): { Instance }
+	function GetPartsObscuringTarget(self, castPoints: { Vector3 }, ignoreList: { Instance }): { BasePart }
 	function GetRenderCFrame(self): CFrame
 	function GetRoll(self): number
 	function GetTiltSpeed(self): number

--- a/scripts/globalTypes.d.lua
+++ b/scripts/globalTypes.d.lua
@@ -8954,7 +8954,7 @@ declare class Team extends Instance
 	PlayerAdded: RBXScriptSignal<Player>
 	PlayerRemoved: RBXScriptSignal<Player>
 	TeamColor: BrickColor
-	function GetPlayers(self): { Instance }
+	function GetPlayers(self): { Player }
 end
 
 declare class TeamCreateService extends Instance
@@ -8962,7 +8962,7 @@ declare class TeamCreateService extends Instance
 end
 
 declare class Teams extends Instance
-	function GetTeams(self): { Instance }
+	function GetTeams(self): { Team }
 end
 
 declare class TeleportAsyncResult extends Instance

--- a/scripts/globalTypes.d.lua
+++ b/scripts/globalTypes.d.lua
@@ -9,13 +9,13 @@ type RotationCurveKey = any
 type Instance = any
 
 declare class Enum
-	function GetEnumItems(self): { any }
+    function GetEnumItems(self): { any }
 end
 
 declare class EnumItem
-	Name: string
-	Value: number
-	EnumType: Enum
+    Name: string
+    Value: number
+    EnumType: Enum
     function IsA(self, enumName: string): boolean
 end
 
@@ -8962,7 +8962,7 @@ declare class TeamCreateService extends Instance
 end
 
 declare class Teams extends Instance
-	function GetTeams(self): { Team }
+	function GetTeams(self): { Instance }
 end
 
 declare class TeleportAsyncResult extends Instance
@@ -10166,8 +10166,8 @@ declare class GlobalSettings extends GenericSettings
     Physics: PhysicsSettings
     Rendering: RenderSettings
     Diagnostics: DebugSettings
-	function GetFFlag(self, name: string): boolean
-	function GetFVariable(self, name: string): string
+    function GetFFlag(self, name: string): boolean
+    function GetFVariable(self, name: string): string
 end
 
 declare game: DataModel

--- a/scripts/globalTypes.d.lua
+++ b/scripts/globalTypes.d.lua
@@ -7497,11 +7497,11 @@ end
 
 
 declare class WorldRoot extends Model
-	function ArePartsTouchingOthers(self, partList: { Instance }, overlapIgnored: number?): boolean
-	function BulkMoveTo(self, partList: { Instance }, cframeList: { any }, eventMode: EnumBulkMoveMode?): nil
-	function GetPartBoundsInBox(self, cframe: CFrame, size: Vector3, overlapParams: OverlapParams?): { Instance }
-	function GetPartBoundsInRadius(self, position: Vector3, radius: number, overlapParams: OverlapParams?): { Instance }
-	function GetPartsInPart(self, part: BasePart, overlapParams: OverlapParams?): { Instance }
+	function ArePartsTouchingOthers(self, partList: { BasePart }, overlapIgnored: number?): boolean
+	function BulkMoveTo(self, partList: { BasePart }, cframeList: { CFrame }, eventMode: EnumBulkMoveMode?): nil
+	function GetPartBoundsInBox(self, cframe: CFrame, size: Vector3, overlapParams: OverlapParams?): { BasePart }
+	function GetPartBoundsInRadius(self, position: Vector3, radius: number, overlapParams: OverlapParams?): { BasePart }
+	function GetPartsInPart(self, part: BasePart, overlapParams: OverlapParams?): { BasePart }
 	function IKMoveTo(self, part: BasePart, target: CFrame, translateStiffness: number?, rotateStiffness: number?, collisionsMode: EnumIKCollisionsMode?): nil
 	function Raycast(self, origin: Vector3, direction: Vector3, raycastParams: RaycastParams?): RaycastResult?
 	function SetInsertPoint(self, point: Vector3, ignoreGrid: boolean?): nil

--- a/scripts/globalTypes.d.lua
+++ b/scripts/globalTypes.d.lua
@@ -4823,7 +4823,7 @@ end
 
 declare class Camera extends Instance
 	CFrame: CFrame
-	CameraSubject: Instance | BasePart | nil
+	CameraSubject: Humanoid | BasePart | nil
 	CameraType: EnumCameraType
 	DiagonalFieldOfView: number
 	FieldOfView: number


### PR DESCRIPTION
Fixes types:
`Camera.CameraSubject` could possibly be `nil`. It's valid types are `BasePart` and `Humanoid`
`Team:GetPlayers()` return a list of `Player`s
`Teams:GetTeams` return a list of `Team`s
`AncestryChanged`'s second signal argument may be nil if the ancestor's parent became `nil`.
`FindFirstChild...` and `FindFirstAncestor...` methods didn't return `Instance?`
`WorldRoot:GetPart...` returns an array of `{ BasePart }`
and some more

`GetPartsObscuringTarget` does in fact take a list of `Instance`s, not `BasePart`s

`Teams:GetTeams()` causes the type definition file to fail to load due to complexity, so the tests will probably fail. I can split it off from this PR.