### PR TITLE
Update to latest types dump + only valid identifiers

### DIFF
--- a/scripts/dumpRobloxTypes.py
+++ b/scripts/dumpRobloxTypes.py
@@ -1,6 +1,7 @@
 # Script to pull in API Dump and export it into a definition file
 # Based off https://gist.github.com/HawDevelopment/97f2411149e24d8e7a712016114d55ff
 from itertools import chain
+import re
 from typing import List, Literal, Optional, Union, TypedDict
 from collections import defaultdict
 import requests
@@ -657,18 +658,15 @@ DataTypesDump = TypedDict(
 )
 
 
+def isIdentifier(name: str):
+    return re.match(r"^[a-zA-Z_]+[a-zA-Z_0-9]*$", name)  # TODO: 'function'
+
+
 def escapeName(name: str):
     """Escape a name string to be property-compatible"""
     if name == "function":
         return "func"
-    return (
-        name.replace(" ", "_")
-        .replace("-", "")
-        .replace('"', "")
-        .replace("(", "")
-        .replace(")", "")
-        .replace("/", "_")
-    )
+    return name
 
 
 def resolveType(type: Union[ApiValueType, CorrectionsValueType]) -> str:
@@ -718,6 +716,11 @@ def filterMember(klassName: str, member: ApiMember):
         and member["Name"] == "GetService"
     ):
         return False
+
+    # TODO: support ["prop"] in CTVs
+    if not isIdentifier(member["Name"]):
+        return False
+
     return True
 
 

--- a/scripts/globalTypes.d.lua
+++ b/scripts/globalTypes.d.lua
@@ -7331,10 +7331,6 @@ declare class NotificationService extends Instance
 end
 
 declare class PVInstance extends Instance
-	Origin_Orientation: Vector3
-	Origin_Position: Vector3
-	Pivot_Offset_Orientation: Vector3
-	Pivot_Offset_Position: Vector3
 	function GetPivot(self): CFrame
 	function PivotTo(self, targetCFrame: CFrame): nil
 end
@@ -7524,8 +7520,6 @@ declare class Model extends PVInstance
 	ModelStreamingMode: EnumModelStreamingMode
 	PrimaryPart: BasePart?
 	WorldPivot: CFrame
-	World_Pivot_Orientation: Vector3
-	World_Pivot_Position: Vector3
 	function BreakJoints(self): nil
 	function GetBoundingBox(self): (CFrame, Vector3)
 	function GetExtentsSize(self): Vector3
@@ -8686,7 +8680,6 @@ declare class StarterPlayer extends Instance
 	GameSettingsScaleRangeWidth: NumberRange
 	HealthDisplayDistance: number
 	LoadCharacterAppearance: boolean
-	LoadCharacterLayeredClothing_: EnumLoadCharacterLayeredClothing
 	NameDisplayDistance: number
 	UserEmotesEnabled: boolean
 	function ClearDefaults(self): nil
@@ -8740,145 +8733,28 @@ declare class StopWatchReporter extends Instance
 end
 
 declare class Studio extends Instance
-	Active_Color: Color3
-	Active_Hover_Over_Color: Color3
-	Always_Save_Script_Changes: boolean
-	Animate_Hover_Over: boolean
-	AutoRecovery_Enabled: boolean
-	AutoRecovery_Interval_Minutes: number
-	AutoRecovery_Path: QDir
-	Auto_Clean_Empty_Line: boolean
-	Auto_Closing_Brackets: boolean
-	Auto_Closing_Quotes: boolean
-	Auto_Indent_Rule: EnumAutoIndentRule
-	Background_Color: Color3
-	Basic_Objects_Display_Mode: EnumListDisplayMode
-	Bool_Color: Color3
-	Bracket_Color: Color3
-	Builtin_Function_Color: Color3
-	Camera_Mouse_Wheel_Speed: number
-	Camera_Pan_Speed: number
-	Camera_Shift_Speed: number
-	Camera_Speed: number
-	Camera_Zoom_to_Mouse_Position: boolean
-	Clear_Output_On_Start: boolean
 	CommandBarLocalState: boolean
