### PR TITLE
Improve handling of UTF-16 encoded Positions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed handling of UTF-16 characters of different size to UTF-8 (i.e., emojis, non-english text). Will no longer produce malformed strings and weird diagnostics
+
 ## [1.11.0] - 2022-09-28
 
 ### Added

--- a/src/LanguageServer.cpp
+++ b/src/LanguageServer.cpp
@@ -329,15 +329,15 @@ lsp::InitializeResult LanguageServer::onInitialize(const lsp::InitializeParams& 
     result.capabilities = getServerCapabilities();
 
     // Position Encoding
-    // TODO: we should check what the client prefers here, and try to support that.
-    // For the time being, we just assume UTF-8 if its available, as thats the only thing we really support right now
-    // TODO: we should really support UTF-16, but need to work on that
-    // if (client->capabilities.general && client->capabilities.general->positionEncodings)
-    // {
-    //     auto& encodings = *client->capabilities.general->positionEncodings;
-    //     if (std::find(encodings.begin(), encodings.end(), lsp::PositionEncodingKind::UTF8) != encodings.end())
-    //         result.capabilities.positionEncoding = lsp::PositionEncodingKind::UTF8;
-    // }
+    if (client->capabilities.general && client->capabilities.general->positionEncodings &&
+        client->capabilities.general->positionEncodings->size() > 0)
+    {
+        auto& encodings = *client->capabilities.general->positionEncodings;
+        if (encodings[0] == lsp::PositionEncodingKind::UTF8 || encodings[0] == lsp::PositionEncodingKind::UTF16)
+            positionEncoding() = encodings[0];
+    }
+    result.capabilities.positionEncoding = positionEncoding();
+    client->sendLogMessage(lsp::MessageType::Info, "negotiated position encoding: " + json(positionEncoding()).dump());
 
     client->sendTrace("server capabilities:" + json(result).dump(), std::nullopt);
     return result;

--- a/src/LanguageServer.cpp
+++ b/src/LanguageServer.cpp
@@ -330,12 +330,12 @@ lsp::InitializeResult LanguageServer::onInitialize(const lsp::InitializeParams& 
     // TODO: we should check what the client prefers here, and try to support that.
     // For the time being, we just assume UTF-8 if its available, as thats the only thing we really support right now
     // TODO: we should really support UTF-16, but need to work on that
-    if (client->capabilities.general && client->capabilities.general->positionEncodings)
-    {
-        auto& encodings = *client->capabilities.general->positionEncodings;
-        if (std::find(encodings.begin(), encodings.end(), lsp::PositionEncodingKind::UTF8) != encodings.end())
-            result.capabilities.positionEncoding = lsp::PositionEncodingKind::UTF8;
-    }
+    // if (client->capabilities.general && client->capabilities.general->positionEncodings)
+    // {
+    //     auto& encodings = *client->capabilities.general->positionEncodings;
+    //     if (std::find(encodings.begin(), encodings.end(), lsp::PositionEncodingKind::UTF8) != encodings.end())
+    //         result.capabilities.positionEncoding = lsp::PositionEncodingKind::UTF8;
+    // }
 
     client->sendTrace("server capabilities:" + json(result).dump(), std::nullopt);
     return result;

--- a/src/LuauExt.cpp
+++ b/src/LuauExt.cpp
@@ -1,4 +1,3 @@
-#include <climits>
 #include "Luau/BuiltinDefinitions.h"
 #include "Luau/ToString.h"
 #include "Luau/Transpiler.h"

--- a/src/LuauExt.cpp
+++ b/src/LuauExt.cpp
@@ -672,13 +672,6 @@ bool types::isMetamethod(const Luau::Name& name)
            name == "__metatable" || name == "__eq" || name == "__lt" || name == "__le" || name == "__mode" || name == "__iter" || name == "__len";
 }
 
-Luau::Position convertPosition(const lsp::Position& position)
-{
-    LUAU_ASSERT(position.line <= UINT_MAX);
-    LUAU_ASSERT(position.character <= UINT_MAX);
-    return Luau::Position{static_cast<unsigned int>(position.line), static_cast<unsigned int>(position.character)};
-}
-
 lsp::Position convertPosition(const Luau::Position& position)
 {
     return lsp::Position{static_cast<size_t>(position.line), static_cast<size_t>(position.column)};

--- a/src/LuauExt.cpp
+++ b/src/LuauExt.cpp
@@ -672,7 +672,8 @@ bool types::isMetamethod(const Luau::Name& name)
            name == "__metatable" || name == "__eq" || name == "__lt" || name == "__le" || name == "__mode" || name == "__iter" || name == "__len";
 }
 
-lsp::Position convertPosition(const Luau::Position& position)
+// NOTE: this does NOT apply UTF-16 transformations
+static lsp::Position convertPosition(const Luau::Position& position)
 {
     return lsp::Position{static_cast<size_t>(position.line), static_cast<size_t>(position.column)};
 }

--- a/src/TextDocument.cpp
+++ b/src/TextDocument.cpp
@@ -184,7 +184,7 @@ static lsp::Range getWellformedRange(lsp::Range range)
 }
 
 
