### PR TITLE
Type corrections for Players, Player, and GuiService

### DIFF
--- a/scripts/dumpRobloxTypes.py
+++ b/scripts/dumpRobloxTypes.py
@@ -183,6 +183,9 @@ IGNORED_MEMBERS = {
     "RunService": [
         "BindToRenderStep",
     ],
+    "GuiService": [
+        "SelectedObject"
+    ]
 }
 
 # Extra members to add in to classes, commonly used to add in metamethods, and add corrections
@@ -362,6 +365,9 @@ EXTRA_MEMBERS = {
     "RunService": [
         "function BindToRenderStep(self, name: string, priority: number, func: ((delta: number) -> ())): ()",
     ],
+    "GuiService": [
+        "SelectedObject: GuiObject?"
+    ]
 }
 
 # Hardcoded types

--- a/scripts/dumpRobloxTypes.py
+++ b/scripts/dumpRobloxTypes.py
@@ -104,7 +104,11 @@ IGNORED_MEMBERS = {
         "Invoke",
         "OnInvoke",
     ],
-    "Players": ["GetPlayers"],
+    "Players": [
+        "PlayerChatted",
+        "GetPlayerByUserId",
+        "GetPlayerFromCharacter",
+    ],
     "ContextActionService": ["BindAction", "BindActionAtPriority"],
     "PluginToolbar": [
         "CreateButton",
@@ -164,7 +168,10 @@ IGNORED_MEMBERS = {
         "WalkToPart",
         "GetAccessories",
     ],
-    "Player": ["Character"],
+    "Player": [
+        "Character",
+        "Chatted",
+     ],
     "InstanceAdornment": ["Adornee"],
     "BasePart": [
         "GetConnectedParts",
@@ -277,7 +284,11 @@ EXTRA_MEMBERS = {
         "function Invoke(self, ...: any): ...any",
         "OnInvoke: (...any) -> ...any",
     ],
-    "Players": ["function GetPlayers(self): { Player }"],
+    "Players": [
+        "PlayerChatted: RBXScriptSignal<EnumPlayerChatType, Player, string, Player?>",
+        "function GetPlayerByUserId(self, userId: number): Player?",
+        "function GetPlayerFromCharacter(self, character: Model): Player?",
+    ],
     "ContextActionService": [
         "function BindAction(self, actionName: string, functionToBind: (actionName: string, inputState: EnumUserInputState, inputObject: InputObject) -> EnumContextActionResult?, createTouchButton: boolean, ...: EnumUserInputType | EnumKeyCode): ()",
         "function BindActionAtPriority(self, actionName: string, functionToBind: (actionName: string, inputState: EnumUserInputState, inputObject: InputObject) -> EnumContextActionResult?, createTouchButton: boolean, priorityLevel: number, ...: EnumUserInputType | EnumKeyCode): ()",
@@ -344,7 +355,10 @@ EXTRA_MEMBERS = {
         "WalkToPart: BasePart?",
         "function GetAccessories(self): { Accessory }",
     ],
-    "Player": ["Character: Model?"],
+    "Player": [
+        "Character: Model?",
+        "Chatted: RBXScriptSignal<string, Player?>",
+    ],
     "InstanceAdornment": ["Adornee: Instance?"],
     "BasePart": [
         "function GetConnectedParts(self, recursive: boolean?): { BasePart }",

--- a/scripts/globalTypes.d.lua
+++ b/scripts/globalTypes.d.lua
@@ -6433,7 +6433,7 @@ declare class GuiService extends Instance
 	Open9SliceEditor: RBXScriptSignal<Instance>
 	SafeZoneOffsetsChanged: RBXScriptSignal<>
 	SelectedCoreObject: GuiObject
-	SelectedObject: GuiObject
+	SelectedObject: GuiObject?
 	SendCoreUiNotification: (title: string, text: string) -> nil
 	ShowLeaveConfirmation: RBXScriptSignal<>
 	SpecialKeyPressed: RBXScriptSignal<EnumSpecialKey, string>

--- a/scripts/globalTypes.d.lua
+++ b/scripts/globalTypes.d.lua
@@ -7876,7 +7876,7 @@ declare class Player extends Instance
 	CharacterAppearanceLoaded: RBXScriptSignal<Model>
 	CharacterRemoving: RBXScriptSignal<Model>
 	ChatMode: EnumChatMode
-	Chatted: RBXScriptSignal<string, Player>
+	Chatted: RBXScriptSignal<string, Player?>
 	DevCameraOcclusionMode: EnumDevCameraOcclusionMode
 	DevComputerCameraMode: EnumDevComputerCameraMovementMode
 	DevComputerMovementMode: EnumDevComputerMovementMode
@@ -7982,7 +7982,7 @@ declare class Players extends Instance
 	MaxPlayers: number
 	MaxPlayersInternal: number
 	PlayerAdded: RBXScriptSignal<Player>
-	PlayerChatted: RBXScriptSignal<EnumPlayerChatType, Player, string, Player>
+	PlayerChatted: RBXScriptSignal<EnumPlayerChatType, Player, string, Player?>
 	PlayerConnecting: RBXScriptSignal<Player>
 	PlayerDisconnecting: RBXScriptSignal<Player>
 	PlayerMembershipChanged: RBXScriptSignal<Player>
@@ -8000,8 +8000,8 @@ declare class Players extends Instance
 	function GetHumanoidDescriptionFromOutfitId(self, outfitId: number): HumanoidDescription
 	function GetHumanoidDescriptionFromUserId(self, userId: number): HumanoidDescription
 	function GetNameFromUserIdAsync(self, userId: number): string
-	function GetPlayerByUserId(self, userId: number): Player
-	function GetPlayerFromCharacter(self, character: Model): Player
+	function GetPlayerByUserId(self, userId: number): Player?
+	function GetPlayerFromCharacter(self, character: Model): Player?
 	function GetPlayers(self): { Player }
 	function GetUserIdFromNameAsync(self, userName: string): number
 	function GetUserThumbnailAsync(self, userId: number, thumbnailType: EnumThumbnailType, thumbnailSize: EnumThumbnailSize): (string, boolean)


### PR DESCRIPTION
`GetPlayerByUserId` and `GetPlayerFromCharacter` may return `nil` if player wasn't found
the second Player parameter in chatted events will be nil if the chat wasn't a whisper.
`GuiService.SelectedObject` may be nil if nothing is selected

Removed type correction for `Player:GetPlayers()` as it's no longer needed