### PR TITLE
Fix Handles/ArcHandles.Adornee type

### DIFF
--- a/scripts/dumpRobloxTypes.py
+++ b/scripts/dumpRobloxTypes.py
@@ -195,7 +195,8 @@ IGNORED_MEMBERS = {
         "UpdateAsync",
     ],
     "Highlight": ["Adornee"],
-    "Handles": ["Adornee"]
+    "Handles": ["Adornee"],
+    "ArcHandles": ["Adornee"]
 }
 
 # Extra members to add in to classes, commonly used to add in metamethods, and add corrections
@@ -409,7 +410,8 @@ EXTRA_MEMBERS = {
     ],
     # The Adornee property is optional
     "Highlight": ["Adornee: BasePart?"],
-    "Handles": ["Adornee: BasePart?"]
+    "Handles": ["Adornee: BasePart?"],
+    "ArcHandles": ["Adornee: BasePart?"]
 }
 
 # Hardcoded types

--- a/scripts/dumpRobloxTypes.py
+++ b/scripts/dumpRobloxTypes.py
@@ -195,6 +195,7 @@ IGNORED_MEMBERS = {
         "UpdateAsync",
     ],
     "Highlight": ["Adornee"],
+    "Handles": ["Adornee"]
 }
 
 # Extra members to add in to classes, commonly used to add in metamethods, and add corrections
@@ -407,7 +408,8 @@ EXTRA_MEMBERS = {
         "function UpdateAsync(self, key: string, transformFunction: ((number?, DataStoreKeyInfo) -> (number, { number }?, {}?))): (number?, DataStoreKeyInfo)",
     ],
     # The Adornee property is optional
-    "Highlight": ["Adornee: Instance?"],
+    "Highlight": ["Adornee: BasePart?"],
+    "Handles": ["Adornee: BasePart?"]
 }
 
 # Hardcoded types

--- a/scripts/dumpRobloxTypes.py
+++ b/scripts/dumpRobloxTypes.py
@@ -195,8 +195,7 @@ IGNORED_MEMBERS = {
         "UpdateAsync",
     ],
     "Highlight": ["Adornee"],
-    "Handles": ["Adornee"],
-    "ArcHandles": ["Adornee"]
+    "PartAdornment": ["Adornee"]
 }
 
 # Extra members to add in to classes, commonly used to add in metamethods, and add corrections
@@ -410,8 +409,7 @@ EXTRA_MEMBERS = {
     ],
     # The Adornee property is optional
     "Highlight": ["Adornee: BasePart?"],
-    "Handles": ["Adornee: BasePart?"],
-    "ArcHandles": ["Adornee: BasePart?"]
+    "PartAdornment": ["Adornee: BasePart?"]
 }
 
 # Hardcoded types

--- a/scripts/globalTypes.d.lua
+++ b/scripts/globalTypes.d.lua
@@ -5902,14 +5902,13 @@ declare class SelectionSphere extends PVAdornment
 end
 
 declare class PartAdornment extends GuiBase3d
-	Adornee: BasePart
+	Adornee: BasePart?
 end
 
 declare class HandlesBase extends PartAdornment
 end
 
 declare class ArcHandles extends HandlesBase
-	Adornee: BasePart?
 	Axes: Axes
 	MouseButton1Down: RBXScriptSignal<EnumAxis>
 	MouseButton1Up: RBXScriptSignal<EnumAxis>
@@ -5919,7 +5918,6 @@ declare class ArcHandles extends HandlesBase
 end
 
 declare class Handles extends HandlesBase
-	Adornee: BasePart?
 	Faces: Faces
 	MouseButton1Down: RBXScriptSignal<EnumNormalId>
 	MouseButton1Up: RBXScriptSignal<EnumNormalId>

--- a/scripts/globalTypes.d.lua
+++ b/scripts/globalTypes.d.lua
@@ -5909,6 +5909,7 @@ declare class HandlesBase extends PartAdornment
 end
 
 declare class ArcHandles extends HandlesBase
+	Adornee: BasePart?
 	Axes: Axes
 	MouseButton1Down: RBXScriptSignal<EnumAxis>
 	MouseButton1Up: RBXScriptSignal<EnumAxis>

--- a/scripts/globalTypes.d.lua
+++ b/scripts/globalTypes.d.lua
@@ -5918,6 +5918,7 @@ declare class ArcHandles extends HandlesBase
 end
 
 declare class Handles extends HandlesBase
+	Adornee: BasePart?
 	Faces: Faces
 	MouseButton1Down: RBXScriptSignal<EnumNormalId>
 	MouseButton1Up: RBXScriptSignal<EnumNormalId>
@@ -6041,7 +6042,7 @@ declare class HiddenSurfaceRemovalAsset extends Instance
 end
 
 declare class Highlight extends Instance
-	Adornee: Instance?
+	Adornee: BasePart?
 	DepthMode: EnumHighlightDepthMode
 	Enabled: boolean
 	FillColor: Color3


### PR DESCRIPTION
Fix the `Handles.Adornee` & `ArcHandles.Adornee` property type (the property can be nil).
Additionally, fix the `Highlight.Adornee` property from a previous change I made. The Adornee property should probably only stick to BaseParts per the Roblox docs.