### PR TITLE
Improved Find All References and Rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Added setting `luau-lsp.index.enabled` which will index the whole workspace into memory. If disabled, only limited support for Find All References and rename is possible
 - Added support for finding all references of both local and exported types. For exported types, `luau-lsp.index.enabled` must be enabled for full support.
+- Added support for renaming table properties across files. If `luau-lsp.index.enabled` is disabled, this feature is disabled for correctness reasons.
+- Added support for renaming types (both local and exported). If `luau-lsp.index.enabled` is disabled, this exported types renaming is disabled for correctness reasons.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 - Added setting `luau-lsp.index.enabled` which will index the whole workspace into memory. If disabled, only limited support for Find All References and rename is possible
+- Added support for finding all references of both local and exported types. For exported types, `luau-lsp.index.enabled` must be enabled for full support.
 ### Changed
 
 - Sync to upstream Luau 0.571

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Added setting `luau-lsp.index.enabled` which will index the whole workspace into memory. If disabled, only limited support for Find All References and rename is possible
 - Added support for finding all references of both local and exported types. For exported types, `luau-lsp.index.enabled` must be enabled for full support.
+
 ### Changed
 
 - Sync to upstream Luau 0.571

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Sync to upstream Luau 0.571
+- Improved find all references system for tables. We can now track all references to table and its properties across files. This requires `luau-lsp.index.enabled` to be enabled for full support.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+- Added setting `luau-lsp.index.enabled` which will index the whole workspace into memory. If disabled, only limited support for Find All References and rename is possible
 ### Changed
 
 - Sync to upstream Luau 0.571

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,7 @@ target_sources(Luau.LanguageServer.Test PRIVATE
     tests/WorkspaceFileResolver.test.cpp
     tests/SemanticTokens.test.cpp
     tests/Sourcemap.test.cpp
+    tests/References.test.cpp
 )
 
 # TODO: Set Luau.Analysis at O2 to speed up debugging

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -336,6 +336,12 @@
             "String requires are interpreted relative to the root of the workspace",
             "String requires are interpreted relative to the current file"
           ]
+        },
+        "luau-lsp.index.enabled": {
+          "type": "boolean",
+          "default": true,
+          "scope": "window",
+          "markdownDescription": "Whether all files in a workspace should be indexed into memory. If disabled, only limited support is available for features such as 'Find All References' and 'Rename'"
         }
       }
     }

--- a/src/LuauExt.cpp
+++ b/src/LuauExt.cpp
@@ -1215,7 +1215,7 @@ struct FindTypeReferences : public Luau::AstVisitor
     bool visit(class Luau::AstTypeReference* node)
     {
         if (node->name.value == typeName && ((!prefix && !node->prefix) || (prefix && node->prefix && node->prefix->value == prefix.value())))
-            result.push_back(node->location); // TODO: only do the node's name location
+            result.push_back(node->nameLocation);
 
         return true;
     }

--- a/src/LuauExt.cpp
+++ b/src/LuauExt.cpp
@@ -674,9 +674,14 @@ struct FindNodeType : public Luau::AstVisitor
     {
     }
 
+    bool isCloserMatch(Luau::Location& newLocation)
+    {
+        return (closed ? newLocation.containsClosed(pos) : newLocation.contains(pos)) && (!best || best->location.encloses(newLocation));
+    }
+
     bool visit(Luau::AstNode* node) override
     {
-        if (closed ? node->location.containsClosed(pos) : node->location.contains(pos))
+        if (isCloserMatch(node->location))
         {
             best = node;
             return true;

--- a/src/include/LSP/ClientConfiguration.hpp
+++ b/src/include/LSP/ClientConfiguration.hpp
@@ -119,6 +119,15 @@ struct ClientRequireConfiguration
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(ClientRequireConfiguration, mode);
 
+struct ClientIndexConfiguration
+{
+    /// Whether the whole workspace should be indexed. If disabled, only limited support is
+    // available for features such as "Find All References" and "Rename"
+    bool enabled = true;
+};
+
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(ClientIndexConfiguration, enabled);
+
 
 // These are the passed configuration options by the client, prefixed with `luau-lsp.`
 // Here we also define the default settings
@@ -135,6 +144,7 @@ struct ClientConfiguration
     ClientCompletionConfiguration completion{};
     ClientSignatureHelpConfiguration signatureHelp{};
     ClientRequireConfiguration require{};
+    ClientIndexConfiguration index{};
 };
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
-    ClientConfiguration, autocompleteEnd, ignoreGlobs, sourcemap, diagnostics, types, inlayHints, hover, completion, signatureHelp, require);
+    ClientConfiguration, autocompleteEnd, ignoreGlobs, sourcemap, diagnostics, types, inlayHints, hover, completion, signatureHelp, require, index);

