### PR TITLE
Fix incorrect Instance ty ptr causing failed unification and `never` types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Luau analyze now exits with code 0 if there are no reported errors (all errors are ignored)
 - `require(instance:FindFirstChild("Testing", true))` will no longer resolve as an immediate child of instance due to the recursive argument
+- Fixed a bug where internally the wrong pointer to an Instance type was being used for DM nodes which manifested into failed unification and `never` types
 
 ## [1.14.3] - 2022-12-10
 

--- a/src/LuauExt.cpp
+++ b/src/LuauExt.cpp
@@ -59,8 +59,9 @@ Luau::TypeId getSourcemapType(
     const Luau::TypeChecker& typeChecker, Luau::TypeArena& arena, const Luau::ScopePtr& globalScope, const SourceNodePtr& node)
 {
     // Gets the type corresponding to the sourcemap node if it exists
-    if (node->ty)
-        return node->ty;
+    // Make sure to use the correct ty version (base typeChecker vs autocomplete typeChecker)
+    if (node->tys.find(&typeChecker) != node->tys.end())
+        return node->tys.at(&typeChecker);
 
     Luau::LazyType ltv;
     ltv.thunk = [&typeChecker, &arena, globalScope, node]()
@@ -151,7 +152,7 @@ Luau::TypeId getSourcemapType(
     };
 
     auto ty = arena.addType(std::move(ltv));
-    node->ty = ty;
+    node->tys.insert_or_assign(&typeChecker, ty);
 
     return ty;
 }

--- a/src/include/LSP/Sourcemap.hpp
+++ b/src/include/LSP/Sourcemap.hpp
@@ -16,8 +16,10 @@ struct SourceNode
     std::string className;
     std::vector<std::filesystem::path> filePaths;
     std::vector<SourceNodePtr> children;
-    std::string virtualPath;   // NB: NOT POPULATED BY SOURCEMAP, must be written to manually
-    Luau::TypeId ty = nullptr; // NB: NOT POPULATED BY SOURCEMAP, created manually. Can be null!
+    std::string virtualPath; // NB: NOT POPULATED BY SOURCEMAP, must be written to manually
+    // The corresponding TypeId for this sourcemap node
+    // A different TypeId is created for each type checker (frontend.typeChecker and frontend.typeCheckerForAutocomplete)
+    std::unordered_map<Luau::TypeChecker const*, Luau::TypeId> tys; // NB: NOT POPULATED BY SOURCEMAP, created manually. Can be null!
 
     bool isScript();
     std::optional<std::filesystem::path> getScriptFilePath();


### PR DESCRIPTION
Fixes #254 

The problem was that `getSourcemapType` returns a cached type if it already exists, but the cached type was created for `frontend.typeChecker`, not `frontend.typeCheckerForAutocomplete`. The `Instance` global ty is different for the two type checkers.
This meant that DM types in autocomplete mode were subtypes of the base type checker global Instance ty, not the autocomplete version, so unification would fail.

To fix this, we create a different ty for general use and autocomplete mode