### PR TITLE
Type improvements

### DIFF
--- a/scripts/dumpRobloxTypes.py
+++ b/scripts/dumpRobloxTypes.py
@@ -78,6 +78,8 @@ IGNORED_MEMBERS = {
         "WaitForChild",
         "GetAttributes",
         "AncestryChanged",
+        "GetAttributeChangedSignal",
+        "GetPropertyChangedSignal",
     ],
     "Model": ["PrimaryPart"],
     "RemoteEvent": [
@@ -142,6 +144,8 @@ IGNORED_MEMBERS = {
     "CollectionService": [
         "GetAllTags",
         "GetTags",
+        "GetInstanceAddedSignal",
+        "GetInstanceRemovedSignal",
     ],
     "UserInputService": [
         "GetConnectedGamepads",
@@ -242,6 +246,8 @@ EXTRA_MEMBERS = {
         "function WaitForChild(self, name: string): Instance",
         "function WaitForChild(self, name: string, timeout: number): Instance?",
         "function GetAttributes(self): { [string]: any }",
+        "function GetAttributeChangedSignal(self, attribute: string): RBXScriptSignal<>",
+        "function GetPropertyChangedSignal(self, property: string): RBXScriptSignal<>",
     ],
     "Model": ["PrimaryPart: BasePart?"],
     "RemoteEvent": [
@@ -315,6 +321,8 @@ EXTRA_MEMBERS = {
     "CollectionService": [
         "function GetAllTags(self): { string }",
         "function GetTags(self, instance: Instance): { string }",
+        "function GetInstanceAddedSignal(self, tag: string): RBXScriptSignal<Instance>",
+        "function GetInstanceRemovedSignal(self, tag: string): RBXScriptSignal<Instance>",
     ],
     "UserInputService": [
         "function GetConnectedGamepads(self): { EnumUserInputType }",

--- a/scripts/dumpRobloxTypes.py
+++ b/scripts/dumpRobloxTypes.py
@@ -334,7 +334,7 @@ EXTRA_MEMBERS = {
     ],
     "Humanoid": [
         "RootPart: BasePart?",
-        "SeatPart: BasePart?",
+        "SeatPart: Seat | VehicleSeat | nil",
         "WalkToPart: BasePart?",
         "function GetAccessories(self): { Accessory }",
     ],

--- a/scripts/globalTypes.d.lua
+++ b/scripts/globalTypes.d.lua
@@ -4258,13 +4258,13 @@ declare class Instance
 	function FindFirstDescendant(self, name: string): Instance?
 	function GetActor(self): Actor?
 	function GetAttribute(self, attribute: string): any
-	function GetAttributeChangedSignal(self, attribute: string): RBXScriptSignal
+	function GetAttributeChangedSignal(self, attribute: string): RBXScriptSignal<>
 	function GetAttributes(self): { [string]: any }
 	function GetChildren(self): { Instance }
 	function GetDebugId(self, scopeLength: number?): string
 	function GetDescendants(self): { Instance }
 	function GetFullName(self): string
-	function GetPropertyChangedSignal(self, property: string): RBXScriptSignal
+	function GetPropertyChangedSignal(self, property: string): RBXScriptSignal<>
 	function IsA(self, className: string): boolean
 	function IsAncestorOf(self, descendant: Instance): boolean
 	function IsDescendantOf(self, ancestor: Instance): boolean
@@ -4945,8 +4945,8 @@ declare class CollectionService extends Instance
 	TagRemoved: RBXScriptSignal<string>
 	function AddTag(self, instance: Instance, tag: string): nil
 	function GetAllTags(self): { string }
-	function GetInstanceAddedSignal(self, tag: string): RBXScriptSignal
-	function GetInstanceRemovedSignal(self, tag: string): RBXScriptSignal
+	function GetInstanceAddedSignal(self, tag: string): RBXScriptSignal<Instance>
+	function GetInstanceRemovedSignal(self, tag: string): RBXScriptSignal<Instance>
 	function GetTagged(self, tag: string): { Instance }
 	function GetTags(self, instance: Instance): { string }
 	function HasTag(self, instance: Instance, tag: string): boolean

--- a/scripts/globalTypes.d.lua
+++ b/scripts/globalTypes.d.lua
@@ -6502,7 +6502,7 @@ declare class Humanoid extends Instance
 	RigType: EnumHumanoidRigType
 	RootPart: BasePart?
 	Running: RBXScriptSignal<number>
-	SeatPart: BasePart?
+	SeatPart: Seat | VehicleSeat | nil
 	Seated: RBXScriptSignal<boolean, Seat>
 	Sit: boolean
 	StateChanged: RBXScriptSignal<EnumHumanoidStateType, EnumHumanoidStateType>


### PR DESCRIPTION
The "parameters" to signals created by `GetInstanceAddedSignal` and `GetInstanceRemovedSignal` were typed as `...any`, instead of `Instance`
This also marks `GetAttributeChangedSignal` and `GetPropertyChangedSignal` as returning signals that don't pass anything

Refines `Humanoid.SeatPart` to be `Seat | VehicleSeat | nil`, rather than `BasePart?`