### PR TITLE
Add ignore glob support for analyze

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Provide autocomplete for class names in `Instance:IsA("ClassName")` and errors when ClassName is unknown
 - Provide autocomplete for properties in `Instance:GetPropertyChangedSignal("Property")` and errors when Property is unknown
 - Added support for moonwave-style documentation comments! Currently only supports comments attached to functions directly. See https://eryn.io/moonwave for how to write doc comments
+- Added command line flag `--ignore=GLOB` to `luau-lsp analyze` allowing you to provide glob patterns to ignore diagnostics, similar to `luau-lsp.ignoreGlobs`. Repeat the flag multiple times for multiple patterns
 
 ### Changed
 

--- a/src/AnalyzeCli.cpp
+++ b/src/AnalyzeCli.cpp
@@ -102,7 +102,7 @@ static bool analyzeFile(Luau::Frontend& frontend, const char* name, ReportFormat
         return false;
     }
 
-    for (auto& error : cr.errors) 
+    for (auto& error : cr.errors)
         reportError(frontend, format, error, ignoreGlobPatterns);
 
     Luau::LintResult lr = frontend.lint(name);
@@ -157,8 +157,8 @@ int startAnalyze(int argc, char** argv)
             // Backwards compatibility
             else if (strncmp(argv[i], "--defs=", 7) == 0)
                 definitionsPaths.push_back(std::string(argv[i] + 7));
-            else if (strncmp(argv[i], "--ignoreGlobs=", 14) == 0)
-                ignoreGlobPatterns.push_back(std::string(argv[i] + 14));
+            else if (strncmp(argv[i], "--ignore=", 9) == 0)
+                ignoreGlobPatterns.push_back(std::string(argv[i] + 9));
         }
         else
         {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -46,6 +46,7 @@ static void displayHelp(const char* argv0)
     printf("  --timetrace: record compiler time tracing information into trace.json\n");
     printf("  --sourcemap=PATH: path to a Rojo-style sourcemap\n");
     printf("  --definitions=PATH: path to definition file for global types\n");
+    printf("  --ignoreGlobs=GLOB: path(s) to ignore error outputs\n");
     printf("LSP options:\n");
     printf("  --definitions=PATH: path to definition file for global types\n");
     printf("  --docs=PATH: path to documentation file to power Intellisense\n");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -46,7 +46,7 @@ static void displayHelp(const char* argv0)
     printf("  --timetrace: record compiler time tracing information into trace.json\n");
     printf("  --sourcemap=PATH: path to a Rojo-style sourcemap\n");
     printf("  --definitions=PATH: path to definition file for global types\n");
-    printf("  --ignoreGlobs=GLOB: path(s) to ignore error outputs\n");
+    printf("  --ignore=GLOB: glob pattern to ignore error outputs\n");
     printf("LSP options:\n");
     printf("  --definitions=PATH: path to definition file for global types\n");
     printf("  --docs=PATH: path to documentation file to power Intellisense\n");


### PR DESCRIPTION
Adds support for ignoring errors from certain files using the glob pattern. The option is prefixed with; `--ignoreGlobs=`, adding multiple options with the same prefix should also work. 

This MR addresses [#176 ](https://github.com/JohnnyMorganz/luau-lsp/issues/176)

Note: I'm fairly "new" to C++ had some university experience with it, but I'm certainly not a pro. With that in mind, please criticize anything that I could fix/improve!