-	Comment_Color: Color3
-	Current_Line_Highlight_Color: Color3
-	Debugger_Current_Line_Color: Color3
-	Debugger_Error_Line_Color: Color3
 	DefaultScriptFileDir: QDir
 	DeprecatedObjectsShown: boolean
 	DisplayLanguage: string
-	Doc_View_Code_Background_Color: Color3
-	Drag_Multiple_Parts_As_Single_Part: boolean
 	EnableOnTypeAutocomplete: boolean
-	Enable_Autocomplete: boolean
-	Enable_Autocomplete_Doc_View: boolean
-	Enable_CoreScript_Debugger: boolean
-	Enable_Http_Sandboxing: boolean
-	Enable_Internal_Beta_Features: boolean
-	Enable_Internal_Features: boolean
-	Enable_Script_Analysis: boolean
-	Enable_Scrollbar_Markers: boolean
-	Enable_Signature_Help: boolean
-	Enable_Signature_Help_Doc_View: boolean
-	Enable_Temporary_Tabs: boolean
-	Enable_Temporary_Tabs_In_Explorer: boolean
-	Enable_Type_Hover: boolean
-	Error_Color: Color3
-	File_>_New_creates_a_place_with_Team_Create_off: boolean
-	Find_Selection_Background_Color: Color3
 	Font: QFont
-	Format_On_Paste: boolean
-	Format_On_Type: boolean
-	Function_Name_Color: Color3
-	Highlight_Current_Line: boolean
-	Highlight_Occurances: boolean
-	Hover_Animate_Speed: EnumHoverAnimateSpeed
-	Hover_Box_Thickness: number
-	Hover_Line_Thickness: number
-	Hover_Over_Color: Color3
 	IconOverrideDir: QDir
-	Indent_Using_Spaces: boolean
-	Keyword_Color: Color3
-	Line_Thickness: number
 	LocalAssetsFolder: QDir
 	LuaDebuggerEnabled: boolean
 	LuaDebuggerEnabledAtStartup: boolean
-	Luau_Keyword_Color: Color3
-	Main_Volume: number
-	Matching_Word_Background_Color: Color3
-	Maximum_Output_Lines: number
-	Menu_Item_Background_Color: Color3
-	Method_Color: Color3
-	Number_Color: Color3
-	Only_Play_Audio_from_Window_in_Focus: boolean
-	Operator_Color: Color3
-	Output_Font: QFont
-	Output_Layout_Mode: EnumOutputLayoutMode
 	PermissionLevelShown: EnumPermissionLevelShown
-	Physical_Draggers_Select_Scope_By_Default: boolean
-	Pivot_Snap_To_Geometry_Color: Color3
 	PluginDebuggingEnabled: boolean
 	PluginsDir: QDir
-	Primary_Text_Color: Color3
-	Property_Color: Color3
-	Render_Throttle_Percentage: number
-	Respect_Studio_shortcuts_when_game_has_focus: boolean
-	Ruler_Color: Color3
 	Rulers: string
 	RuntimeUndoBehavior: EnumRuntimeUndoBehavior
 	ScriptEditorMenuBorderColor: Color3
 	ScriptEditorShouldShowPluginMethods: boolean
 	ScriptTimeoutLength: number
-	Script_Editor_Color_Preset: EnumStudioScriptEditorColorPresets
-	Script_Editor_Scrollbar_Background_Color: Color3
-	Script_Editor_Scrollbar_Handle_Color: Color3
-	Scroll_Past_Last_Line: boolean
-	Search_Content_For_Core_Scripts: boolean
-	Secondary_Text_Color: Color3
-	Select_Color: Color3
-	Select_Hover_Color: Color3
-	Selected_Menu_Item_Background_Color: Color3
-	Selected_Text_Color: Color3
-	Selection_Background_Color: Color3
-	Selection_Color: Color3
-	Selection_Highlight_Thickness: number
-	Selection_Line_Thickness: number
-	Server_Audio_Behavior: EnumServerAudioBehavior
-	Set_Pivot_of_Imported_Parts: boolean
 	ShowCorePackagesInExplorer: boolean