--- a/src/include/LSP/LuauExt.hpp
+++ b/src/include/LSP/LuauExt.hpp
@@ -42,62 +42,8 @@ std::optional<Luau::AstExpr*> matchRequire(const Luau::AstExprCall& call);
 } // namespace types
 
 // TODO: should upstream this
-struct FindNodeType : public Luau::AstVisitor
-{
-    const Luau::Position pos;
-    const Luau::Position documentEnd;
-    Luau::AstNode* best = nullptr;
-
-    explicit FindNodeType(Luau::Position pos, Luau::Position documentEnd)
-        : pos(pos)
-        , documentEnd(documentEnd)
-    {
-    }
-
-    bool visit(Luau::AstNode* node) override
-    {
-        if (node->location.contains(pos))
-        {
-            best = node;
-            return true;
-        }
-
-        // Edge case: If we ask for the node at the position that is the very end of the document
-        // return the innermost AST element that ends at that position.
-
-        if (node->location.end == documentEnd && pos >= documentEnd)
-        {
-            best = node;
-            return true;
-        }
-
-        return false;
-    }
-
-    bool visit(class Luau::AstType* node) override
-    {
-        return visit(static_cast<Luau::AstNode*>(node));
-    }
-
-    bool visit(Luau::AstStatBlock* block) override
-    {
-        visit(static_cast<Luau::AstNode*>(block));
-
-        for (Luau::AstStat* stat : block->body)
-        {
-            if (stat->location.end < pos)
-                continue;
-            if (stat->location.begin > pos)
-                break;
-
-            stat->visit(this);
-        }
-
-        return false;
-    }
-};
-
 Luau::AstNode* findNodeOrTypeAtPosition(const Luau::SourceModule& source, Luau::Position pos);
+Luau::AstNode* findNodeOrTypeAtPositionClosed(const Luau::SourceModule& source, Luau::Position pos);
 Luau::ExprOrLocal findExprOrLocalAtPositionClosed(const Luau::SourceModule& source, Luau::Position pos);
 std::vector<Luau::Location> findSymbolReferences(const Luau::SourceModule& source, Luau::Symbol symbol);
 std::vector<Luau::Location> findTypeReferences(const Luau::SourceModule& source, const Luau::Name& typeName, std::optional<const Luau::Name> prefix);

--- a/src/include/LSP/LuauExt.hpp
+++ b/src/include/LSP/LuauExt.hpp
@@ -100,6 +100,7 @@ struct FindNodeType : public Luau::AstVisitor
 Luau::AstNode* findNodeOrTypeAtPosition(const Luau::SourceModule& source, Luau::Position pos);
 Luau::ExprOrLocal findExprOrLocalAtPositionClosed(const Luau::SourceModule& source, Luau::Position pos);
 std::vector<Luau::Location> findSymbolReferences(const Luau::SourceModule& source, Luau::Symbol symbol);
+std::vector<Luau::Location> findTypeReferences(const Luau::SourceModule& source, const Luau::Name& typeName, std::optional<const Luau::Name> prefix);
 
 std::optional<Luau::Location> getLocation(Luau::TypeId type);
 

--- a/src/include/LSP/Workspace.hpp
+++ b/src/include/LSP/Workspace.hpp
@@ -9,6 +9,14 @@
 #include "LSP/Client.hpp"
 #include "LSP/WorkspaceFileResolver.hpp"
 
+struct Reference
+{
+    const Luau::ModuleName moduleName;
+    const Luau::Location location;
+    // NOTE: DO NOT STORE THIS EXPR, it will be freed if the module becomes dirty
+    const Luau::AstExpr* expr = nullptr;
+};
+
 class WorkspaceFolder
 {
 public:
@@ -63,6 +71,8 @@ private:
         const TextDocument& textDocument, std::vector<lsp::CompletionItem>& result);
     lsp::WorkspaceEdit computeOrganiseRequiresEdit(const lsp::DocumentUri& uri);
     lsp::WorkspaceEdit computeOrganiseServicesEdit(const lsp::DocumentUri& uri);
+    std::optional<std::vector<Reference>> WorkspaceFolder::findAllReferences(
+        const Luau::TypeId ty, std::optional<Luau::Name> property = std::nullopt);
 
 public:
     std::vector<std::string> getComments(const Luau::ModuleName& moduleName, const Luau::Location& node);

