### PR TITLE
Improve Completion Ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Added support for Semantic Tokens
 
+### Changed
+
+- Improved autocomplete items ordering by applying heuristics to sort items
+
 ### Fixed
 
 - Fixed `.meta.json` file being picked as a script's file path instead of the actual Luau file


### PR DESCRIPTION
This PR improves the ordering of autocomplete items by utilising sort text.
We provide items in the following order:
1) variables which match the correct type
2) functions which return the correct type
3) catch-all local and global variables
4) (Index/Calls only) property with incorrect index (i.e. suggest `foo.prop` for `foo:`, or `foo:call` on `foo.`)
5) Automatic Imports
6) General Lua keywords (and/or/then etc.)

Closes #156 