-	Show_Core_GUI_in_Explorer_while_Playing: boolean
-	Show_Deployment_Warnings: boolean
-	Show_Diagnostics_Bar: boolean
-	Show_FileSyncService: boolean
-	Show_Hidden_Objects_in_Explorer: boolean
-	Show_Hover_Over: boolean
-	Show_Light_Guides: boolean
-	Show_Navigation_Labels: boolean
-	Show_Navigation_Mesh: boolean
-	Show_Pathfinding_Links: boolean
-	Show_Plugin_GUI_Service_in_Explorer: boolean
-	Show_QT_warnings_in_output: boolean
-	Show_Whitespace: boolean
-	Show_plus_button_on_hover_in_Explorer: boolean
-	Skip_Closing_Brackets_and_Quotes: boolean
-	String_Color: Color3
-	TODO_Color: Color3
-	Tab_Width: number
-	Text_Color: Color3
-	Text_Wrapping: boolean
 	Theme: StudioTheme
 	ThemeChanged: RBXScriptSignal<>
-	Use_Bounding_Box_Move_Handles: boolean
-	Warning_Color: Color3
-	Whitespace_Color: Color3
 	function GetAvailableThemes(self): { any }
-	function_Color: Color3
-	local_Color: Color3
-	nil_Color: Color3
-	self_Color: Color3
 end
 
 declare class StudioAssetService extends Instance

--- a/scripts/globalTypes.d.lua
+++ b/scripts/globalTypes.d.lua
@@ -743,6 +743,7 @@ declare class EnumCoreGuiType_INTERNAL extends Enum
 	Chat: EnumCoreGuiType
 	All: EnumCoreGuiType
 	EmotesMenu: EnumCoreGuiType
+	SelfView: EnumCoreGuiType
 end
 declare class EnumCreateOutfitFailure extends EnumItem end
 declare class EnumCreateOutfitFailure_INTERNAL extends Enum
@@ -1788,6 +1789,11 @@ declare class EnumModelLevelOfDetail_INTERNAL extends Enum
 	StreamingMesh: EnumModelLevelOfDetail
 	Disabled: EnumModelLevelOfDetail
 end
+declare class EnumModelStreamingMode extends EnumItem end
+declare class EnumModelStreamingMode_INTERNAL extends Enum
+	Default: EnumModelStreamingMode
+	Atomic: EnumModelStreamingMode
+end
 declare class EnumModifierKey extends EnumItem end
 declare class EnumModifierKey_INTERNAL extends Enum
 	Alt: EnumModifierKey
@@ -2344,6 +2350,7 @@ declare class EnumStreamingIntegrityMode_INTERNAL extends Enum
 	Default: EnumStreamingIntegrityMode
 	Disabled: EnumStreamingIntegrityMode
 	MinimumRadiusPause: EnumStreamingIntegrityMode
+	PauseOutsideLoadedArea: EnumStreamingIntegrityMode
 end
 declare class EnumStreamingPauseMode extends EnumItem end
 declare class EnumStreamingPauseMode_INTERNAL extends Enum