--- a/src/include/LSP/Workspace.hpp
+++ b/src/include/LSP/Workspace.hpp
@@ -73,6 +73,7 @@ private:
     lsp::WorkspaceEdit computeOrganiseServicesEdit(const lsp::DocumentUri& uri);
     std::optional<std::vector<Reference>> WorkspaceFolder::findAllReferences(
         const Luau::TypeId ty, std::optional<Luau::Name> property = std::nullopt);
+    std::optional<std::vector<Reference>> WorkspaceFolder::findAllTypeReferences(const Luau::ModuleName& moduleName, const Luau::Name& typeName);
 
 public:
     std::vector<std::string> getComments(const Luau::ModuleName& moduleName, const Luau::Location& node);

--- a/src/include/LSP/Workspace.hpp
+++ b/src/include/LSP/Workspace.hpp
@@ -55,6 +55,8 @@ public:
 
     void clearDiagnosticsForFile(const lsp::DocumentUri& uri);
 
+    void indexFiles(const ClientConfiguration& config);
+
 private:
     void endAutocompletion(const lsp::CompletionParams& params);
     void suggestImports(const Luau::ModuleName& moduleName, const Luau::Position& position, const ClientConfiguration& config,

--- a/src/include/LSP/Workspace.hpp
+++ b/src/include/LSP/Workspace.hpp
@@ -13,8 +13,6 @@ struct Reference
 {
     const Luau::ModuleName moduleName;
     const Luau::Location location;
-    // NOTE: DO NOT STORE THIS EXPR, it will be freed if the module becomes dirty
-    const Luau::AstExpr* expr = nullptr;
 };
 
 class WorkspaceFolder

--- a/src/include/LSP/Workspace.hpp
+++ b/src/include/LSP/Workspace.hpp
@@ -71,9 +71,8 @@ private:
         const TextDocument& textDocument, std::vector<lsp::CompletionItem>& result);
     lsp::WorkspaceEdit computeOrganiseRequiresEdit(const lsp::DocumentUri& uri);
     lsp::WorkspaceEdit computeOrganiseServicesEdit(const lsp::DocumentUri& uri);
-    std::optional<std::vector<Reference>> WorkspaceFolder::findAllReferences(
-        const Luau::TypeId ty, std::optional<Luau::Name> property = std::nullopt);
-    std::optional<std::vector<Reference>> WorkspaceFolder::findAllTypeReferences(const Luau::ModuleName& moduleName, const Luau::Name& typeName);
+    std::optional<std::vector<Reference>> findAllReferences(const Luau::TypeId ty, std::optional<Luau::Name> property = std::nullopt);
+    std::optional<std::vector<Reference>> findAllTypeReferences(const Luau::ModuleName& moduleName, const Luau::Name& typeName);
 
 public:
     std::vector<std::string> getComments(const Luau::ModuleName& moduleName, const Luau::Location& node);

--- a/src/include/LSP/Workspace.hpp
+++ b/src/include/LSP/Workspace.hpp
@@ -69,12 +69,12 @@ private:
         const TextDocument& textDocument, std::vector<lsp::CompletionItem>& result);
     lsp::WorkspaceEdit computeOrganiseRequiresEdit(const lsp::DocumentUri& uri);
     lsp::WorkspaceEdit computeOrganiseServicesEdit(const lsp::DocumentUri& uri);
-    std::optional<std::vector<Reference>> findAllReferences(const Luau::TypeId ty, std::optional<Luau::Name> property = std::nullopt);
-    std::optional<std::vector<Reference>> findAllTypeReferences(const Luau::ModuleName& moduleName, const Luau::Name& typeName);
 
 public:
     std::vector<std::string> getComments(const Luau::ModuleName& moduleName, const Luau::Location& node);
     std::optional<std::string> getDocumentationForType(const Luau::TypeId ty);
+    std::vector<Reference> findAllReferences(const Luau::TypeId ty, std::optional<Luau::Name> property = std::nullopt);
+    std::vector<Reference> findAllTypeReferences(const Luau::ModuleName& moduleName, const Luau::Name& typeName);
 
     std::vector<lsp::CompletionItem> completion(const lsp::CompletionParams& params);
 

--- a/src/operations/References.cpp
+++ b/src/operations/References.cpp
@@ -4,9 +4,114 @@
 #include "Luau/AstQuery.h"
 #include "LSP/LuauExt.hpp"
 
