### PR TITLE
Fix workspace diagnostics type errors creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Fixed inlay hints not showing for variable types when `hover.strictDataModelTypes` is disabled
+- Fixed Internal Errors for workspace diagnostics when a type error was being displayed backed by the incorrect text document causing string errors
 
 ## [1.11.2] - 2022-10-08
 

--- a/src/operations/Diagnostics.cpp
+++ b/src/operations/Diagnostics.cpp
@@ -128,9 +128,9 @@ lsp::WorkspaceDiagnosticReport WorkspaceFolder::workspaceDiagnostics(const lsp::
         // Only report errors for the current file
         for (auto& error : cr.errors)
         {
-            auto diagnostic = createTypeErrorDiagnostic(error, &fileResolver, document);
             if (error.moduleName == moduleName)
             {
+                auto diagnostic = createTypeErrorDiagnostic(error, &fileResolver, document);
                 documentReport.items.emplace_back(diagnostic);
             }
         }


### PR DESCRIPTION
We accidently were creating diagnostics before applying the check to see if the error applies to the current text document. This meant we were using the current text document to create type errors that weren't part of this document, causing string errors due to UTF-8/16 conversions.