### PR TITLE
Support more documentation comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,31 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Added syntax highlighting support for interpolated strings
 - Added color viewers for Color3.new/fromRGB/fromHSV/fromHex
+- Support documentation comments on variables:
+
+```lua
+--- documentation comment
+local x = "string"
+
+--- another doc comment
+local y = function()
+end
+```
+
+- Support documentation comments on table properties, such as the following:
+
+```lua
+local tbl = {
+    --- This is some special information
+    data = "hello",
+    --- This is a doc comment
+    values = function()
+    end,
+}
+
+local x = tbl.values -- Should give "This is a doc comment"
+local y = tbl.data -- Should give "This is some special information"
+```
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ local y = tbl.data -- Should give "This is some special information"
 
 - Sync to upstream Luau 0.558
 - All Luau FFlags are no longer enabled by default. This can be re-enabled by configuring `luau-lsp.fflags.enableByDefault`. It is recommended to keep `luau-lsp.fflags.sync` enabled so that FFlags sync with upstream Luau
+- Allow variable number of `=` sign for multiline doc comments, so `--[[` and `--[===[` etc. are valid openers
 
 ### Fixed
 

--- a/src/DocumentationParser.cpp
+++ b/src/DocumentationParser.cpp
@@ -279,6 +279,22 @@ struct AttachCommentsVisitor : public Luau::AstVisitor
         return result;
     }
 
+    bool visit(Luau::AstExprTable* tbl) override
+    {
+        for (Luau::AstExprTable::Item item : tbl->items)
+        {
+            if (item.value->location.begin >= pos)
+                continue;
+            if (item.value->location.begin > closestPreviousNode)
+                closestPreviousNode = item.value->location.begin;
+            item.value->visit(this);
+            if (item.value->location.end <= pos && item.value->location.end > closestPreviousNode)
+                closestPreviousNode = item.value->location.end;
+        }
+
+        return false;
+    }
+
     bool visit(Luau::AstStatBlock* block) override
     {
         for (Luau::AstStat* stat : block->body)

--- a/tests/Documentation.test.cpp
+++ b/tests/Documentation.test.cpp
@@ -49,6 +49,55 @@ TEST_CASE_FIXTURE(Fixture, "attach_comments_to_function_2")
     CHECK_EQ(1, comments.size());
 }
 
+TEST_CASE_FIXTURE(Fixture, "attach_comments_to_table_property_function_1")
+{
+    auto result = check(R"(
+        local tbl = {
+            --- This is a function inside of a table
+            values = function()
+            end,
+        }
+
+        local x = tbl.values
+    )");
+
+    REQUIRE_EQ(0, result.errors.size());
+
+    auto ty = requireType("x");
+    auto ftv = Luau::get<Luau::FunctionType>(ty);
+    REQUIRE(ftv);
+    REQUIRE(ftv->definition);
+
+    auto comments = getCommentLocations(getMainSourceModule(), ftv->definition->definitionLocation);
+    CHECK_EQ(1, comments.size());
+}
+
+TEST_CASE_FIXTURE(Fixture, "attach_comments_to_table_property_function_2")
+{
+    auto result = check(R"(
+        local tbl = {
+            --- This is a function inside of a table
+            values = function()
+            end,
+            --- This is another function, and there should only be one comment connected to it
+            map = function()
+            end,
+        }
+
+        local x = tbl.map
+    )");
+
+    REQUIRE_EQ(0, result.errors.size());
+
+    auto ty = requireType("x");
+    auto ftv = Luau::get<Luau::FunctionType>(ty);
+    REQUIRE(ftv);
+    REQUIRE(ftv->definition);
+
+    auto comments = getCommentLocations(getMainSourceModule(), ftv->definition->definitionLocation);
+    CHECK_EQ(1, comments.size());
+}
+
 TEST_CASE_FIXTURE(Fixture, "print_comments")
 {
     auto result = check(R"(

--- a/tests/Documentation.test.cpp
+++ b/tests/Documentation.test.cpp
@@ -257,6 +257,65 @@ TEST_CASE_FIXTURE(Fixture, "print_multiline_comment")
     CHECK(comments[3] == "@return number -- Returns `x` with 5 added to it");
 }
 
+TEST_CASE_FIXTURE(Fixture, "print_multiline_comment_no_equals")
+{
+    auto result = check(R"(
+        --[[
+            Adds 5 to the input number
+
+            @param x number -- The number to add 5 to
+            @return number -- Returns `x` with 5 added to it
+        ]]
+        function add5(x: number)
+            return x + 5
+        end
+    )");
+
+    REQUIRE_EQ(0, result.errors.size());
+
+    auto ty = requireType("add5");
+    auto ftv = Luau::get<Luau::FunctionType>(ty);
+    REQUIRE(ftv);
+    REQUIRE(ftv->definition);
+
+    auto comments = getComments(ftv->definition->definitionLocation);
+    REQUIRE_EQ(4, comments.size());
+    CHECK(comments[0] == "Adds 5 to the input number");
+    CHECK(comments[1] == "");
+    CHECK(comments[2] == "@param x number -- The number to add 5 to");
+    CHECK(comments[3] == "@return number -- Returns `x` with 5 added to it");
+}
+
+
+TEST_CASE_FIXTURE(Fixture, "print_multiline_comment_variable_equals")
+{
+    auto result = check(R"(
+        --[====[
+            Adds 5 to the input number
+
+            @param x number -- The number to add 5 to
+            @return number -- Returns `x` with 5 added to it
+        ]====]
+        function add5(x: number)
+            return x + 5
+        end
+    )");
+
+    REQUIRE_EQ(0, result.errors.size());
+
+    auto ty = requireType("add5");
+    auto ftv = Luau::get<Luau::FunctionType>(ty);
+    REQUIRE(ftv);
+    REQUIRE(ftv->definition);
+
+    auto comments = getComments(ftv->definition->definitionLocation);
+    REQUIRE_EQ(4, comments.size());
+    CHECK(comments[0] == "Adds 5 to the input number");
+    CHECK(comments[1] == "");
+    CHECK(comments[2] == "@param x number -- The number to add 5 to");
+    CHECK(comments[3] == "@return number -- Returns `x` with 5 added to it");
+}
+
 TEST_CASE_FIXTURE(Fixture, "trim_common_leading_whitespace")
 {
     auto result = check(R"(


### PR DESCRIPTION
This PR adds in support for documentation comments attached to local variables, functions defined through `local var = function()` syntax, and table properties:

```lua
--- documentation comment
local x = "string"

--- another doc comment
local y = function()
end

local tbl = {
    --- This is some special information
    data = "hello",
    --- This is a doc comment
    values = function()
    end,
}

local x = tbl.values -- Should give "This is a doc comment"
local y = tbl.data -- Should give "This is some special information"
```

Closes #247 

Also support a variable number of `=` signs used to denote a multiline documentation comment (Closes #236)
```lua
--[[
    Adds 5 to the input number

    @param x number -- The number to add 5 to
    @return number -- Returns `x` with 5 added to it
]]
function add5(x: number)
    return x + 5
end
```