+static bool isSameTable(const Luau::TypeId a, const Luau::TypeId b)
+{
+    if (a == b)
+        return true;
+
+    // TODO: in some cases, the table in the first module doesnt point to the same ty as the table in the second
+    // for example, in the first module (the one being required), the table may be unsealed
+    // we check for location equality in these cases
+    if (auto ttv1 = Luau::get<Luau::TableType>(a))
+        if (auto ttv2 = Luau::get<Luau::TableType>(b))
+            return !ttv1->definitionModuleName.empty() && ttv1->definitionModuleName == ttv2->definitionModuleName &&
+                   ttv1->definitionLocation == ttv2->definitionLocation;
+
+    return false;
+}
+
+// Find all references across all files for the usage of TableType, or a property on a TableType
+std::optional<std::vector<Reference>> WorkspaceFolder::findAllReferences(Luau::TypeId ty, std::optional<Luau::Name> property)
+{
+    ty = Luau::follow(ty);
+    auto ttv = Luau::get<Luau::TableType>(ty);
+
+    if (!ttv)
+        return std::nullopt;
+
+    if (ttv->definitionModuleName.empty())
+        return std::nullopt;
+
+    std::vector<Reference> references;
+
+    // Find all reverse dependencies of the top-level module
+    // TODO: this function is quite expensive as it requires a BFS
+    // TODO: this comes from `markDirty`
+    std::vector<Luau::ModuleName> dependents{};
+    std::unordered_map<Luau::ModuleName, std::vector<Luau::ModuleName>> reverseDeps;
+    for (const auto& module : frontend.sourceNodes)
+    {
+        for (const auto& dep : module.second.requireSet)
+            reverseDeps[dep].push_back(module.first);
+    }
+    std::vector<Luau::ModuleName> queue{ttv->definitionModuleName};
+    while (!queue.empty())
+    {
+        Luau::ModuleName next = std::move(queue.back());
+        queue.pop_back();
+
+        // TODO: maybe do a set-lookup instead?
+        if (contains(dependents, next))
+            continue;
+
+        dependents.push_back(next);
+
+        if (0 == reverseDeps.count(next))
+            continue;
+
+        const std::vector<Luau::ModuleName>& dependents = reverseDeps[next];
+        queue.insert(queue.end(), dependents.begin(), dependents.end());
+    }
+
+    // For every module, search for its referencing
+    for (const auto& moduleName : dependents)
+    {
+        auto module = frontend.moduleResolverForAutocomplete.getModule(moduleName);
+        if (!module)
+            continue;
+
+        for (const auto [expr, referencedTy] : module->astTypes)
+        {
+            // If we are looking for a property specifically,
+            // then only look for LuauAstExprIndexName
+            if (property)
+            {
+                if (auto indexName = expr->as<Luau::AstExprIndexName>(); indexName && indexName->index.value == property.value())
+                {
+                    auto possibleParentTy = module->astTypes.find(indexName->expr);
+                    if (possibleParentTy && isSameTable(ty, Luau::follow(*possibleParentTy)))
+                        references.push_back(Reference{moduleName, indexName->indexLocation, expr});
+                }
+                else if (auto table = expr->as<Luau::AstExprTable>(); table && isSameTable(ty, Luau::follow(referencedTy)))
+                {
+                    for (const auto& item : table->items)
+                    {
+                        if (item.key)
+                        {
+                            if (auto propName = item.key->as<Luau::AstExprConstantString>())
+                            {
+                                if (propName->value.data == property.value())
+                                    references.push_back(Reference{moduleName, item.key->location, item.key});
+                            }
+                        }
+                    }
+                }
+            }
+            else
+            {
+                if (isSameTable(ty, Luau::follow(referencedTy)))
+                    references.push_back(Reference{moduleName, expr->location, expr});
+            }
+        }
+    }
+
+    return references;
+}
+
+
 lsp::ReferenceResult WorkspaceFolder::references(const lsp::ReferenceParams& params)
 {
-    // TODO: currently we only support searching for a binding at a current position
+    // TODO: we do not yet support finding type references
     auto moduleName = fileResolver.getModuleName(params.textDocument.uri);
     auto textDocument = fileResolver.getTextDocument(params.textDocument.uri);
     if (!textDocument)
@@ -15,35 +120,78 @@ lsp::ReferenceResult WorkspaceFolder::references(const lsp::ReferenceParams& par
     auto position = textDocument->convertPosition(params.position);
 
     // Run the type checker to ensure we are up to date
-    // TODO: we only need the parse result here - can typechecking be skipped?
-    if (frontend.isDirty(moduleName))
-        frontend.check(moduleName);
+    // We check for autocomplete here since autocomplete has stricter types
+    frontend.check(moduleName, Luau::FrontendOptions{/* retainFullTypeGraphs: */ true, /* forAutocomplete: */ true});
 
     auto sourceModule = frontend.getSourceModule(moduleName);
     if (!sourceModule)
         return std::nullopt;
 
     auto exprOrLocal = Luau::findExprOrLocalAtPosition(*sourceModule, position);
-    Luau::Symbol symbol;
-
+    Luau::Symbol localSymbol;
     if (exprOrLocal.getLocal())
-        symbol = exprOrLocal.getLocal();
+        localSymbol = exprOrLocal.getLocal();
     else if (auto exprLocal = exprOrLocal.getExpr()->as<Luau::AstExprLocal>())
-        symbol = exprLocal->local;
-    else
-        return std::nullopt;
+        localSymbol = exprLocal->local;
 
-    auto references = findSymbolReferences(*sourceModule, symbol);
+
     std::vector<lsp::Location> result{};
 
-    result.reserve(references.size());
-    for (auto& location : references)
+    if (localSymbol)
     {
-        result.emplace_back(
-            lsp::Location{params.textDocument.uri, {textDocument->convertPosition(location.begin), textDocument->convertPosition(location.end)}});
+        // Search for a local binding
+        // TODO: what if this local binding is returned! need to handle that so we can find cross-file references
+        auto references = findSymbolReferences(*sourceModule, localSymbol);
+
+        result.reserve(references.size());
+        for (auto& location : references)
+        {
+            result.emplace_back(
+                lsp::Location{params.textDocument.uri, {textDocument->convertPosition(location.begin), textDocument->convertPosition(location.end)}});
+        }
+
+        return result;
     }
 
-    return result;
+    // Search for a property
+    auto module = frontend.moduleResolverForAutocomplete.getModule(moduleName);
+    if (auto indexName = exprOrLocal.getExpr()->as<Luau::AstExprIndexName>())
+    {
+        auto possibleParentTy = module->astTypes.find(indexName->expr);
+        if (possibleParentTy)
+        {
+            auto parentTy = Luau::follow(*possibleParentTy);
+            auto references = findAllReferences(parentTy, indexName->index.value);
+            if (references)
+            {
+                for (const auto& reference : *references)
+                {
+                    if (auto refTextDocument = fileResolver.getTextDocumentFromModuleName(reference.moduleName))
+                    {
+                        result.emplace_back(lsp::Location{refTextDocument->uri(),
+                            {refTextDocument->convertPosition(reference.location.begin), refTextDocument->convertPosition(reference.location.end)}});
+                    }
+                    else
+                    {
+                        if (auto filePath = fileResolver.resolveToRealPath(reference.moduleName))
+                        {
+                            if (auto source = fileResolver.readSource(reference.moduleName))
+                            {
+                                auto refTextDocument = TextDocument{Uri::file(*filePath), "luau", 0, source->source};
+                                result.emplace_back(
+                                    lsp::Location{refTextDocument.uri(), {refTextDocument.convertPosition(reference.location.begin),
+                                                                             refTextDocument.convertPosition(reference.location.end)}});
+                            }
+                        }
+                    }
+                }
+
+                return result;
+            }
+        }
+    }
+
+    return std::nullopt;
 }
 
 lsp::ReferenceResult LanguageServer::references(const lsp::ReferenceParams& params)

--- a/src/operations/References.cpp
+++ b/src/operations/References.cpp
@@ -85,7 +85,7 @@ std::optional<std::vector<Reference>> WorkspaceFolder::findAllReferences(Luau::T
                 {
                     auto possibleParentTy = module->astTypes.find(indexName->expr);
                     if (possibleParentTy && isSameTable(ty, Luau::follow(*possibleParentTy)))
-                        references.push_back(Reference{moduleName, indexName->indexLocation, expr});
+                        references.push_back(Reference{moduleName, indexName->indexLocation});
                 }
                 else if (auto table = expr->as<Luau::AstExprTable>(); table && isSameTable(ty, Luau::follow(referencedTy)))
                 {
@@ -96,7 +96,7 @@ std::optional<std::vector<Reference>> WorkspaceFolder::findAllReferences(Luau::T
                             if (auto propName = item.key->as<Luau::AstExprConstantString>())
                             {
                                 if (propName->value.data == property.value())
-                                    references.push_back(Reference{moduleName, item.key->location, item.key});
+                                    references.push_back(Reference{moduleName, item.key->location});
                             }
                         }
                     }
@@ -105,7 +105,7 @@ std::optional<std::vector<Reference>> WorkspaceFolder::findAllReferences(Luau::T
             else
             {
                 if (isSameTable(ty, Luau::follow(referencedTy)))
-                    references.push_back(Reference{moduleName, expr->location, expr});
+                    references.push_back(Reference{moduleName, expr->location});
             }
         }
     }
@@ -126,7 +126,7 @@ std::optional<std::vector<Reference>> WorkspaceFolder::findAllTypeReferences(con
     auto references = findTypeReferences(*sourceModule, typeName, std::nullopt);
     result.reserve(references.size() + 1);
     for (auto& location : references)
-        result.emplace_back(Reference{moduleName, location, nullptr});
+        result.emplace_back(Reference{moduleName, location});
 
     // Find the actual declaration location
     auto module = frontend.moduleResolverForAutocomplete.getModule(moduleName);
@@ -135,7 +135,7 @@ std::optional<std::vector<Reference>> WorkspaceFolder::findAllTypeReferences(con
 
     if (auto location = module->getModuleScope()->typeAliasNameLocations.find(typeName);
         location != module->getModuleScope()->typeAliasNameLocations.end())
-        result.emplace_back(Reference{moduleName, location->second, nullptr});
+        result.emplace_back(Reference{moduleName, location->second});
 
     // Find all cross-module references
     auto reverseDependencies = findReverseDependencies(frontend, moduleName);
@@ -166,7 +166,7 @@ std::optional<std::vector<Reference>> WorkspaceFolder::findAllTypeReferences(con
             auto references = findTypeReferences(*sourceModule, typeName, importName);
             result.reserve(result.size() + references.size());
             for (auto& location : references)
-                result.emplace_back(Reference{dependencyModuleName, location, nullptr});
+                result.emplace_back(Reference{dependencyModuleName, location});
         }
     }
 

--- a/src/operations/Rename.cpp
+++ b/src/operations/Rename.cpp
@@ -3,6 +3,42 @@
 
 #include "LSP/LuauExt.hpp"
 
+static void processReferences(
+    WorkspaceFileResolver& fileResolver, const std::string& newName, const std::vector<Reference>& references, lsp::WorkspaceEdit& result)
+{
+    for (const auto& reference : references)
+    {
+        if (auto refTextDocument = fileResolver.getTextDocumentFromModuleName(reference.moduleName))
+        {
+            // Create a vector of changes if it does not yet exist
+            if (!contains(result.changes, refTextDocument->uri().toString()))
+                result.changes.insert_or_assign(refTextDocument->uri().toString(), std::vector<lsp::TextEdit>{});
+
+            result.changes.at(refTextDocument->uri().toString())
+                .emplace_back(lsp::TextEdit{
+                    {refTextDocument->convertPosition(reference.location.begin), refTextDocument->convertPosition(reference.location.end)}, newName});
+        }
+        else
+        {
+            if (auto filePath = fileResolver.resolveToRealPath(reference.moduleName))
+            {
+                if (auto source = fileResolver.readSource(reference.moduleName))
+                {
+                    auto refTextDocument = TextDocument{Uri::file(*filePath), "luau", 0, source->source};
+                    // Create a vector of changes if it does not yet exist
+                    if (!contains(result.changes, refTextDocument.uri().toString()))
+                        result.changes.insert_or_assign(refTextDocument.uri().toString(), std::vector<lsp::TextEdit>{});
+
+                    result.changes.at(refTextDocument.uri().toString())
+                        .emplace_back(lsp::TextEdit{
+                            {refTextDocument.convertPosition(reference.location.begin), refTextDocument.convertPosition(reference.location.end)},
+                            newName});
+                }
+            }
+        }
+    }
+}
+
 lsp::RenameResult WorkspaceFolder::rename(const lsp::RenameParams& params)
 {
     // Verify the new name is valid (is an identifier)
@@ -17,7 +53,6 @@ lsp::RenameResult WorkspaceFolder::rename(const lsp::RenameParams& params)
                 lsp::ErrorCode::RequestFailed, "The new name must be a valid identifier composed of characters, digits, and underscores only");
     }
 
-    // TODO: currently we only support renaming local bindings in the current file
     auto moduleName = fileResolver.getModuleName(params.textDocument.uri);
     auto textDocument = fileResolver.getTextDocument(params.textDocument.uri);
     if (!textDocument)
@@ -25,36 +60,113 @@ lsp::RenameResult WorkspaceFolder::rename(const lsp::RenameParams& params)
     auto position = textDocument->convertPosition(params.position);
 
     // Run the type checker to ensure we are up to date
-    // TODO: we only need the parse result here - can typechecking be skipped?
-    if (frontend.isDirty(moduleName))
-        frontend.check(moduleName);
+    // We check for autocomplete here since autocomplete has stricter types
+    frontend.check(moduleName, Luau::FrontendOptions{/* retainFullTypeGraphs: */ true, /* forAutocomplete: */ true});
 
     auto sourceModule = frontend.getSourceModule(moduleName);
     if (!sourceModule)
         throw JsonRpcException(lsp::ErrorCode::RequestFailed, "Unable to read source code");
 
     auto exprOrLocal = findExprOrLocalAtPositionClosed(*sourceModule, position);
-    if (!exprOrLocal.getLocal() && !exprOrLocal.getExpr())
-        throw JsonRpcException(lsp::ErrorCode::RequestFailed, "Unable to find symbol. Ensure the variable is highlighted correctly");
-
-    Luau::Symbol symbol;
-
+    Luau::Symbol localSymbol;
     if (exprOrLocal.getLocal())
-        symbol = exprOrLocal.getLocal();
-    else if (auto exprLocal = exprOrLocal.getExpr()->as<Luau::AstExprLocal>())
-        symbol = exprLocal->local;
-    else
-        throw JsonRpcException(lsp::ErrorCode::RequestFailed, "Rename is currently only supported for local variable bindings in the current file");
-
-    auto references = findSymbolReferences(*sourceModule, symbol);
-    std::vector<lsp::TextEdit> localChanges{};
-    for (auto& location : references)
+        localSymbol = exprOrLocal.getLocal();
+    else if (auto expr = exprOrLocal.getExpr())
     {
-        localChanges.emplace_back(
-            lsp::TextEdit{{textDocument->convertPosition(location.begin), textDocument->convertPosition(location.end)}, params.newName});
+        if (auto local = expr->as<Luau::AstExprLocal>())
+            localSymbol = local->local;
     }
 
-    return lsp::WorkspaceEdit{{{params.textDocument.uri.toString(), localChanges}}};
+    lsp::WorkspaceEdit result{};
+
+    if (localSymbol)
+    {
+        // Search for a local binding
+        auto references = findSymbolReferences(*sourceModule, localSymbol);
+        std::vector<lsp::TextEdit> localChanges{};
+        for (auto& location : references)
+        {
+            localChanges.emplace_back(
+                lsp::TextEdit{{textDocument->convertPosition(location.begin), textDocument->convertPosition(location.end)}, params.newName});
+        }
+        result.changes.insert_or_assign(params.textDocument.uri.toString(), localChanges);
+
+        return result;
+    }
+
+    // Search for a property
+    auto module = frontend.moduleResolverForAutocomplete.getModule(moduleName);
+    if (auto expr = exprOrLocal.getExpr())
+    {
+        if (auto indexName = expr->as<Luau::AstExprIndexName>())
+        {
+            auto possibleParentTy = module->astTypes.find(indexName->expr);
+            if (possibleParentTy)
+            {
+                auto parentTy = Luau::follow(*possibleParentTy);
+                auto references = findAllReferences(parentTy, indexName->index.value);
+                if (references)
+                {
+                    processReferences(fileResolver, params.newName, *references, result);
+                    return result;
+                }
+            }
+        }
+    }
+
+    // Search for a type reference
+    auto node = findNodeOrTypeAtPositionClosed(*sourceModule, position);
+    if (!node)
+        return std::nullopt;
+
+    if (auto reference = node->as<Luau::AstTypeReference>())
+    {
+        if (auto prefix = reference->prefix)
+        {
+            if (auto importedModuleName = module->getModuleScope()->importedModules.find(prefix.value().value);
+                importedModuleName != module->getModuleScope()->importedModules.end())
+            {
+                auto references = findAllTypeReferences(importedModuleName->second, reference->name.value);
+                if (references)
+                {
+                    processReferences(fileResolver, params.newName, *references, result);
+                    return result;
+                }
+            }
+
+            return std::nullopt;
+        }
+        else
+        {
+            std::vector<lsp::TextEdit> localChanges{};
+            auto references = findTypeReferences(*sourceModule, reference->name.value, std::nullopt);
+            localChanges.reserve(references.size() + 1);
+            for (auto& location : references)
+                localChanges.emplace_back(
+                    lsp::TextEdit{{textDocument->convertPosition(location.begin), textDocument->convertPosition(location.end)}, params.newName});
+
+            // Find the actual declaration location
+            auto scope = Luau::findScopeAtPosition(*module, position);
+            while (scope)
+            {
+                if (auto location = scope->typeAliasNameLocations.find(reference->name.value); location != scope->typeAliasNameLocations.end())
+                {
+                    localChanges.emplace_back(
+                        lsp::TextEdit{{textDocument->convertPosition(location->second.begin), textDocument->convertPosition(location->second.end)},
+                            params.newName});
+                    break;
+                }
+
+                scope = scope->parent;
+            }
+
+            result.changes.insert_or_assign(params.textDocument.uri.toString(), localChanges);
+
+            return result;
+        }
+    }
+
+    throw JsonRpcException(lsp::ErrorCode::RequestFailed, "Unable to find symbol to rename");
 }
 
 lsp::RenameResult LanguageServer::rename(const lsp::RenameParams& params)

