### PR TITLE
Fix types for datastores

### DIFF
--- a/scripts/dumpRobloxTypes.py
+++ b/scripts/dumpRobloxTypes.py
@@ -193,6 +193,20 @@ IGNORED_MEMBERS = {
     ],
     "GuiService": [
         "SelectedObject"
+    ],
+    "GlobalDataStore": [
+        "GetAsync",
+        "IncrementAsync",
+        "RemoveAsync",
+        "SetAsync",
+        "UpdateAsync",
+    ],
+    "OrderedDataStore": [
+        "GetAsync",
+        "GetSortedAsync",
+        "RemoveAsync",
+        "SetAsync",
+        "UpdateAsync",
     ]
 }
 
@@ -382,6 +396,29 @@ EXTRA_MEMBERS = {
     ],
     "GuiService": [
         "SelectedObject: GuiObject?"
+    ],
+    "GlobalDataStore": [
+        # GetAsync we received from upstream didn't have a second return value of DataStoreKeyInfo
+        "function GetAsync(self, key: string): (any, DataStoreKeyInfo)",
+        # IncrementAsync didn't have a second return value of DataStoreKeyInfo, and the first return value is always a number
+        "function IncrementAsync(self, key: string, delta: number?, userIds: { number }?, options: DataStoreIncrementOptions?): (number, DataStoreKeyInfo)",
+        # RemoveAsync didn't have a second return value of DataStoreKeyInfo
+        "function RemoveAsync(self, key: string): (any, DataStoreKeyInfo)",
+        # SetAsync returns the version as a string, upstream says it's any
+        "function SetAsync(self, key: string, value: any, userIds: { number }?, options: DataStoreSetOptions?): string",
+        # UpdateAsync didn't have a second return value of DataStoreKeyInfo
+        # and the second parameter passed to the transform function is always a DataStoreKeyInfo
+        # and the return of the transform function was incorrect
+        "function UpdateAsync(self, key: string, transformFunction: ((any, DataStoreKeyInfo) -> (any, { number }?, {}?))): (any, DataStoreKeyInfo)",
+    ],
+    # Trying to set the value in a OrderedDataStore to anything other than a number will error,
+    # So we override the method's types to use numbers instead of any
+    "OrderedDataStore": [
+        "function GetAsync(self, key: string): (number?, DataStoreKeyInfo)",
+        "function GetSortedAsync(self, ascending: boolean, pageSize: number, minValue: number, maxValue: number): DataStorePages",
+        "function RemoveAsync(self, key: string): (number?, DataStoreKeyInfo)",
+        "function SetAsync(self, key: string, value: number, userIds: { number }?, options: DataStoreSetOptions?): string",
+        "function UpdateAsync(self, key: string, transformFunction: ((number?, DataStoreKeyInfo) -> (number, { number }?, {}?))): (number?, DataStoreKeyInfo)",
     ]
 }
 

--- a/scripts/globalTypes.d.lua
+++ b/scripts/globalTypes.d.lua
@@ -5926,11 +5926,11 @@ declare class GetTextBoundsParams extends Instance
 end
 
 declare class GlobalDataStore extends Instance
-	function GetAsync(self, key: string): any
-	function IncrementAsync(self, key: string, delta: number?, userIds: { number }?, options: DataStoreIncrementOptions?): any
-	function RemoveAsync(self, key: string): any
-	function SetAsync(self, key: string, value: any, userIds: { number }?, options: DataStoreSetOptions?): any
-	function UpdateAsync(self, key: string, transformFunction: ((...any) -> ...any)): any
+	function GetAsync(self, key: string): (any, DataStoreKeyInfo)
+	function IncrementAsync(self, key: string, delta: number?, userIds: { number }?, options: DataStoreIncrementOptions?): (number, DataStoreKeyInfo)
+	function RemoveAsync(self, key: string): (any, DataStoreKeyInfo)
+	function SetAsync(self, key: string, value: any, userIds: { number }?, options: DataStoreSetOptions?): string
+	function UpdateAsync(self, key: string, transformFunction: ((any, DataStoreKeyInfo) -> (any, { number }?, {}?))): (any, DataStoreKeyInfo)
 end
 
 declare class DataStore extends GlobalDataStore
@@ -5941,7 +5941,11 @@ declare class DataStore extends GlobalDataStore
 end
 
 declare class OrderedDataStore extends GlobalDataStore
-	function GetSortedAsync(self, ascending: boolean, pagesize: number, minValue: any, maxValue: any): DataStorePages
+	function GetAsync(self, key: string): (number?, DataStoreKeyInfo)
+	function GetSortedAsync(self, ascending: boolean, pageSize: number, minValue: number, maxValue: number): DataStorePages
+	function RemoveAsync(self, key: string): (number?, DataStoreKeyInfo)
+	function SetAsync(self, key: string, value: number, userIds: { number }?, options: DataStoreSetOptions?): string
+	function UpdateAsync(self, key: string, transformFunction: ((number?, DataStoreKeyInfo) -> (number, { number }?, {}?))): (number?, DataStoreKeyInfo)
 end
 
 declare class GoogleAnalyticsConfiguration extends Instance


### PR DESCRIPTION
Fixed none of the functions types returning the second `DataStoreKeyInfo` type.
Made `OrderedDataStore` only be able to use numbers as the value, since passing any other type to the function will error with `103: string is not allowed in data stores.`
`SetAsync` returns a `string` that stores the version's id
Fixed the `transformFunction`'s type in `UpdateAsync`