### PR TITLE
Add Vector3:Angle to type def

### DIFF
--- a/scripts/dumpRobloxTypes.py
+++ b/scripts/dumpRobloxTypes.py
@@ -212,6 +212,7 @@ IGNORED_MEMBERS = {
 # Extra members to add in to classes, commonly used to add in metamethods, and add corrections
 EXTRA_MEMBERS = {
     "Vector3": [
+        "function Angle(self, other: Vector3, axis: Vector3?): number",
         "function __add(self, other: Vector3): Vector3",
         "function __sub(self, other: Vector3): Vector3",
         "function __mul(self, other: Vector3 | number): Vector3",

--- a/scripts/globalTypes.d.lua
+++ b/scripts/globalTypes.d.lua
@@ -3592,6 +3592,7 @@ declare class Vector3
 	X: number
 	Y: number
 	Z: number
+	function Angle(self, other: Vector3, axis: Vector3?): number
 	function Cross(self, other: Vector3): Vector3
 	function Dot(self, other: Vector3): number
 	function FuzzyEq(self, other: Vector3, epsilon: number): boolean


### PR DESCRIPTION
Adds the missing Vector3:Angle function to the type definitions.