--- a/src/operations/Rename.cpp
+++ b/src/operations/Rename.cpp
@@ -105,11 +105,8 @@ lsp::RenameResult WorkspaceFolder::rename(const lsp::RenameParams& params)
             {
                 auto parentTy = Luau::follow(*possibleParentTy);
                 auto references = findAllReferences(parentTy, indexName->index.value);
-                if (references)
-                {
-                    processReferences(fileResolver, params.newName, *references, result);
-                    return result;
-                }
+                processReferences(fileResolver, params.newName, references, result);
+                return result;
             }
         }
     }
@@ -127,11 +124,8 @@ lsp::RenameResult WorkspaceFolder::rename(const lsp::RenameParams& params)
                 importedModuleName != module->getModuleScope()->importedModules.end())
             {
                 auto references = findAllTypeReferences(importedModuleName->second, reference->name.value);
-                if (references)
-                {
-                    processReferences(fileResolver, params.newName, *references, result);
-                    return result;
-                }
+                processReferences(fileResolver, params.newName, references, result);
+                return result;
             }
 
             return std::nullopt;

--- a/tests/Fixture.cpp
+++ b/tests/Fixture.cpp
@@ -101,6 +101,7 @@ Fixture::Fixture()
 
     ClientConfiguration config;
     config.sourcemap.enabled = false;