-std::string TextDocument::getText(std::optional<lsp::Range> range)
+const std::string& TextDocument::getText(std::optional<lsp::Range> range) const
 {
     if (range)
     {
@@ -195,7 +195,7 @@ std::string TextDocument::getText(std::optional<lsp::Range> range)
     return _content;
 }
 
-lsp::Position TextDocument::positionAt(size_t offset)
+lsp::Position TextDocument::positionAt(size_t offset) const
 {
     offset = std::max(std::min(offset, _content.size()), (size_t)0);
     auto lineOffsets = getLineOffsets();
@@ -226,7 +226,7 @@ lsp::Position TextDocument::positionAt(size_t offset)
     return lsp::Position{line, lspLength(currentContent)};
 }
 
-size_t TextDocument::offsetAt(const lsp::Position& position)
+size_t TextDocument::offsetAt(const lsp::Position& position) const
 {
     auto utf8Position = convertPosition(position);
     auto lineOffsets = getLineOffsets();
@@ -235,13 +235,13 @@ size_t TextDocument::offsetAt(const lsp::Position& position)
 }
 
 // We treat all lsp:Positions as UTF-16 encoded. We must convert between the two when necessary
-Luau::Position TextDocument::convertPosition(const lsp::Position& position)
+Luau::Position TextDocument::convertPosition(const lsp::Position& position) const
 {
     LUAU_ASSERT(position.line <= UINT_MAX);
     LUAU_ASSERT(position.character <= UINT_MAX);
 
     auto lineOffsets = getLineOffsets();
-    if (position.line >= lineOffsets.size())
+    if (position.line >= lineCount())
     {
         return Luau::Position{lineOffsets.size() - 1, _content.size() - lineOffsets.back()};
     }
@@ -320,12 +320,12 @@ void TextDocument::update(const std::vector<lsp::TextDocumentContentChangeEvent>
     }
 }
 
-size_t TextDocument::lineCount()
+size_t TextDocument::lineCount() const
 {
     return getLineOffsets().size();
 }
 
-const std::vector<size_t>& TextDocument::getLineOffsets()
+const std::vector<size_t>& TextDocument::getLineOffsets() const
 {
     if (!_lineOffsets)
     {
@@ -335,7 +335,7 @@ const std::vector<size_t>& TextDocument::getLineOffsets()
 }
 
 // TODO: this is a bit expensive
-std::vector<std::string_view> TextDocument::getLines()
+std::vector<std::string_view> TextDocument::getLines() const
 {
     return Luau::split(_content, '\n');
 }

--- a/src/TextDocument.cpp
+++ b/src/TextDocument.cpp
@@ -4,21 +4,19 @@
 #include "Luau/StringUtils.h"
 #include "LSP/TextDocument.hpp"
 
-template<typename T>
-static size_t countLeadingZeros(T n)
+static size_t countLeadingZeros(unsigned char n)
 {
 #ifdef _MSC_VER
     unsigned long rl;
-    return _BitScanReverse(&rl, n) ? 31 - int(rl) : 32;
+    return _BitScanReverse(&rl, n) ? 31 - int(rl) - 24 : 8;
 #else
-    return n == 0 ? 32 : __builtin_clz(n);
+    return n == 0 ? 8 : __builtin_clz(n) - 24;
 #endif
 }
 
-template<typename T>
-static size_t countLeadingOnes(T n)
+static size_t countLeadingOnes(unsigned char n)
 {
-    return countLeadingZeros(~n);
+    return countLeadingZeros((unsigned char)~n);
 }
 
 // https://github.com/llvm/llvm-project/blob/main/clang-tools-extra/clangd/SourceCode.cpp

--- a/src/TextDocument.cpp
+++ b/src/TextDocument.cpp
@@ -79,7 +79,7 @@ static bool iterateCodepoints(const std::string& U8, const Callback& CB)
 // the specified encoding.
 // Conceptually, this converts to the encoding, truncates to CodeUnits,
 // converts back to UTF-8, and returns the length in bytes.
-static size_t measureUnits(const std::string& U8, int Units, lsp::PositionEncodingKind Enc, bool& Valid)
+static size_t measureUnits(const std::string& U8, size_t Units, lsp::PositionEncodingKind Enc, bool& Valid)
 {
     Valid = Units >= 0;
     if (Units <= 0)
@@ -92,7 +92,7 @@ static size_t measureUnits(const std::string& U8, int Units, lsp::PositionEncodi
         break;
     case lsp::PositionEncodingKind::UTF16:
         Valid = iterateCodepoints(U8,
-            [&](int U8Len, int U16Len)
+            [&](size_t U8Len, size_t U16Len)
             {
                 Result += U8Len;
                 Units -= U16Len;
@@ -103,7 +103,7 @@ static size_t measureUnits(const std::string& U8, int Units, lsp::PositionEncodi
         break;
     case lsp::PositionEncodingKind::UTF32:
         Valid = iterateCodepoints(U8,
-            [&](int U8Len, int U16Len)
+            [&](size_t U8Len, size_t U16Len)
             {
                 Result += U8Len;
                 Units--;
@@ -133,7 +133,7 @@ size_t lspLength(const std::string& Code)
         break;
     case lsp::PositionEncodingKind::UTF16:
         iterateCodepoints(Code,
-            [&](int U8Len, int U16Len)
+            [&](size_t U8Len, size_t U16Len)
             {
                 Count += U16Len;
                 return false;
@@ -141,7 +141,7 @@ size_t lspLength(const std::string& Code)
         break;
     case lsp::PositionEncodingKind::UTF32:
         iterateCodepoints(Code,
-            [&](int U8Len, int U16Len)
+            [&](size_t U8Len, size_t U16Len)
             {
                 ++Count;
                 return false;

--- a/src/TextDocument.cpp
+++ b/src/TextDocument.cpp
@@ -264,7 +264,13 @@ Luau::Position TextDocument::convertPosition(const lsp::Position& position) cons
     return Luau::Position{static_cast<unsigned int>(position.line), static_cast<unsigned int>(byteInLine)};
 }
 
-// lsp::Position TextDocument::convertPosition(const Luau::Position& position) {}
+lsp::Position TextDocument::convertPosition(const Luau::Position& position) const
+{
+    auto lineOffsets = getLineOffsets();
+    auto line = position.line;
+    std::string currentContent = _content.substr(lineOffsets[line], position.column);
+    return lsp::Position{line, lspLength(currentContent)};
+}
 
 void TextDocument::update(const std::vector<lsp::TextDocumentContentChangeEvent>& changes, size_t version)
 {

--- a/src/TextDocument.cpp
+++ b/src/TextDocument.cpp
@@ -266,7 +266,7 @@ Luau::Position TextDocument::convertPosition(const lsp::Position& position)
 
 // lsp::Position TextDocument::convertPosition(const Luau::Position& position) {}
 
-void TextDocument::update(std::vector<lsp::TextDocumentContentChangeEvent> changes, size_t version)
+void TextDocument::update(const std::vector<lsp::TextDocumentContentChangeEvent>& changes, size_t version)
 {
     _version = version;
     for (auto& change : changes)
@@ -325,7 +325,7 @@ size_t TextDocument::lineCount()
     return getLineOffsets().size();
 }
 
-std::vector<size_t> TextDocument::getLineOffsets()
+const std::vector<size_t>& TextDocument::getLineOffsets()
 {
     if (!_lineOffsets)
     {

--- a/src/TextDocument.cpp
+++ b/src/TextDocument.cpp
@@ -222,7 +222,8 @@ lsp::Position TextDocument::positionAt(size_t offset)
     // low is the least x for which the line offset is larger than the current offset
     // or array.length if no line offset is larger than the current offset
     auto line = low - 1;
-    return lsp::Position{line, offset - lineOffsets[line]};
+    std::string currentContent = _content.substr(lineOffsets[line], offset - lineOffsets[line]);
+    return lsp::Position{line, lspLength(currentContent)};
 }
 
 size_t TextDocument::offsetAt(lsp::Position position)
@@ -251,8 +252,17 @@ size_t TextDocument::offsetAt(lsp::Position position)
     return std::max(std::min(lineOffset + byteInLine, nextLineOffset), lineOffset);
 }
 
-// lsp::Position convertPosition(const Luau::Position& position) {}
-// Luau::Position convertToUtf8(const lsp::Position& position) {}
+// // We treat all lsp:Positions as UTF-16 encoded. We must convert between the two when necessary
+// Luau::Position TextDocument::convertPosition(const lsp::Position& position)
+// {
+//     LUAU_ASSERT(position.line <= UINT_MAX);
+//     LUAU_ASSERT(position.character <= UINT_MAX);
+
+//     std::string line = _content.substr(lineOffset, nextLineOffset - lineOffset);
+
+//     return Luau::Position{static_cast<unsigned int>(position.line), static_cast<unsigned int>(position.character)};
+// }
+// lsp::Position TextDocument::convertPosition(const Luau::Position& position) {}
 
 void TextDocument::update(std::vector<lsp::TextDocumentContentChangeEvent> changes, size_t version)
 {

--- a/src/TextDocument.cpp
+++ b/src/TextDocument.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <climits>
 #include "Luau/Common.h"
 #include "Luau/Location.h"
 #include "Luau/StringUtils.h"
@@ -243,7 +244,7 @@ Luau::Position TextDocument::convertPosition(const lsp::Position& position) cons
     auto lineOffsets = getLineOffsets();
     if (position.line >= lineCount())
     {
-        return Luau::Position{lineOffsets.size() - 1, _content.size() - lineOffsets.back()};
+        return Luau::Position{static_cast<unsigned int>(lineOffsets.size() - 1), static_cast<unsigned int>(_content.size() - lineOffsets.back())};
     }
     else if (position.line < 0)
     {

--- a/src/TextDocument.cpp
+++ b/src/TextDocument.cpp
@@ -68,7 +68,7 @@ static bool iterateCodepoints(const std::string& U8, const CodepointsCallback& C
         I += UTF8Length; // Skip over all trailing bytes.
         // A codepoint takes two UTF-16 code unit if it's astral (outside BMP).
         // Astral codepoints are encoded as 4 bytes in UTF-8 (11110xxx ...)
-        if (CB(UTF8Length, UTF8Length == 4 ? 2 : 1))
+        if (CB(static_cast<int>(UTF8Length), UTF8Length == 4 ? 2 : 1))
             return true;
     }
     return false;
@@ -257,7 +257,7 @@ Luau::Position TextDocument::convertPosition(const lsp::Position& position) cons
     // position.character may be in UTF-16, so we need to convert as necessary
     bool valid;
     std::string line = _content.substr(lineOffset, nextLineOffset - lineOffset);
-    size_t byteInLine = measureUnits(line, position.character, positionEncoding(), valid);
+    size_t byteInLine = measureUnits(line, static_cast<int>(position.character), positionEncoding(), valid);
 
     if (!valid)
         std::cerr << "UTF-16 offset " << position.character << " is invalid for line " << position.line << "\n";

--- a/src/TextDocument.cpp
+++ b/src/TextDocument.cpp
@@ -184,7 +184,7 @@ static lsp::Range getWellformedRange(lsp::Range range)
 }
 
 
-const std::string& TextDocument::getText(std::optional<lsp::Range> range) const
+std::string TextDocument::getText(std::optional<lsp::Range> range) const
 {
     if (range)
     {

--- a/src/TextDocument.cpp
+++ b/src/TextDocument.cpp
@@ -248,7 +248,7 @@ size_t TextDocument::offsetAt(lsp::Position position)
     if (!valid)
         std::cerr << "UTF-16 offset " << position.character << " is invalid for line " << position.line << "\n";
 
-    return std::max(std::min(lineOffset + position.character, nextLineOffset), lineOffset);
+    return std::max(std::min(lineOffset + byteInLine, nextLineOffset), lineOffset);
 }
 
 // lsp::Position convertPosition(const Luau::Position& position) {}

--- a/src/TextDocument.cpp
+++ b/src/TextDocument.cpp
@@ -1,6 +1,157 @@
 #include <iostream>
+#include "Luau/Common.h"
+#include "Luau/Location.h"
 #include "Luau/StringUtils.h"
 #include "LSP/TextDocument.hpp"
+
+template<typename T>
+static size_t countLeadingZeros(T n)
+{
+#ifdef _MSC_VER
+    unsigned long rl;
+    return _BitScanReverse(&rl, n) ? 31 - int(rl) : 32;
+#else
+    return n == 0 ? 32 : __builtin_clz(n);
+#endif
+}
+
+template<typename T>
+static size_t countLeadingOnes(T n)
+{
+    return countLeadingZeros(~n);
+}
+
+// https://github.com/llvm/llvm-project/blob/main/clang-tools-extra/clangd/SourceCode.cpp
+// Iterates over unicode codepoints in the (UTF-8) string. For each,
+// invokes CB(UTF-8 length, UTF-16 length), and breaks if it returns true.
+// Returns true if CB returned true, false if we hit the end of string.
+//
+// If the string is not valid UTF-8, we log this error and "decode" the
+// text in some arbitrary way. This is pretty sad, but this tends to happen deep
+// within indexing of headers where clang misdetected the encoding, and
+// propagating the error all the way back up is (probably?) not be worth it.
+template<typename Callback>
+static bool iterateCodepoints(const std::string& U8, const Callback& CB)
+{
+    bool LoggedInvalid = false;
+    // A codepoint takes two UTF-16 code unit if it's astral (outside BMP).
+    // Astral codepoints are encoded as 4 bytes in UTF-8, starting with 11110xxx.
+    for (size_t I = 0; I < U8.size();)
+    {
+        unsigned char C = static_cast<unsigned char>(U8[I]);
+        if (LUAU_LIKELY(!(C & 0x80)))
+        { // ASCII character.
+            if (CB(1, 1))
+                return true;
+            ++I;
+            continue;
+        }
+        // This convenient property of UTF-8 holds for all non-ASCII characters.
+        size_t UTF8Length = countLeadingOnes(C);
+        // 0xxx is ASCII, handled above. 10xxx is a trailing byte, invalid here.
+        // 11111xxx is not valid UTF-8 at all, maybe some ISO-8859-*.
+        if (LUAU_UNLIKELY(UTF8Length < 2 || UTF8Length > 4))
+        {
+            if (!LoggedInvalid)
+            {
+                std::cerr << "File has invalid UTF-8 near offset " << I << ": " << U8 << "\n";
+                LoggedInvalid = true;
+            }
+            // We can't give a correct result, but avoid returning something wild.
+            // Pretend this is a valid ASCII byte, for lack of better options.
+            // (Too late to get ISO-8859-* right, we've skipped some bytes already).
+            if (CB(1, 1))
+                return true;
+            ++I;
+            continue;
+        }
+        I += UTF8Length; // Skip over all trailing bytes.
+        // A codepoint takes two UTF-16 code unit if it's astral (outside BMP).
+        // Astral codepoints are encoded as 4 bytes in UTF-8 (11110xxx ...)
+        if (CB(UTF8Length, UTF8Length == 4 ? 2 : 1))
+            return true;
+    }
+    return false;
+}
+
+// https://github.com/llvm/llvm-project/blob/main/clang-tools-extra/clangd/SourceCode.cpp
+// Returns the byte offset into the string that is an offset of \p Units in
+// the specified encoding.
+// Conceptually, this converts to the encoding, truncates to CodeUnits,
+// converts back to UTF-8, and returns the length in bytes.
+static size_t measureUnits(const std::string& U8, int Units, lsp::PositionEncodingKind Enc, bool& Valid)
+{
+    Valid = Units >= 0;
+    if (Units <= 0)
+        return 0;
+    size_t Result = 0;
+    switch (Enc)
+    {
+    case lsp::PositionEncodingKind::UTF8:
+        Result = Units;
+        break;
+    case lsp::PositionEncodingKind::UTF16:
+        Valid = iterateCodepoints(U8,
+            [&](int U8Len, int U16Len)
+            {
+                Result += U8Len;
+                Units -= U16Len;
+                return Units <= 0;
+            });
+        if (Units < 0) // Offset in the middle of a surrogate pair.
+            Valid = false;
+        break;
+    case lsp::PositionEncodingKind::UTF32:
+        Valid = iterateCodepoints(U8,
+            [&](int U8Len, int U16Len)
+            {
+                Result += U8Len;
+                Units--;
+                return Units <= 0;
+            });
+        break;
+        // case OffsetEncoding::UnsupportedEncoding:
+        //     llvm_unreachable("unsupported encoding");
+    }
+    // Don't return an out-of-range index if we overran.
+    if (Result > U8.size())
+    {
+        Valid = false;
+        return U8.size();
+    }
+    return Result;
+}
+
+// https://github.com/llvm/llvm-project/blob/main/clang-tools-extra/clangd/SourceCode.cpp
+size_t lspLength(const std::string& Code)
+{
+    size_t Count = 0;
+    // switch (lspEncoding())
+    // {
+    // case OffsetEncoding::UTF8:
+    //     Count = Code.size();
+    //     break;
+    // case OffsetEncoding::UTF16:
+    iterateCodepoints(Code,
+        [&](int U8Len, int U16Len)
+        {
+            Count += U16Len;
+            return false;
+        });
+    //  break;
+    // case OffsetEncoding::UTF32:
+    //     iterateCodepoints(Code,
+    //         [&](int U8Len, int U16Len)
+    //         {
+    //             ++Count;
+    //             return false;
+    //         });
+    //     break;
+    // case OffsetEncoding::UnsupportedEncoding:
+    //     llvm_unreachable("unsupported encoding");
+    // }
+    return Count;
+}
 
 static std::vector<size_t> computeLineOffsets(const std::string& content, bool isAtLineStart, size_t textOffset = 0)
 {
@@ -89,8 +240,21 @@ size_t TextDocument::offsetAt(lsp::Position position)
     }
     auto lineOffset = lineOffsets[position.line];
     auto nextLineOffset = position.line + 1 < lineOffsets.size() ? lineOffsets[position.line + 1] : _content.size();
+
+    // position.character is in UTF-16, so we need to convert as necessary
+    // TODO: use positionEncoding negotiated with client
+    bool valid;
+    std::string line = _content.substr(lineOffset, nextLineOffset - lineOffset);
+    size_t byteInLine = measureUnits(line, position.character, lsp::PositionEncodingKind::UTF16, valid);
+
+    if (!valid)
+        std::cerr << "UTF-16 offset " << position.character << " is invalid for line " << position.line << "\n";
+
     return std::max(std::min(lineOffset + position.character, nextLineOffset), lineOffset);
 }
+
+// lsp::Position convertPosition(const Luau::Position& position) {}
+// Luau::Position convertToUtf8(const lsp::Position& position) {}
 
 void TextDocument::update(std::vector<lsp::TextDocumentContentChangeEvent> changes, size_t version)
 {

--- a/src/TextDocument.cpp
+++ b/src/TextDocument.cpp
@@ -30,8 +30,8 @@ static size_t countLeadingOnes(unsigned char n)
 // text in some arbitrary way. This is pretty sad, but this tends to happen deep
 // within indexing of headers where clang misdetected the encoding, and
 // propagating the error all the way back up is (probably?) not be worth it.
-template<typename Callback>
-static bool iterateCodepoints(const std::string& U8, const Callback& CB)
+using CodepointsCallback = std::function<bool(int, int)>;
+static bool iterateCodepoints(const std::string& U8, const CodepointsCallback& CB)
 {
     bool LoggedInvalid = false;
     // A codepoint takes two UTF-16 code unit if it's astral (outside BMP).

--- a/src/TextDocument.cpp
+++ b/src/TextDocument.cpp
@@ -79,7 +79,7 @@ static bool iterateCodepoints(const std::string& U8, const Callback& CB)
 // the specified encoding.
 // Conceptually, this converts to the encoding, truncates to CodeUnits,
 // converts back to UTF-8, and returns the length in bytes.
-static size_t measureUnits(const std::string& U8, size_t Units, lsp::PositionEncodingKind Enc, bool& Valid)
+static size_t measureUnits(const std::string& U8, int Units, lsp::PositionEncodingKind Enc, bool& Valid)
 {
     Valid = Units >= 0;
     if (Units <= 0)
@@ -92,7 +92,7 @@ static size_t measureUnits(const std::string& U8, size_t Units, lsp::PositionEnc
         break;
     case lsp::PositionEncodingKind::UTF16:
         Valid = iterateCodepoints(U8,
-            [&](size_t U8Len, size_t U16Len)
+            [&](int U8Len, int U16Len)
             {
                 Result += U8Len;
                 Units -= U16Len;
@@ -103,7 +103,7 @@ static size_t measureUnits(const std::string& U8, size_t Units, lsp::PositionEnc
         break;
     case lsp::PositionEncodingKind::UTF32:
         Valid = iterateCodepoints(U8,
-            [&](size_t U8Len, size_t U16Len)
+            [&](int U8Len, int U16Len)
             {
                 Result += U8Len;
                 Units--;
@@ -133,7 +133,7 @@ size_t lspLength(const std::string& Code)
         break;
     case lsp::PositionEncodingKind::UTF16:
         iterateCodepoints(Code,
-            [&](size_t U8Len, size_t U16Len)
+            [&](int U8Len, int U16Len)
             {
                 Count += U16Len;
                 return false;
@@ -141,7 +141,7 @@ size_t lspLength(const std::string& Code)
         break;
     case lsp::PositionEncodingKind::UTF32:
         iterateCodepoints(Code,
-            [&](size_t U8Len, size_t U16Len)
+            [&](int U8Len, int U16Len)
             {
                 ++Count;
                 return false;

--- a/src/WorkspaceFileResolver.cpp
+++ b/src/WorkspaceFileResolver.cpp
@@ -15,6 +15,12 @@ Luau::ModuleName WorkspaceFileResolver::getModuleName(const Uri& name)
 
     return fsPath;
 }
+const TextDocument* WorkspaceFileResolver::getTextDocument(const Luau::ModuleName& name) const
+{
+    if (managedFiles.find(name) != managedFiles.end())
+        return nullptr;
+    return &managedFiles.at(name);
+}
 
 std::optional<SourceNodePtr> WorkspaceFileResolver::getSourceNodeFromVirtualPath(const Luau::ModuleName& name) const
 {
@@ -105,9 +111,9 @@ std::optional<Luau::SourceCode> WorkspaceFileResolver::readSource(const Luau::Mo
         sourceType = sourceCodeTypeFromPath(realFileName);
     }
 
-    if (isManagedFile(name))
+    if (auto textDocument = getTextDocument(name))
     {
-        source = managedFiles.at(name).getText();
+        source = textDocument->getText();
     }
     else
     {

--- a/src/WorkspaceFileResolver.cpp
+++ b/src/WorkspaceFileResolver.cpp
@@ -17,9 +17,10 @@ Luau::ModuleName WorkspaceFileResolver::getModuleName(const Uri& name)
 }
 const TextDocument* WorkspaceFileResolver::getTextDocument(const Luau::ModuleName& name) const
 {
-    if (managedFiles.find(name) != managedFiles.end())
+    auto it = managedFiles.find(name);
+    if (it == managedFiles.end())
         return nullptr;
-    return &managedFiles.at(name);
+    return &it->second;
 }
 
 std::optional<SourceNodePtr> WorkspaceFileResolver::getSourceNodeFromVirtualPath(const Luau::ModuleName& name) const

--- a/src/include/LSP/LanguageServer.hpp
+++ b/src/include/LSP/LanguageServer.hpp
@@ -14,6 +14,12 @@ using Response = json;
 using WorkspaceFolderPtr = std::shared_ptr<WorkspaceFolder>;
 using ClientPtr = std::shared_ptr<Client>;
 
+inline lsp::PositionEncodingKind& positionEncoding()
+{
+    static lsp::PositionEncodingKind encoding = lsp::PositionEncodingKind::UTF16;
+    return encoding;
+}
+
 class LanguageServer
 {
 public:

--- a/src/include/LSP/LuauExt.hpp
+++ b/src/include/LSP/LuauExt.hpp
@@ -116,8 +116,6 @@ std::optional<Luau::Location> getLocation(Luau::TypeId type);
 std::optional<Luau::Location> lookupTypeLocation(const Luau::Scope& deepScope, const Luau::Name& name);
 std::optional<Luau::Property> lookupProp(const Luau::TypeId& parentType, const Luau::Name& name);
 
-lsp::Position convertPosition(const Luau::Position& position);
-
 lsp::Diagnostic createTypeErrorDiagnostic(const Luau::TypeError& error, Luau::FileResolver* fileResolver);
 lsp::Diagnostic createLintDiagnostic(const Luau::LintWarning& lint);
 lsp::Diagnostic createParseErrorDiagnostic(const Luau::ParseError& error);

--- a/src/include/LSP/LuauExt.hpp
+++ b/src/include/LSP/LuauExt.hpp
@@ -116,6 +116,6 @@ std::optional<Luau::Location> getLocation(Luau::TypeId type);
 std::optional<Luau::Location> lookupTypeLocation(const Luau::Scope& deepScope, const Luau::Name& name);
 std::optional<Luau::Property> lookupProp(const Luau::TypeId& parentType, const Luau::Name& name);
 
-lsp::Diagnostic createTypeErrorDiagnostic(const Luau::TypeError& error, Luau::FileResolver* fileResolver);
-lsp::Diagnostic createLintDiagnostic(const Luau::LintWarning& lint);
-lsp::Diagnostic createParseErrorDiagnostic(const Luau::ParseError& error);
+lsp::Diagnostic createTypeErrorDiagnostic(const Luau::TypeError& error, Luau::FileResolver* fileResolver, const TextDocument* textDocument = nullptr);
+lsp::Diagnostic createLintDiagnostic(const Luau::LintWarning& lint, const TextDocument* textDocument = nullptr);
+lsp::Diagnostic createParseErrorDiagnostic(const Luau::ParseError& error, const TextDocument* textDocument = nullptr);

--- a/src/include/LSP/LuauExt.hpp
+++ b/src/include/LSP/LuauExt.hpp
@@ -116,7 +116,6 @@ std::optional<Luau::Location> getLocation(Luau::TypeId type);
 std::optional<Luau::Location> lookupTypeLocation(const Luau::Scope& deepScope, const Luau::Name& name);
 std::optional<Luau::Property> lookupProp(const Luau::TypeId& parentType, const Luau::Name& name);
 
-Luau::Position convertPosition(const lsp::Position& position);
 lsp::Position convertPosition(const Luau::Position& position);
 
 lsp::Diagnostic createTypeErrorDiagnostic(const Luau::TypeError& error, Luau::FileResolver* fileResolver);

--- a/src/include/LSP/TextDocument.hpp
+++ b/src/include/LSP/TextDocument.hpp
@@ -2,6 +2,8 @@
 #include "LSP/Uri.hpp"
 #include "LSP/Protocol.hpp"
 
+size_t lspLength(const std::string& Code);
+
 class TextDocument
 {
 private:

--- a/src/include/LSP/TextDocument.hpp
+++ b/src/include/LSP/TextDocument.hpp
@@ -38,7 +38,7 @@ public:
         return _version;
     }
 
-    const std::string& getText(std::optional<lsp::Range> range = std::nullopt) const;
+    std::string getText(std::optional<lsp::Range> range = std::nullopt) const;
 
     lsp::Position positionAt(size_t offset) const;
     size_t offsetAt(const lsp::Position& position) const;

--- a/src/include/LSP/TextDocument.hpp
+++ b/src/include/LSP/TextDocument.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "LSP/Uri.hpp"
 #include "LSP/Protocol.hpp"
+#include "Luau/Location.h"
 
 size_t lspLength(const std::string& Code);
 
@@ -40,7 +41,9 @@ public:
     std::string getText(std::optional<lsp::Range> range = std::nullopt);
 
     lsp::Position positionAt(size_t offset);
-    size_t offsetAt(lsp::Position position);
+    size_t offsetAt(const lsp::Position& position);
+
+    Luau::Position convertPosition(const lsp::Position& position);
 
     bool applyChange(const lsp::TextDocumentContentChangeEvent& change);
 

--- a/src/include/LSP/TextDocument.hpp
+++ b/src/include/LSP/TextDocument.hpp
@@ -12,7 +12,7 @@ private:
     std::string _languageId;
     size_t _version;
     std::string _content;
-    std::optional<std::vector<size_t>> _lineOffsets = std::nullopt;
+    mutable std::optional<std::vector<size_t>> _lineOffsets = std::nullopt;
 
 public:
     TextDocument(const lsp::DocumentUri& uri, const std::string& languageId, size_t version, const std::string& content)
@@ -38,20 +38,20 @@ public:
         return _version;
     }
 
-    std::string getText(std::optional<lsp::Range> range = std::nullopt);
+    const std::string& getText(std::optional<lsp::Range> range = std::nullopt) const;
 
-    lsp::Position positionAt(size_t offset);
-    size_t offsetAt(const lsp::Position& position);
+    lsp::Position positionAt(size_t offset) const;
+    size_t offsetAt(const lsp::Position& position) const;
 
-    Luau::Position convertPosition(const lsp::Position& position);
+    Luau::Position convertPosition(const lsp::Position& position) const;
 
     bool applyChange(const lsp::TextDocumentContentChangeEvent& change);
 
     void update(const std::vector<lsp::TextDocumentContentChangeEvent>& changes, size_t version);
 
-    const std::vector<size_t>& getLineOffsets();
-    size_t lineCount();
+    const std::vector<size_t>& getLineOffsets() const;
+    size_t lineCount() const;
 
     // TODO: this is a bit expensive
-    std::vector<std::string_view> getLines();
+    std::vector<std::string_view> getLines() const;
 };

--- a/src/include/LSP/TextDocument.hpp
+++ b/src/include/LSP/TextDocument.hpp
@@ -23,12 +23,12 @@ public:
     {
     }
 
-    lsp::DocumentUri uri() const
+    const lsp::DocumentUri& uri() const
     {
         return _uri;
     }
 
-    std::string languageId() const
+    const std::string& languageId() const
     {
         return _languageId;
     }
@@ -47,9 +47,9 @@ public:
 
     bool applyChange(const lsp::TextDocumentContentChangeEvent& change);
 
-    void update(std::vector<lsp::TextDocumentContentChangeEvent> changes, size_t version);
+    void update(const std::vector<lsp::TextDocumentContentChangeEvent>& changes, size_t version);
 
-    std::vector<size_t> getLineOffsets();
+    const std::vector<size_t>& getLineOffsets();
     size_t lineCount();
 
     // TODO: this is a bit expensive

--- a/src/include/LSP/TextDocument.hpp
+++ b/src/include/LSP/TextDocument.hpp
@@ -44,6 +44,7 @@ public:
     size_t offsetAt(const lsp::Position& position) const;
 
     Luau::Position convertPosition(const lsp::Position& position) const;
+    lsp::Position convertPosition(const Luau::Position& position) const;
 
     bool applyChange(const lsp::TextDocumentContentChangeEvent& change);
 

--- a/src/include/LSP/WorkspaceFileResolver.hpp
+++ b/src/include/LSP/WorkspaceFileResolver.hpp
@@ -37,10 +37,7 @@ struct WorkspaceFileResolver
     }
 
     /// The file is managed by the client, so FS will be out of date
-    bool isManagedFile(const Luau::ModuleName& name) const
-    {
-        return managedFiles.find(name) != managedFiles.end();
-    }
+    const TextDocument* getTextDocument(const Luau::ModuleName& name) const;
 
     /// The name points to a virtual path (i.e., game/ or ProjectRoot/)
     bool isVirtualPath(const Luau::ModuleName& name) const

--- a/src/operations/Completion.cpp
+++ b/src/operations/Completion.cpp
@@ -24,7 +24,10 @@ static std::optional<Luau::AutocompleteEntryMap> nullCallback(std::string tag, s
 void WorkspaceFolder::endAutocompletion(const lsp::CompletionParams& params)
 {
     auto moduleName = fileResolver.getModuleName(params.textDocument.uri);
-    auto position = convertPosition(params.position);
+    auto document = fileResolver.getTextDocument(moduleName);
+    if (!document)
+        return;
+    auto position = document->convertPosition(params.position);
 
     if (frontend.isDirty(moduleName))
         frontend.check(moduleName);
@@ -69,10 +72,7 @@ void WorkspaceFolder::endAutocompletion(const lsp::CompletionParams& params)
 
     if (unclosedBlock)
     {
-        if (!fileResolver.isManagedFile(moduleName))
-            return;
-        auto document = fileResolver.managedFiles.at(moduleName);
-        auto lines = document.getLines();
+        auto lines = document->getLines();
 
         // If the position marker is at the very end of the file, if we insert one line further then vscode will
         // not be happy and will insert at the position marker.
@@ -302,7 +302,11 @@ std::vector<lsp::CompletionItem> WorkspaceFolder::completion(const lsp::Completi
     }
 
     auto moduleName = fileResolver.getModuleName(params.textDocument.uri);
-    auto position = convertPosition(params.position);
+    auto textDocument = fileResolver.getTextDocument(moduleName);
+    if (!textDocument)
+        return {};
+
+    auto position = textDocument->convertPosition(params.position);
     auto result = Luau::autocomplete(frontend, moduleName, position, nullCallback);
     std::vector<lsp::CompletionItem> items;
 

--- a/src/operations/Completion.cpp
+++ b/src/operations/Completion.cpp
@@ -361,13 +361,14 @@ std::vector<lsp::CompletionItem> WorkspaceFolder::completion(const lsp::Completi
             {
                 lsp::TextEdit textEdit;
                 textEdit.newText = "[\"" + name + "\"]";
-                textEdit.range = {convertPosition(indexName->indexLocation.begin), convertPosition(indexName->indexLocation.end)};
+                textEdit.range = {
+                    textDocument->convertPosition(indexName->indexLocation.begin), textDocument->convertPosition(indexName->indexLocation.end)};
                 item.textEdit = textEdit;
 
                 // For some reason, the above text edit can't handle replacing the index operator
                 // Hence we remove it using an additional text edit
-                item.additionalTextEdits.emplace_back(
-                    lsp::TextEdit{{convertPosition(indexName->opPosition), {indexName->opPosition.line, indexName->opPosition.column + 1}}, ""});
+                item.additionalTextEdits.emplace_back(lsp::TextEdit{
+                    {textDocument->convertPosition(indexName->opPosition), {indexName->opPosition.line, indexName->opPosition.column + 1}}, ""});
             }
         }
 

--- a/src/operations/Diagnostics.cpp
+++ b/src/operations/Diagnostics.cpp
@@ -98,8 +98,8 @@ lsp::WorkspaceDiagnosticReport WorkspaceFolder::workspaceDiagnostics(const lsp::
         lsp::WorkspaceDocumentDiagnosticReport documentReport;
         documentReport.uri = uri;
         documentReport.kind = lsp::DocumentDiagnosticReportKind::Full;
-        if (fileResolver.isManagedFile(moduleName))
-            documentReport.version = fileResolver.managedFiles.at(moduleName).version();
+        if (auto document = fileResolver.getTextDocument(moduleName))
+            documentReport.version = document->version();
 
         // If we don't have workspace diagnostics enabled, or we are are ignoring this file
         // Then provide an empty report to clear the file diagnostics

--- a/src/operations/Diagnostics.cpp
+++ b/src/operations/Diagnostics.cpp
@@ -16,6 +16,10 @@ lsp::DocumentDiagnosticReport WorkspaceFolder::documentDiagnostics(const lsp::Do
     std::unordered_map<std::string /* lsp::DocumentUri */, std::vector<lsp::Diagnostic>> relatedDiagnostics;
 
     auto moduleName = fileResolver.getModuleName(params.textDocument.uri);
+    auto textDocument = fileResolver.getTextDocument(moduleName);
+    if (!textDocument)
+        throw JsonRpcException(lsp::ErrorCode::RequestFailed, "No managed text document");
+
     Luau::CheckResult cr = frontend.check(moduleName);
 
     // If there was an error retrieving the source module
@@ -33,9 +37,9 @@ lsp::DocumentDiagnosticReport WorkspaceFolder::documentDiagnostics(const lsp::Do
     // Note that type errors can extend to related modules in the require graph - so we report related information here
     for (auto& error : cr.errors)
     {
-        auto diagnostic = createTypeErrorDiagnostic(error, &fileResolver);
         if (error.moduleName == moduleName)
         {
+            auto diagnostic = createTypeErrorDiagnostic(error, &fileResolver, textDocument);
             report.items.emplace_back(diagnostic);
         }
         else
@@ -43,6 +47,7 @@ lsp::DocumentDiagnosticReport WorkspaceFolder::documentDiagnostics(const lsp::Do
             auto fileName = fileResolver.resolveToRealPath(error.moduleName);
             if (!fileName || isIgnoredFile(*fileName, config))
                 continue;
+            auto diagnostic = createTypeErrorDiagnostic(error, &fileResolver, fileResolver.getTextDocument(error.moduleName));
             auto uri = Uri::file(*fileName);
             auto& currentDiagnostics = relatedDiagnostics[uri.toString()];
             currentDiagnostics.emplace_back(diagnostic);
@@ -65,12 +70,12 @@ lsp::DocumentDiagnosticReport WorkspaceFolder::documentDiagnostics(const lsp::Do
     Luau::LintResult lr = frontend.lint(moduleName);
     for (auto& error : lr.errors)
     {
-        auto diagnostic = createLintDiagnostic(error);
+        auto diagnostic = createLintDiagnostic(error, textDocument);
         diagnostic.severity = lsp::DiagnosticSeverity::Error; // Report this as an error instead
         report.items.emplace_back(diagnostic);
     }
     for (auto& error : lr.warnings)
-        report.items.emplace_back(createLintDiagnostic(error));
+        report.items.emplace_back(createLintDiagnostic(error, textDocument));
 
     return report;
 }
@@ -95,10 +100,12 @@ lsp::WorkspaceDiagnosticReport WorkspaceFolder::workspaceDiagnostics(const lsp::
     for (auto uri : files)
     {
         auto moduleName = fileResolver.getModuleName(uri);
+        auto document = fileResolver.getTextDocument(moduleName);
+
         lsp::WorkspaceDocumentDiagnosticReport documentReport;
         documentReport.uri = uri;
         documentReport.kind = lsp::DocumentDiagnosticReportKind::Full;
-        if (auto document = fileResolver.getTextDocument(moduleName))
+        if (document)
             documentReport.version = document->version();
 
         // If we don't have workspace diagnostics enabled, or we are are ignoring this file
@@ -121,7 +128,7 @@ lsp::WorkspaceDiagnosticReport WorkspaceFolder::workspaceDiagnostics(const lsp::
         // Only report errors for the current file
         for (auto& error : cr.errors)
         {
-            auto diagnostic = createTypeErrorDiagnostic(error, &fileResolver);
+            auto diagnostic = createTypeErrorDiagnostic(error, &fileResolver, document);
             if (error.moduleName == moduleName)
             {
                 documentReport.items.emplace_back(diagnostic);
@@ -132,12 +139,12 @@ lsp::WorkspaceDiagnosticReport WorkspaceFolder::workspaceDiagnostics(const lsp::
         Luau::LintResult lr = frontend.lint(moduleName);
         for (auto& error : lr.errors)
         {
-            auto diagnostic = createLintDiagnostic(error);
+            auto diagnostic = createLintDiagnostic(error, document);
             diagnostic.severity = lsp::DiagnosticSeverity::Error; // Report this as an error instead
             documentReport.items.emplace_back(diagnostic);
         }
         for (auto& error : lr.warnings)
-            documentReport.items.emplace_back(createLintDiagnostic(error));
+            documentReport.items.emplace_back(createLintDiagnostic(error, document));
 
         workspaceReport.items.emplace_back(documentReport);
     }

--- a/src/operations/GotoDefinition.cpp
+++ b/src/operations/GotoDefinition.cpp
@@ -6,7 +6,10 @@ lsp::DefinitionResult WorkspaceFolder::gotoDefinition(const lsp::DefinitionParam
     lsp::DefinitionResult result;
 
     auto moduleName = fileResolver.getModuleName(params.textDocument.uri);
-    auto position = convertPosition(params.position);
+    auto textDocument = fileResolver.getTextDocument(moduleName);
+    if (!textDocument)
+        throw JsonRpcException(lsp::ErrorCode::RequestFailed, "No managed text document");
+    auto position = textDocument->convertPosition(params.position);
 
     // Run the type checker to ensure we are up to date
     if (frontend.isDirty(moduleName))
@@ -131,7 +134,10 @@ std::optional<lsp::Location> WorkspaceFolder::gotoTypeDefinition(const lsp::Type
     // If its a type, then just find the definintion of that type (i.e. the type alias)
 
     auto moduleName = fileResolver.getModuleName(params.textDocument.uri);
-    auto position = convertPosition(params.position);
+    auto textDocument = fileResolver.getTextDocument(moduleName);
+    if (!textDocument)
+        throw JsonRpcException(lsp::ErrorCode::RequestFailed, "No managed text document");
+    auto position = textDocument->convertPosition(params.position);
 
     // Run the type checker to ensure we are up to date
     if (frontend.isDirty(moduleName))

--- a/src/operations/GotoDefinition.cpp
+++ b/src/operations/GotoDefinition.cpp
@@ -33,8 +33,8 @@ lsp::DefinitionResult WorkspaceFolder::gotoDefinition(const lsp::DefinitionParam
             return result;
 
         // TODO: can we maybe get further references if it points to something like `local X = require(...)`?
-        result.emplace_back(
-            lsp::Location{params.textDocument.uri, lsp::Range{convertPosition(binding->location.begin), convertPosition(binding->location.end)}});
+        result.emplace_back(lsp::Location{params.textDocument.uri,
+            lsp::Range{textDocument->convertPosition(binding->location.begin), textDocument->convertPosition(binding->location.end)}});
     }
 
     auto node = findNodeOrTypeAtPosition(*sourceModule, position);
@@ -97,14 +97,14 @@ lsp::DefinitionResult WorkspaceFolder::gotoDefinition(const lsp::DefinitionParam
             {
                 if (auto file = fileResolver.resolveToRealPath(*definitionModuleName))
                 {
-                    result.emplace_back(
-                        lsp::Location{Uri::file(*file), lsp::Range{convertPosition(location->begin), convertPosition(location->end)}});
+                    result.emplace_back(lsp::Location{
+                        Uri::file(*file), lsp::Range{textDocument->convertPosition(location->begin), textDocument->convertPosition(location->end)}});
                 }
             }
             else
             {
-                result.emplace_back(
-                    lsp::Location{params.textDocument.uri, lsp::Range{convertPosition(location->begin), convertPosition(location->end)}});
+                result.emplace_back(lsp::Location{params.textDocument.uri,
+                    lsp::Range{textDocument->convertPosition(location->begin), textDocument->convertPosition(location->end)}});
             }
         }
     }
@@ -122,7 +122,8 @@ lsp::DefinitionResult WorkspaceFolder::gotoDefinition(const lsp::DefinitionParam
         if (!location)
             return result;
 
-        result.emplace_back(lsp::Location{params.textDocument.uri, lsp::Range{convertPosition(location->begin), convertPosition(location->end)}});
+        result.emplace_back(lsp::Location{
+            params.textDocument.uri, lsp::Range{textDocument->convertPosition(location->begin), textDocument->convertPosition(location->end)}});
     }
 
     return result;
@@ -157,7 +158,7 @@ std::optional<lsp::Location> WorkspaceFolder::gotoTypeDefinition(const lsp::Type
     if (!node)
         return std::nullopt;
 
-    auto findTypeLocation = [&module, &position, &params](Luau::AstType* type) -> std::optional<lsp::Location>
+    auto findTypeLocation = [textDocument, &module, &position, &params](Luau::AstType* type) -> std::optional<lsp::Location>
     {
         // TODO: should we only handle references here? what if its an actual type
         if (auto reference = type->as<Luau::AstTypeReference>())
@@ -174,7 +175,8 @@ std::optional<lsp::Location> WorkspaceFolder::gotoTypeDefinition(const lsp::Type
             if (!location)
                 return std::nullopt;
 
-            return lsp::Location{params.textDocument.uri, lsp::Range{convertPosition(location->begin), convertPosition(location->end)}};
+            return lsp::Location{
+                params.textDocument.uri, lsp::Range{textDocument->convertPosition(location->begin), textDocument->convertPosition(location->end)}};
         }
         return std::nullopt;
     };

--- a/src/operations/Hover.cpp
+++ b/src/operations/Hover.cpp
@@ -9,7 +9,11 @@ std::optional<lsp::Hover> WorkspaceFolder::hover(const lsp::HoverParams& params)
         return std::nullopt;
 
     auto moduleName = fileResolver.getModuleName(params.textDocument.uri);
-    auto position = convertPosition(params.position);
+    auto textDocument = fileResolver.getTextDocument(moduleName);
+    if (!textDocument)
+        throw JsonRpcException(lsp::ErrorCode::RequestFailed, "No managed text document");
+
+    auto position = textDocument->convertPosition(params.position);
 
     // Run the type checker to ensure we are up to date
     // TODO: expressiveTypes - remove "forAutocomplete" once the types have been fixed

--- a/src/operations/References.cpp
+++ b/src/operations/References.cpp
@@ -5,7 +5,11 @@ lsp::ReferenceResult WorkspaceFolder::references(const lsp::ReferenceParams& par
 {
     // TODO: currently we only support searching for a binding at a current position
     auto moduleName = fileResolver.getModuleName(params.textDocument.uri);
-    auto position = convertPosition(params.position);
+    auto textDocument = fileResolver.getTextDocument(moduleName);
+    if (!textDocument)
+        return std::nullopt;
+
+    auto position = textDocument->convertPosition(params.position);
 
     // Run the type checker to ensure we are up to date
     // TODO: we only need the parse result here - can typechecking be skipped?

--- a/src/operations/References.cpp
+++ b/src/operations/References.cpp
@@ -35,7 +35,8 @@ lsp::ReferenceResult WorkspaceFolder::references(const lsp::ReferenceParams& par
 
     for (auto& location : references)
     {
-        result.emplace_back(lsp::Location{params.textDocument.uri, {convertPosition(location.begin), convertPosition(location.end)}});
+        result.emplace_back(
+            lsp::Location{params.textDocument.uri, {textDocument->convertPosition(location.begin), textDocument->convertPosition(location.end)}});
     }
 
     return result;

--- a/src/operations/Rename.cpp
+++ b/src/operations/Rename.cpp
@@ -17,7 +17,10 @@ lsp::RenameResult WorkspaceFolder::rename(const lsp::RenameParams& params)
 
     // TODO: currently we only support renaming local bindings in the current file
     auto moduleName = fileResolver.getModuleName(params.textDocument.uri);
-    auto position = convertPosition(params.position);
+    auto textDocument = fileResolver.getTextDocument(moduleName);
+    if (!textDocument)
+        throw JsonRpcException(lsp::ErrorCode::RequestFailed, "No managed text document");
+    auto position = textDocument->convertPosition(params.position);
 
     // Run the type checker to ensure we are up to date
     // TODO: we only need the parse result here - can typechecking be skipped?

--- a/src/operations/Rename.cpp
+++ b/src/operations/Rename.cpp
@@ -45,7 +45,8 @@ lsp::RenameResult WorkspaceFolder::rename(const lsp::RenameParams& params)
     std::vector<lsp::TextEdit> localChanges;
     for (auto& location : references)
     {
-        localChanges.emplace_back(lsp::TextEdit{{convertPosition(location.begin), convertPosition(location.end)}, params.newName});
+        localChanges.emplace_back(
+            lsp::TextEdit{{textDocument->convertPosition(location.begin), textDocument->convertPosition(location.end)}, params.newName});
     }
 
     return lsp::WorkspaceEdit{{{params.textDocument.uri.toString(), localChanges}}};

--- a/src/operations/SignatureHelp.cpp
+++ b/src/operations/SignatureHelp.cpp
@@ -9,7 +9,10 @@ std::optional<lsp::SignatureHelp> WorkspaceFolder::signatureHelp(const lsp::Sign
         return std::nullopt;
 
     auto moduleName = fileResolver.getModuleName(params.textDocument.uri);
-    auto position = convertPosition(params.position);
+    auto textDocument = fileResolver.getTextDocument(moduleName);
+    if (!textDocument)
+        throw JsonRpcException(lsp::ErrorCode::RequestFailed, "No managed text document");
+    auto position = textDocument->convertPosition(params.position);
 
     // Run the type checker to ensure we are up to date
     // TODO: expressiveTypes - remove "forAutocomplete" once the types have been fixed

--- a/tests/TextDocument.test.cpp
+++ b/tests/TextDocument.test.cpp
@@ -166,30 +166,26 @@ TEST_CASE("PositionToOffset")
     CHECK_EQ(document.offsetAt(lsp::Position{0, 6}), 6); // last character
     CHECK_EQ(document.offsetAt(lsp::Position{0, 7}), 7); // the newline itself
     CHECK_EQ(document.offsetAt(lsp::Position{0, 7}), 7);
-    CHECK_EQ(document.offsetAt(lsp::Position{0, 8}), 7); // out of range
-    CHECK_EQ(document.offsetAt(lsp::Position{0, 8}), 0); // out of range
+    CHECK_EQ(document.offsetAt(lsp::Position{0, 8}), 8); // out of range
     // middle line
-    // CHECK_EQ(document.offsetAt(lsp::Position{1, -1}), llvm::Failed()); // out of range
+    // CHECK_EQ(document.offsetAt(lsp::Position{1, -1}), 0); // out of range
     CHECK_EQ(document.offsetAt(lsp::Position{1, 0}), 8);  // first character
     CHECK_EQ(document.offsetAt(lsp::Position{1, 3}), 11); // middle character
-    CHECK_EQ(document.offsetAt(lsp::Position{1, 3}), 11);
     CHECK_EQ(document.offsetAt(lsp::Position{1, 6}), 16); // last character
     CHECK_EQ(document.offsetAt(lsp::Position{1, 7}), 17); // the newline itself
-    CHECK_EQ(document.offsetAt(lsp::Position{1, 8}), 17); // out of range
-    // CHECK_EQ(document.offsetAt(lsp::Position{1, 8}), llvm::Failed()); // out of range
+    CHECK_EQ(document.offsetAt(lsp::Position{1, 8}), 18); // out of range
     // last line
-    // CHECK_EQ(document.offsetAt(lsp::Position{2, -1}), llvm::Failed()); // out of range
-    CHECK_EQ(document.offsetAt(lsp::Position{2, 0}), 18); // first character
-    CHECK_EQ(document.offsetAt(lsp::Position{2, 3}), 21); // middle character
-    // CHECK_EQ(document.offsetAt(lsp::Position{2, 5}), llvm::Failed());  // middle of surrogate pair
-    CHECK_EQ(document.offsetAt(lsp::Position{2, 5}), 26); // middle of surrogate pair
-    CHECK_EQ(document.offsetAt(lsp::Position{2, 6}), 26); // end of surrogate pair
-    CHECK_EQ(document.offsetAt(lsp::Position{2, 8}), 28); // last character
-    CHECK_EQ(document.offsetAt(lsp::Position{2, 9}), 29); // EOF
-    // CHECK_EQ(document.offsetAt(lsp::Position{2, 10}), llvm::Failed()); // out of range
+    // CHECK_EQ(document.offsetAt(lsp::Position{2, -1}), 0); // out of range
+    CHECK_EQ(document.offsetAt(lsp::Position{2, 0}), 18);  // first character
+    CHECK_EQ(document.offsetAt(lsp::Position{2, 3}), 21);  // middle character
+    CHECK_EQ(document.offsetAt(lsp::Position{2, 5}), 26);  // middle of surrogate pair
+    CHECK_EQ(document.offsetAt(lsp::Position{2, 6}), 26);  // end of surrogate pair
+    CHECK_EQ(document.offsetAt(lsp::Position{2, 8}), 28);  // last character
+    CHECK_EQ(document.offsetAt(lsp::Position{2, 9}), 29);  // EOF
+    CHECK_EQ(document.offsetAt(lsp::Position{2, 10}), 29); // out of range
     // line out of bounds
-    // CHECK_EQ(document.offsetAt(lsp::Position{3, 0}), llvm::Failed());
-    // CHECK_EQ(document.offsetAt(lsp::Position{3, 1}), llvm::Failed());
+    CHECK_EQ(document.offsetAt(lsp::Position{3, 0}), 29);
+    CHECK_EQ(document.offsetAt(lsp::Position{3, 1}), 29);
 };
 
 TEST_SUITE_END();

--- a/tests/TextDocument.test.cpp
+++ b/tests/TextDocument.test.cpp
@@ -1,6 +1,7 @@
 // Source: https://github.com/microsoft/vscode-languageserver-node/blob/main/textDocument/src/test/textdocument.test.ts
 
 #include "doctest.h"
+#include "LSP/LanguageServer.hpp"
 #include "LSP/Protocol.hpp"
 #include "LSP/TextDocument.hpp"
 #include "LSP/Uri.hpp"
@@ -122,6 +123,7 @@ TEST_CASE("Invalid inputs")
 // https://github.com/llvm/llvm-project/blob/main/clang-tools-extra/clangd/unittests/SourceCodeTests.cpp
 TEST_CASE("lspLength")
 {
+    positionEncoding() = lsp::PositionEncodingKind::UTF16;
     CHECK_EQ(lspLength(""), 0UL);
     CHECK_EQ(lspLength("ascii"), 5UL);
     // BMP
@@ -130,23 +132,23 @@ TEST_CASE("lspLength")
     // astral
     CHECK_EQ(lspLength("😂"), 2UL);
 
-    // WithContextValue UTF8(kCurrentOffsetEncoding, OffsetEncoding::UTF8);
-    // EXPECT_EQ(lspLength(""), 0UL);
-    // EXPECT_EQ(lspLength("ascii"), 5UL);
-    // // BMP
-    // EXPECT_EQ(lspLength("↓"), 3UL);
-    // EXPECT_EQ(lspLength("¥"), 2UL);
-    // // astral
-    // EXPECT_EQ(lspLength("😂"), 4UL);
+    positionEncoding() = lsp::PositionEncodingKind::UTF8;
+    CHECK_EQ(lspLength(""), 0UL);
+    CHECK_EQ(lspLength("ascii"), 5UL);
+    // BMP
+    CHECK_EQ(lspLength("↓"), 3UL);
+    CHECK_EQ(lspLength("¥"), 2UL);
+    // astral
+    CHECK_EQ(lspLength("😂"), 4UL);
 
-    // WithContextValue UTF32(kCurrentOffsetEncoding, OffsetEncoding::UTF32);
-    // EXPECT_EQ(lspLength(""), 0UL);
-    // EXPECT_EQ(lspLength("ascii"), 5UL);
-    // // BMP
-    // EXPECT_EQ(lspLength("↓"), 1UL);
-    // EXPECT_EQ(lspLength("¥"), 1UL);
-    // // astral
-    // EXPECT_EQ(lspLength("😂"), 1UL);
+    positionEncoding() = lsp::PositionEncodingKind::UTF32;
+    CHECK_EQ(lspLength(""), 0UL);
+    CHECK_EQ(lspLength("ascii"), 5UL);
+    // BMP
+    CHECK_EQ(lspLength("↓"), 1UL);
+    CHECK_EQ(lspLength("¥"), 1UL);
+    // astral
+    CHECK_EQ(lspLength("😂"), 1UL);
 }
 
 TEST_CASE("PositionToOffset")
@@ -154,6 +156,8 @@ TEST_CASE("PositionToOffset")
     auto document = newDocument(R"(0:0 = 0
 1:0 → 8
 2:0 🡆 18)");
+
+    positionEncoding() = lsp::PositionEncodingKind::UTF16;
 
     // DEVIATION: we do not accept negative positions
     // line out of bounds
@@ -186,6 +190,49 @@ TEST_CASE("PositionToOffset")
     // line out of bounds
     CHECK_EQ(document.offsetAt(lsp::Position{3, 0}), 29);
     CHECK_EQ(document.offsetAt(lsp::Position{3, 1}), 29);
+
+    // Codepoints are similar, except near astral characters.
+    positionEncoding() = lsp::PositionEncodingKind::UTF32;
+    // line out of bounds
+    // CHECK_EQ(document.offsetAt(lsp::Position{-1, 2}), 0);
+    // first line
+    // CHECK_EQ(document.offsetAt(lsp::Position{0, -1}), 0); // out of range
+    CHECK_EQ(document.offsetAt(lsp::Position{0, 0}), 0); // first character
+    CHECK_EQ(document.offsetAt(lsp::Position{0, 3}), 3); // middle character
+    CHECK_EQ(document.offsetAt(lsp::Position{0, 6}), 6); // last character
+    CHECK_EQ(document.offsetAt(lsp::Position{0, 7}), 7); // the newline itself
+    CHECK_EQ(document.offsetAt(lsp::Position{0, 8}), 8); // out of range
+    // middle line
+    // CHECK_EQ(document.offsetAt(lsp::Position{1, -1}), 0); // out of range
+    CHECK_EQ(document.offsetAt(lsp::Position{1, 0}), 8);  // first character
+    CHECK_EQ(document.offsetAt(lsp::Position{1, 3}), 11); // middle character
+    CHECK_EQ(document.offsetAt(lsp::Position{1, 6}), 16); // last character
+    CHECK_EQ(document.offsetAt(lsp::Position{1, 7}), 17); // the newline itself
+    CHECK_EQ(document.offsetAt(lsp::Position{1, 8}), 18); // out of range
+    // last line
+    // CHECK_EQ(document.offsetAt(lsp::Position{2, -1}), 0); // out of range
+    CHECK_EQ(document.offsetAt(lsp::Position{2, 0}), 18); // first character
+    CHECK_EQ(document.offsetAt(lsp::Position{2, 4}), 22); // Before astral character.
+    CHECK_EQ(document.offsetAt(lsp::Position{2, 5}), 26); // after astral character
+    CHECK_EQ(document.offsetAt(lsp::Position{2, 7}), 28); // last character
+    CHECK_EQ(document.offsetAt(lsp::Position{2, 8}), 29); // EOF
+    CHECK_EQ(document.offsetAt(lsp::Position{2, 9}), 29); // out of range
+    // line out of bounds
+    CHECK_EQ(document.offsetAt(lsp::Position{3, 0}), 29);
+    CHECK_EQ(document.offsetAt(lsp::Position{3, 1}), 29);
+
+    // Test UTF-8, where transformations are trivial.
+    positionEncoding() = lsp::PositionEncodingKind::UTF8;
+    // CHECK_EQ(document.offsetAt(lsp::Position{-1, 2}), 0);
+    CHECK_EQ(document.offsetAt(lsp::Position{3, 0}), 29);
+    for (unsigned int i = 0; i < document.lineCount(); i++)
+    {
+        auto line = document.getLines()[i];
+        auto offset = document.getLineOffsets()[i];
+        // CHECK_EQ(document.offsetAt(lsp::Position{i, -1}), 0); // out of range
+        for (unsigned I = 0; I < line.length(); ++I)
+            CHECK_EQ(document.offsetAt(lsp::Position{i, I}), offset + I);
+    }
 };
 
 TEST_CASE("OffsetToPosition")
@@ -193,6 +240,7 @@ TEST_CASE("OffsetToPosition")
     auto document = newDocument(R"(0:0 = 0
 1:0 → 8
 2:0 🡆 18)");
+    positionEncoding() = lsp::PositionEncodingKind::UTF16;
     CHECK_EQ(document.positionAt(0), lsp::Position{0, 0});  // "start of file"
     CHECK_EQ(document.positionAt(3), lsp::Position{0, 3});  // "in first line"
     CHECK_EQ(document.positionAt(6), lsp::Position{0, 6});  // "end of first line"
@@ -213,33 +261,35 @@ TEST_CASE("OffsetToPosition")
     CHECK_EQ(document.positionAt(30), lsp::Position{2, 9}); // "out of bounds"
 
     // // Codepoints are similar, except near astral characters.
-    // WithContextValue UTF32(kCurrentOffsetEncoding, OffsetEncoding::UTF32);
-    // CHECK_EQ(document.positionAt(0), lsp::Position{0, 0}) << "start of file";
-    // CHECK_EQ(document.positionAt(3), lsp::Position{0, 3}) << "in first line";
-    // CHECK_EQ(document.positionAt(6), lsp::Position{0, 6}) << "end of first line";
-    // CHECK_EQ(document.positionAt(7), lsp::Position{0, 7}) << "first newline";
-    // CHECK_EQ(document.positionAt(8), lsp::Position{1, 0}) << "start of second line";
-    // CHECK_EQ(document.positionAt(12), lsp::Position{1, 4}) << "before BMP char";
-    // CHECK_EQ(document.positionAt(13), lsp::Position{1, 5}) << "in BMP char";
-    // CHECK_EQ(document.positionAt(15), lsp::Position{1, 5}) << "after BMP char";
-    // CHECK_EQ(document.positionAt(16), lsp::Position{1, 6}) << "end of second line";
-    // CHECK_EQ(document.positionAt(17), lsp::Position{1, 7}) << "second newline";
-    // CHECK_EQ(document.positionAt(18), lsp::Position{2, 0}) << "start of last line";
-    // CHECK_EQ(document.positionAt(21), lsp::Position{2, 3}) << "in last line";
-    // CHECK_EQ(document.positionAt(22), lsp::Position{2, 4}) << "before astral char";
-    // CHECK_EQ(document.positionAt(24), lsp::Position{2, 5}) << "in astral char";
-    // CHECK_EQ(document.positionAt(26), lsp::Position{2, 5}) << "after astral char";
-    // CHECK_EQ(document.positionAt(28), lsp::Position{2, 7}) << "end of last line";
-    // CHECK_EQ(document.positionAt(29), lsp::Position{2, 8}) << "EOF";
-    // CHECK_EQ(document.positionAt(30), lsp::Position{2, 8}) << "out of bounds";
+    positionEncoding() = lsp::PositionEncodingKind::UTF32;
+    CHECK_EQ(document.positionAt(0), lsp::Position{0, 0});  // "start of file";
+    CHECK_EQ(document.positionAt(3), lsp::Position{0, 3});  // "in first line";
+    CHECK_EQ(document.positionAt(6), lsp::Position{0, 6});  // "end of first line";
+    CHECK_EQ(document.positionAt(7), lsp::Position{0, 7});  // "first newline";
+    CHECK_EQ(document.positionAt(8), lsp::Position{1, 0});  // "start of second line";
+    CHECK_EQ(document.positionAt(12), lsp::Position{1, 4}); // "before BMP char";
+    CHECK_EQ(document.positionAt(13), lsp::Position{1, 5}); // "in BMP char";
+    CHECK_EQ(document.positionAt(15), lsp::Position{1, 5}); // "after BMP char";
+    CHECK_EQ(document.positionAt(16), lsp::Position{1, 6}); // "end of second line";
+    CHECK_EQ(document.positionAt(17), lsp::Position{1, 7}); // "second newline";
+    CHECK_EQ(document.positionAt(18), lsp::Position{2, 0}); // "start of last line";
+    CHECK_EQ(document.positionAt(21), lsp::Position{2, 3}); // "in last line";
+    CHECK_EQ(document.positionAt(22), lsp::Position{2, 4}); // "before astral char";
+    CHECK_EQ(document.positionAt(24), lsp::Position{2, 5}); // "in astral char";
+    CHECK_EQ(document.positionAt(26), lsp::Position{2, 5}); // "after astral char";
+    CHECK_EQ(document.positionAt(28), lsp::Position{2, 7}); // "end of last line";
+    CHECK_EQ(document.positionAt(29), lsp::Position{2, 8}); // "EOF";
+    CHECK_EQ(document.positionAt(30), lsp::Position{2, 8}); // "out of bounds";
 
-    // WithContextValue UTF8(kCurrentOffsetEncoding, OffsetEncoding::UTF8);
-    // for (Line L : FileLines)
-    // {
-    //     for (unsigned I = 0; I <= L.Length; ++I)
-    //         CHECK_EQ(document.positionAt(L.Offset + I), Pos(L.Number, I));
-    // }
-    // CHECK_EQ(document.positionAt(30), lsp::Position{2, 11}) << "out of bounds";
+    positionEncoding() = lsp::PositionEncodingKind::UTF8;
+    for (unsigned int i = 0; i < document.lineCount(); i++)
+    {
+        auto line = document.getLines()[i];
+        auto offset = document.getLineOffsets()[i];
+        for (unsigned I = 0; I <= line.length(); ++I)
+            CHECK_EQ(document.positionAt(offset + I), lsp::Position{i, I});
+    }
+    CHECK_EQ(document.positionAt(30), lsp::Position{2, 11}); // "out of bounds";
 }
 
 TEST_SUITE_END();

--- a/tests/TextDocument.test.cpp
+++ b/tests/TextDocument.test.cpp
@@ -188,6 +188,60 @@ TEST_CASE("PositionToOffset")
     CHECK_EQ(document.offsetAt(lsp::Position{3, 1}), 29);
 };
 
+TEST_CASE("OffsetToPosition")
+{
+    auto document = newDocument(R"(0:0 = 0
+1:0 → 8
+2:0 🡆 18)");
+    CHECK_EQ(document.positionAt(0), lsp::Position{0, 0});  // "start of file"
+    CHECK_EQ(document.positionAt(3), lsp::Position{0, 3});  // "in first line"
+    CHECK_EQ(document.positionAt(6), lsp::Position{0, 6});  // "end of first line"
+    CHECK_EQ(document.positionAt(7), lsp::Position{0, 7});  // "first newline"
+    CHECK_EQ(document.positionAt(8), lsp::Position{1, 0});  // "start of second line"
+    CHECK_EQ(document.positionAt(12), lsp::Position{1, 4}); // "before BMP char"
+    CHECK_EQ(document.positionAt(13), lsp::Position{1, 5}); // "in BMP char"
+    CHECK_EQ(document.positionAt(15), lsp::Position{1, 5}); // "after BMP char"
+    CHECK_EQ(document.positionAt(16), lsp::Position{1, 6}); // "end of second line"
+    CHECK_EQ(document.positionAt(17), lsp::Position{1, 7}); // "second newline"
+    CHECK_EQ(document.positionAt(18), lsp::Position{2, 0}); // "start of last line"
+    CHECK_EQ(document.positionAt(21), lsp::Position{2, 3}); // "in last line"
+    CHECK_EQ(document.positionAt(22), lsp::Position{2, 4}); // "before astral char"
+    CHECK_EQ(document.positionAt(24), lsp::Position{2, 6}); // "in astral char"
+    CHECK_EQ(document.positionAt(26), lsp::Position{2, 6}); // "after astral char"
+    CHECK_EQ(document.positionAt(28), lsp::Position{2, 8}); // "end of last line"
+    CHECK_EQ(document.positionAt(29), lsp::Position{2, 9}); // "EOF"
+    CHECK_EQ(document.positionAt(30), lsp::Position{2, 9}); // "out of bounds"
+
+    // // Codepoints are similar, except near astral characters.
+    // WithContextValue UTF32(kCurrentOffsetEncoding, OffsetEncoding::UTF32);
+    // CHECK_EQ(document.positionAt(0), lsp::Position{0, 0}) << "start of file";
+    // CHECK_EQ(document.positionAt(3), lsp::Position{0, 3}) << "in first line";
+    // CHECK_EQ(document.positionAt(6), lsp::Position{0, 6}) << "end of first line";
+    // CHECK_EQ(document.positionAt(7), lsp::Position{0, 7}) << "first newline";
+    // CHECK_EQ(document.positionAt(8), lsp::Position{1, 0}) << "start of second line";
+    // CHECK_EQ(document.positionAt(12), lsp::Position{1, 4}) << "before BMP char";
+    // CHECK_EQ(document.positionAt(13), lsp::Position{1, 5}) << "in BMP char";
+    // CHECK_EQ(document.positionAt(15), lsp::Position{1, 5}) << "after BMP char";
+    // CHECK_EQ(document.positionAt(16), lsp::Position{1, 6}) << "end of second line";
+    // CHECK_EQ(document.positionAt(17), lsp::Position{1, 7}) << "second newline";
+    // CHECK_EQ(document.positionAt(18), lsp::Position{2, 0}) << "start of last line";
+    // CHECK_EQ(document.positionAt(21), lsp::Position{2, 3}) << "in last line";
+    // CHECK_EQ(document.positionAt(22), lsp::Position{2, 4}) << "before astral char";
+    // CHECK_EQ(document.positionAt(24), lsp::Position{2, 5}) << "in astral char";
+    // CHECK_EQ(document.positionAt(26), lsp::Position{2, 5}) << "after astral char";
+    // CHECK_EQ(document.positionAt(28), lsp::Position{2, 7}) << "end of last line";
+    // CHECK_EQ(document.positionAt(29), lsp::Position{2, 8}) << "EOF";
+    // CHECK_EQ(document.positionAt(30), lsp::Position{2, 8}) << "out of bounds";
+
+    // WithContextValue UTF8(kCurrentOffsetEncoding, OffsetEncoding::UTF8);
+    // for (Line L : FileLines)
+    // {
+    //     for (unsigned I = 0; I <= L.Length; ++I)
+    //         CHECK_EQ(document.positionAt(L.Offset + I), Pos(L.Number, I));
+    // }
+    // CHECK_EQ(document.positionAt(30), lsp::Position{2, 11}) << "out of bounds";
+}
+
 TEST_SUITE_END();
 
 TEST_SUITE_BEGIN("Text Document Full Updates");


### PR DESCRIPTION
Fixes #42 

We now correctly handle UTF-16 encoded Positions sent by the client.
Our internal representation of the text document is now correct, and does not lead to malformed issues.
We also properly convert from and to UTF-16 positions before processing the code / sending it back to the client.
`lsp::Position` is now treated as a UTF-16 encoded position, whilst `Luau::Position` is UTF-8