### PR TITLE
Correct return type for Teams:GetTeams()

### DIFF
--- a/scripts/dumpRobloxTypes.py
+++ b/scripts/dumpRobloxTypes.py
@@ -167,6 +167,7 @@ IGNORED_MEMBERS = {
         "UnionAsync",
     ],
     "Team": ["GetPlayers"],
+    "Teams": ["GetTeams"],
     "Camera": [
         "CameraSubject",
         "GetPartsObscuringTarget",
@@ -340,6 +341,9 @@ EXTRA_MEMBERS = {
     ],
     "Team": [
         "function GetPlayers(self): { Player }"
+    ],
+    "Teams": [
+        "function GetTeams(self): { Team }",
     ],
     "Camera": [
         "CameraSubject: Humanoid | BasePart | nil",

--- a/scripts/globalTypes.d.lua
+++ b/scripts/globalTypes.d.lua
@@ -8933,7 +8933,7 @@ declare class TeamCreateService extends Instance
 end
 
 declare class Teams extends Instance
-	function GetTeams(self): { Instance }
+	function GetTeams(self): { Team }
 end
 
 declare class TeleportAsyncResult extends Instance


### PR DESCRIPTION
This will probably fail because it causes too much complexity in the type definitions file