+    config.index.enabled = false;
     workspace.setupWithConfiguration(config);
 
     Luau::setPrintLine([](auto s) {});

--- a/tests/References.test.cpp
+++ b/tests/References.test.cpp
@@ -1,0 +1,85 @@
+#include "doctest.h"
+#include "Fixture.h"
+
+TEST_SUITE_BEGIN("References");
+
+// TODO: cross module tests
+// TODO: type references tests (cross module)
+
+TEST_CASE_FIXTURE(Fixture, "find_table_property_declaration_1")
+{
+    auto result = check(R"(
+        local T = {}
+        T.name = "testing"
+    )");
+    REQUIRE_EQ(0, result.errors.size());
+
+    auto ty = requireType("T");
+    auto references = workspace.findAllReferences(ty, "name");
+    REQUIRE_EQ(1, references.size());
+    CHECK(references[0].location.begin.line == 2);
+    CHECK(references[0].location.begin.column == 10);
+    CHECK(references[0].location.end.line == 2);
+    CHECK(references[0].location.end.column == 14);
+}
+
+TEST_CASE_FIXTURE(Fixture, "find_table_property_declaration_2")
+{
+    auto result = check(R"(
+        local T = {
+            name = "Testing"
+        }
+    )");
+    REQUIRE_EQ(0, result.errors.size());
+
+    auto ty = requireType("T");
+    auto references = workspace.findAllReferences(ty, "name");
+    REQUIRE_EQ(1, references.size());
+    CHECK(references[0].location.begin.line == 2);
+    CHECK(references[0].location.begin.column == 12);
+    CHECK(references[0].location.end.line == 2);
+    CHECK(references[0].location.end.column == 16);
+}
+
+TEST_CASE_FIXTURE(Fixture, "find_table_property_declaration_3")
+{
+    auto result = check(R"(
+        local T = {}
+
+        function T.name()
+            return "testing"
+        end
+    )");
+    REQUIRE_EQ(0, result.errors.size());
+
+    auto ty = requireType("T");
+    auto references = workspace.findAllReferences(ty, "name");
+    REQUIRE_EQ(1, references.size());
+    CHECK(references[0].location.begin.line == 3);
+    CHECK(references[0].location.begin.column == 19);
+    CHECK(references[0].location.end.line == 3);
+    CHECK(references[0].location.end.column == 23);
+}
+
+TEST_CASE_FIXTURE(Fixture, "find_table_property_declaration_4")
+{
+    auto result = check(R"(
+        local T = {}
+
+        function T:name()
+            return "testing"
+        end
+    )");
+    REQUIRE_EQ(0, result.errors.size());
+
+    auto ty = requireType("T");
+    auto references = workspace.findAllReferences(ty, "name");
+    REQUIRE_EQ(1, references.size());
+    CHECK(references[0].location.begin.line == 3);
+    CHECK(references[0].location.begin.column == 19);
+    CHECK(references[0].location.end.line == 3);
+    CHECK(references[0].location.end.column == 23);
+}
+
+
+TEST_SUITE_END();


### PR DESCRIPTION
Adds support for proper cross-module find all references.
Also adds support for finding references of types (both local and exported, cross-module)
This also adds in a workspace indexing system, which will be useful for #124 as well

These improvements are also extended to rename support
Closes #117

TODO:
- Find all references of a require? We only do table properties right now