@@ -3168,6 +3175,7 @@ type ENUM_LIST = {
 	MeshType: EnumMeshType_INTERNAL,
 	MessageType: EnumMessageType_INTERNAL,
 	ModelLevelOfDetail: EnumModelLevelOfDetail_INTERNAL,
+	ModelStreamingMode: EnumModelStreamingMode_INTERNAL,
 	ModifierKey: EnumModifierKey_INTERNAL,
 	MouseBehavior: EnumMouseBehavior_INTERNAL,
 	MoveState: EnumMoveState_INTERNAL,
@@ -5412,7 +5420,7 @@ declare class DataStoreService extends Instance
 	function GetGlobalDataStore(self): GlobalDataStore
 	function GetOrderedDataStore(self, name: string, scope: string?): OrderedDataStore
 	function GetRequestBudgetForRequestType(self, requestType: EnumDataStoreRequestType): number
-	function ListDataStoresAsync(self, prefix: string?, pageSize: number?): DataStoreListingPages
+	function ListDataStoresAsync(self, prefix: string?, pageSize: number?, cursor: string?): DataStoreListingPages
 end
 
 declare class DataStoreSetOptions extends Instance
@@ -5519,6 +5527,7 @@ declare class DebuggerUIService extends Instance
 	function Pause(self): nil
 	function RemoveScriptLineMarkers(self, debuggerConnectionId: number, allMarkers: boolean): nil
 	function Resume(self): nil
+	function SetCurrentFrameId(self, debuggerThreadId: number, debuggerFrameId: number): nil
 	function SetCurrentThreadId(self, debuggerThreadId: number): nil
 	function SetScriptLineMarker(self, guid: string, debuggerConnectionId: number, line: number, lineMarkerType: boolean): nil
 end
@@ -5764,6 +5773,7 @@ declare class Fire extends Instance
 	SecondaryColor: Color3
 	Size: number
 	TimeScale: number
+	function FastForward(self, numFrames: number): nil
 end
 
 declare class FlagStandService extends Instance
@@ -5841,7 +5851,7 @@ end
 
 declare class DataStore extends GlobalDataStore
 	function GetVersionAsync(self, key: string, version: string): any
-	function ListKeysAsync(self, prefix: string?, pageSize: number?): DataStoreKeyPages
+	function ListKeysAsync(self, prefix: string?, pageSize: number?, cursor: string?): DataStoreKeyPages
 	function ListVersionsAsync(self, key: string, sortDirection: EnumSortDirection?, minDate: number?, maxDate: number?, pageSize: number?): DataStoreVersionPages
 	function RemoveVersionAsync(self, key: string, version: string): nil
 end
@@ -6610,10 +6620,12 @@ declare class HumanoidDescription extends Instance
 end
 
 declare class IKControl extends Instance
+	AlignmentOffset: CFrame
 	ChainRoot: Instance
 	Enabled: boolean
 	EndEffector: Instance
 	Offset: CFrame
+	Pole: Instance
 	Priority: number
 	Target: Instance
 	Type: EnumIKControlType
@@ -6633,6 +6645,7 @@ declare class IXPService extends Instance
 	function GetBrowserTrackerLayerLoadingStatus(self): EnumIXPLoadingStatus
 	function GetBrowserTrackerLayerVariables(self, layerName: string): { [any]: any }
 	function GetBrowserTrackerStatusForLayer(self, layerName: string): EnumIXPLoadingStatus?
+	function GetRegisteredUserLayersToStatus(self): { [any]: any }
 	function GetUserLayerLoadingStatus(self): EnumIXPLoadingStatus
 	function GetUserLayerVariables(self, layerName: string): { [any]: any }
 	function GetUserStatusForLayer(self, layerName: string): EnumIXPLoadingStatus?
@@ -7508,6 +7521,7 @@ end
 
 declare class Model extends PVInstance
 	LevelOfDetail: EnumModelLevelOfDetail
+	ModelStreamingMode: EnumModelStreamingMode
 	PrimaryPart: BasePart?
 	WorldPivot: CFrame
 	World_Pivot_Orientation: Vector3
@@ -7548,6 +7562,7 @@ declare class Workspace extends WorldRoot
 	HumanoidOnlySetCollisionsOnStateChange: EnumHumanoidOnlySetCollisionsOnStateChange
 	InterpolationThrottling: EnumInterpolationThrottlingMode
 	MeshPartHeadsAndAccessories: EnumMeshPartHeadsAndAccessories
+	PersistentLoaded: RBXScriptSignal<Player>
 	PhysicsSteppingMethod: EnumPhysicsSteppingMethod
 	ReplicateInstanceDestroySetting: EnumReplicateInstanceDestroySetting
 	Retargeting: EnumAnimatorRetargetingMode
@@ -7556,7 +7571,6 @@ declare class Workspace extends WorldRoot
 	StreamingEnabled: boolean
 	StreamingIntegrityMode: EnumStreamingIntegrityMode
 	StreamingMinRadius: number
-	StreamingPauseMode: EnumStreamingPauseMode
 	StreamingTargetRadius: number
 	Terrain: Terrain
 	TouchesUseCollisionGroups: boolean
@@ -7614,9 +7628,11 @@ declare class CatalogPages extends Pages
 end
 
 declare class DataStoreKeyPages extends Pages
+	Cursor: string
 end
 
 declare class DataStoreListingPages extends Pages
+	Cursor: string
 end
 
 declare class DataStorePages extends Pages
@@ -8457,6 +8473,7 @@ declare class Smoke extends Instance
 	RiseVelocity: number
 	Size: number
 	TimeScale: number
+	function FastForward(self, numFrames: number): nil
 end
 
 declare class SnippetService extends Instance
@@ -8603,6 +8620,7 @@ declare class Sparkles extends Instance
 	Enabled: boolean
 	SparkleColor: Color3
 	TimeScale: number
+	function FastForward(self, numFrames: number): nil
 end
 
 declare class SpawnerService extends Instance
@@ -8769,6 +8787,7 @@ declare class Studio extends Instance
 	Enable_Temporary_Tabs_In_Explorer: boolean
 	Enable_Type_Hover: boolean
 	Error_Color: Color3
+	File_>_New_creates_a_place_with_Team_Create_off: boolean
 	Find_Selection_Background_Color: Color3
 	Font: QFont
 	Format_On_Paste: boolean
@@ -8998,6 +9017,7 @@ end
 
 declare class TeamCreateService extends Instance
 	ToggleManageCollaborators: RBXScriptSignal<>
+	function SendUnarchiveUniverseAsync(self, universeId: number): nil
 end
 
 declare class Teams extends Instance
@@ -9296,15 +9316,15 @@ declare class UGCValidationService extends Instance
 	function GetTextureSizeSync(self, textureId: string): Vector2
 	function ResetCollisionFidelity(self, meshPart: Instance): nil
 	function SetMeshIdBlocking(self, meshPart: Instance, meshId: string): nil
+	function ValidateCageMeshIntersection(self, innerCageMeshId: string, outerCageMeshId: string, refMeshId: string): any
+	function ValidateCageNonManifoldAndHoles(self, meshId: string): any
+	function ValidateFullBodyCageDeletion(self, meshId: string): boolean
 	function ValidateMeshTriangles(self, meshId: string): boolean
 	function ValidateMeshVertColors(self, meshId: string): boolean
+	function ValidateMisMatchUV(self, innerCageMeshId: string, outerCageMeshId: string): boolean
+	function ValidateOverlappingVertices(self, meshId: string): boolean
 	function ValidateTextureSize(self, textureId: string): boolean
 	function ValidateUVSpace(self, meshId: string): boolean
-	function validateCageMeshIntersection(self, innerCageMeshId: string, outerCageMeshId: string, refMeshId: string): { any }
-	function validateCageNonManifoldAndHoles(self, meshId: string): { any }
-	function validateFullBodyCageDeletion(self, meshId: string): boolean
-	function validateMisMatchUV(self, innerCageMeshId: string, outerCageMeshId: string): boolean
-	function validateOverlappingVertices(self, meshId: string): boolean
 end
 
 declare class UIBase extends Instance
@@ -9573,6 +9593,8 @@ declare class VRService extends Instance
 	function GetTouchpadMode(self, pad: EnumVRTouchpad): EnumVRTouchpadMode
 	function GetUserCFrame(self, type: EnumUserCFrame): CFrame
 	function GetUserCFrameEnabled(self, type: EnumUserCFrame): boolean
+	function IsMaquettes(self): boolean
+	function IsVRAppBuild(self): boolean
 	function RecenterUserHeadCFrame(self): nil
 	function RequestNavigation(self, cframe: CFrame, inputUserCFrame: EnumUserCFrame): nil
 	function SetTouchpadMode(self, pad: EnumVRTouchpad, mode: EnumVRTouchpadMode): nil
@@ -10205,6 +10227,9 @@ declare CatalogSearchParams: {
 
 declare Font: {
 	new: ((family: string, weight: EnumFontWeight?, style: EnumFontStyle?) -> Font),
+	fromEnum: ((font: EnumFont) -> Font),
+	fromName: ((name: string, weight: EnumFontWeight?, style: EnumFontStyle?) -> Font),
+	fromId: ((id: number, weight: EnumFontWeight?, style: EnumFontStyle?) -> Font),
 }
 
 


### PR DESCRIPTION
Only allow valid identifiers as properties (previously we "escaped" them, but they were incorrect and provide no benefit)