### PR TITLE
Support relative-to-file string requires

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ type Contents = {
 ```
 
 - Include documentation comments on functions and tables in autocompletion
+- Added configuration option `luau-lsp.require.mode` to configure how string requires are resolved. It can either be `relativeToWorkspaceRoot` (default) or `relativeToFile`
 
 ### Changed
 

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -311,6 +311,19 @@
           "type": "number",
           "default": 3667,
           "scope": "window"
+        },
+        "luau-lsp.require.mode": {
+          "markdownDescription": "How string requires should be interpreted",
+          "type": "string",
+          "default": "relativeToWorkspaceRoot",
+          "enum": [
+            "relativeToWorkspaceRoot",
+            "relativeToFile"
+          ],
+          "enumDescriptions": [
+            "String requires are interpreted relative to the root of the workspace",
+            "String requires are interpreted relative to the current file"
+          ]
         }
       }
     }

--- a/src/include/LSP/ClientConfiguration.hpp
+++ b/src/include/LSP/ClientConfiguration.hpp
@@ -100,6 +100,23 @@ struct ClientSignatureHelpConfiguration
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(ClientSignatureHelpConfiguration, enabled);
 
+enum struct RequireModeConfig
+{
+    RelativeToWorkspaceRoot,
+    RelativeToFile,
+};
+NLOHMANN_JSON_SERIALIZE_ENUM(RequireModeConfig, {
+                                                    {RequireModeConfig::RelativeToWorkspaceRoot, "relativeToWorkspaceRoot"},
+                                                    {RequireModeConfig::RelativeToFile, "relativeToFile"},
+                                                });
+
+struct ClientRequireConfiguration
+{
+    RequireModeConfig mode = RequireModeConfig::RelativeToWorkspaceRoot;
+};
+
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(ClientRequireConfiguration, mode);
+
 
 // These are the passed configuration options by the client, prefixed with `luau-lsp.`
 // Here we also define the default settings
@@ -115,6 +132,7 @@ struct ClientConfiguration
     ClientHoverConfiguration hover{};
     ClientCompletionConfiguration completion{};
     ClientSignatureHelpConfiguration signatureHelp{};
+    ClientRequireConfiguration require{};
 };
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
-    ClientConfiguration, autocompleteEnd, ignoreGlobs, sourcemap, diagnostics, types, inlayHints, hover, completion, signatureHelp);
+    ClientConfiguration, autocompleteEnd, ignoreGlobs, sourcemap, diagnostics, types, inlayHints, hover, completion, signatureHelp, require);

--- a/src/include/LSP/Workspace.hpp
+++ b/src/include/LSP/Workspace.hpp
@@ -38,6 +38,7 @@ public:
         , fileResolver(WorkspaceFileResolver())
         , frontend(Luau::Frontend(&fileResolver, &fileResolver, {true}))
     {
+        fileResolver.client = client;
         fileResolver.rootUri = uri;
     }
 

--- a/src/include/LSP/WorkspaceFileResolver.hpp
+++ b/src/include/LSP/WorkspaceFileResolver.hpp
@@ -5,6 +5,7 @@
 #include "Luau/FileResolver.h"
 #include "Luau/StringUtils.h"
 #include "Luau/Config.h"
+#include "LSP/Client.hpp"
 #include "LSP/Uri.hpp"
 #include "LSP/Sourcemap.hpp"
 #include "LSP/PluginDataModel.hpp"
@@ -15,6 +16,7 @@ struct WorkspaceFileResolver
     , Luau::ConfigResolver
 {
     Luau::Config defaultConfig;
+    std::shared_ptr<Client> client;
 
     // The root source node from a parsed Rojo source map
     Uri rootUri;
@@ -43,6 +45,8 @@ struct WorkspaceFileResolver
     {
         return name == "game" || name == "ProjectRoot" || Luau::startsWith(name, "game/") || Luau::startsWith(name, "ProjectRoot/");
     }
+
+    std::filesystem::path WorkspaceFileResolver::getRequireBasePath(std::optional<Luau::ModuleName> fileModuleName) const;
 
     // Return the corresponding module name from a file Uri
     // We first try and find a virtual file path which matches it, and return that. Otherwise, we use the file system path

--- a/src/include/LSP/WorkspaceFileResolver.hpp
+++ b/src/include/LSP/WorkspaceFileResolver.hpp
@@ -46,7 +46,7 @@ struct WorkspaceFileResolver
         return name == "game" || name == "ProjectRoot" || Luau::startsWith(name, "game/") || Luau::startsWith(name, "ProjectRoot/");
     }
 
-    std::filesystem::path WorkspaceFileResolver::getRequireBasePath(std::optional<Luau::ModuleName> fileModuleName) const;
+    std::filesystem::path getRequireBasePath(std::optional<Luau::ModuleName> fileModuleName) const;
 
     // Return the corresponding module name from a file Uri
     // We first try and find a virtual file path which matches it, and return that. Otherwise, we use the file system path

--- a/src/operations/Completion.cpp
+++ b/src/operations/Completion.cpp
@@ -381,7 +381,7 @@ std::vector<lsp::CompletionItem> WorkspaceFolder::completion(const lsp::Completi
                 try
                 {
                     auto contentsString = contents.value();
-                    auto currentDirectory = rootUri.fsPath().append(contentsString);
+                    auto currentDirectory = fileResolver.getRequireBasePath(moduleName).append(contentsString);
 
                     Luau::AutocompleteEntryMap result;
                     for (const auto& dir_entry : std::filesystem::directory_iterator(currentDirectory))


### PR DESCRIPTION
Adds a new config option `luau-lsp.require.mode`:
- `relativeToWorkspaceRoot` (default)
- `relativeToFile`

Closes #272 