### PR TITLE
Add FloatCurveKey and RotationCurveKey type

### DIFF
--- a/scripts/dumpRobloxTypes.py
+++ b/scripts/dumpRobloxTypes.py
@@ -393,8 +393,6 @@ type ProtectedString = string
 type BinaryString = string
 type QDir = string
 type QFont = string
-type FloatCurveKey = any
-type RotationCurveKey = any
 type Instance = any
 
 declare class Enum
@@ -483,6 +481,22 @@ type HumanoidDescriptionAccessory = {
     IsLayered: boolean,
     Order: number?,
     Puffiness: number?,
+}
+
+type FloatCurveKey = {
+    Interpolation: EnumKeyInterpolationMode,
+    Time: number,
+    Value: number,
+    RightTangent: number?,
+    LeftTangent: number?
+}
+
+type RotationCurveKey = {
+    Interpolation: EnumKeyInterpolationMode,
+    Time: number,
+    Value: CFrame,
+    RightTangent: number?,
+    LeftTangent: number?
 }
 """
 


### PR DESCRIPTION
I noticed there was no type of ``FloatCurveKey`` (https://robloxapi.github.io/ref/type/FloatCurveKey.html) and ``RotationCurveKey`` (https://robloxapi.github.io/ref/type/RotationCurveKey.html), so I've made a PR to add the types for those two.

Hopefully I didn't make a mistake here while editing the file