### PR TITLE
Fix inlay hints not showing when `hover.strictDatamodelTypes` is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed inlay hints not showing for variable types when `hover.strictDataModelTypes` is disabled
+
 ## [1.11.2] - 2022-10-08
 
 ### Changed

--- a/src/operations/InlayHints.cpp
+++ b/src/operations/InlayHints.cpp
@@ -247,7 +247,8 @@ lsp::InlayHintResult WorkspaceFolder::inlayHint(const lsp::InlayHintParams& para
     frontend.check(moduleName, Luau::FrontendOptions{/* retainFullTypeGraphs: */ true, /* forAutocomplete: */ config.hover.strictDatamodelTypes});
 
     auto sourceModule = frontend.getSourceModule(moduleName);
-    auto module = frontend.moduleResolverForAutocomplete.getModule(moduleName);
+    auto module = config.hover.strictDatamodelTypes ? frontend.moduleResolverForAutocomplete.getModule(moduleName)
+                                                    : frontend.moduleResolver.getModule(moduleName);
     if (!sourceModule || !module)
         return {};
 


### PR DESCRIPTION
Fixes #184 