### PR TITLE
Add settings for auto-imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Deprecated
+
+- Deprecated config `luau-lsp.completion.suggestImports`: use `luau-lsp.completion.imports.enabled` instead
+
+### Added
+
+- Added more settings to auto-importing:
+  - `luau-lsp.completion.imports.enabled`: replaces `luau-lsp.completion.suggestImports` (default: false)
+  - `luau-lsp.completion.imports.suggestServices`: whether GetService imports are included in suggestions (default: true)
+  - `luau-lsp.completion.imports.suggestRequires`: whether auto-requires are included in suggestions (default: true)
+  - `luau-lsp.completion.imports.requireStyle`: the style of require format (default: "auto")
+
 ### Changed
 
 - Sync to upstream Luau 0.573

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -106,12 +106,6 @@
           "default": false,
           "scope": "resource"
         },
-        "luau-lsp.completion.suggestImports": {
-          "markdownDescription": "Suggest automatic imports in completion items",
-          "type": "boolean",
-          "default": false,
-          "scope": "resource"
-        },
         "luau-lsp.ignoreGlobs": {
           "markdownDescription": "Diagnostics will not be reported for any file matching these globs unless the file is currently open",
           "type": "array",
@@ -304,6 +298,48 @@
           "markdownDescription": "Fill parameter names in an autocompleted function call, which can be tabbed through. Requires `#luau-lsp.completion.addParentheses#` to be enabled",
           "type": "boolean",
           "default": true,
+          "scope": "resource"
+        },
+        "luau-lsp.completion.suggestImports": {
+          "markdownDescription": "Suggest automatic imports in completion items",
+          "type": "boolean",
+          "default": false,
+          "scope": "resource",
+          "markdownDeprecationMessage": "**Deprecated**: Please use `#luau-lsp.completion.imports.enabled#` instead.",
+          "deprecationMessage": "Deprecated: Please use luau-lsp.completion.imports.enabled instead."
+        },
+        "luau-lsp.completion.imports.enabled": {
+          "markdownDescription": "Suggest automatic imports in completion items",
+          "type": "boolean",
+          "default": false,
+          "scope": "resource"
+        },
+        "luau-lsp.completion.imports.suggestServices": {
+          "markdownDescription": "Whether GetService completions are suggested in autocomplete",
+          "type": "boolean",
+          "default": true,
+          "scope": "resource"
+        },
+        "luau-lsp.completion.imports.suggestRequires": {
+          "markdownDescription": "Whether module requires are suggested in autocomplete",
+          "type": "boolean",
+          "default": true,
+          "scope": "resource"
+        },
+        "luau-lsp.completion.imports.requireStyle": {
+          "markdownDescription": "The style of requires when autocompleted",
+          "type": "string",
+          "default": "auto",
+          "enum": [
+            "auto",
+            "alwaysRelative",
+            "alwaysAbsolute"
+          ],
+          "enumDescriptions": [
+            "Automatically compute the style of require to use based on heuristics",
+            "Always require the module relative to the current file",
+            "Always require the module absolute based on root"
+          ],
           "scope": "resource"
         },
         "luau-lsp.signatureHelp.enabled": {

--- a/src/include/LSP/ClientConfiguration.hpp
+++ b/src/include/LSP/ClientConfiguration.hpp
@@ -79,11 +79,39 @@ struct ClientHoverConfiguration
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
     ClientHoverConfiguration, enabled, showTableKinds, multilineFunctionDefinitions, strictDatamodelTypes);
 
+enum struct ImportRequireStyle
+{
+    Auto,
+    AlwaysRelative,
+    AlwaysAbsolute,
+};
+NLOHMANN_JSON_SERIALIZE_ENUM(ImportRequireStyle, {
+                                                     {ImportRequireStyle::Auto, "auto"},
+                                                     {ImportRequireStyle::AlwaysRelative, "alwaysRelative"},
+                                                     {ImportRequireStyle::AlwaysAbsolute, "alwaysAbsolute"},
+                                                 })
+
+struct ClientCompletionImportsConfiguration
+{
+    /// Whether we should suggest automatic imports in completions
+    bool enabled = false;
+    /// Whether services should be suggested in auto-import
+    bool suggestServices = true;
+    /// Whether requires should be suggested in auto-import
+    bool suggestRequires = true;
+    /// The style of the auto-imported require
+    ImportRequireStyle requireStyle = ImportRequireStyle::Auto;
+};
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(ClientCompletionImportsConfiguration, enabled, suggestServices, suggestRequires, requireStyle);
+
 struct ClientCompletionConfiguration
 {
     bool enabled = true;
     /// Whether we should suggest automatic imports in completions
+    /// DEPRECATED: USE `completion.imports.enabled` INSTEAD
     bool suggestImports = false;
+    /// Automatic imports configuration
+    ClientCompletionImportsConfiguration imports{};
     /// Automatically add parentheses to a function call
     bool addParentheses = true;
     /// If parentheses are added, include a $0 tabstop after the parentheses
@@ -93,7 +121,7 @@ struct ClientCompletionConfiguration
 };
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
-    ClientCompletionConfiguration, enabled, suggestImports, addParentheses, addTabstopAfterParentheses, fillCallArguments);
+    ClientCompletionConfiguration, enabled, suggestImports, imports, addParentheses, addTabstopAfterParentheses, fillCallArguments);
 
 struct ClientSignatureHelpConfiguration
 {


### PR DESCRIPTION
Added more settings to auto-importing:
  - `luau-lsp.completion.imports.enabled`: replaces `luau-lsp.completion.suggestImports` (default: false)
  - `luau-lsp.completion.imports.suggestServices`: whether GetService imports are included in suggestions (default: true)
  - `luau-lsp.completion.imports.suggestRequires`: whether auto-requires are included in suggestions (default: true)
  - `luau-lsp.completion.imports.requireStyle`: the style of require format (default: "auto")

Deprecated config `luau-lsp.completion.suggestImports`: use `luau-lsp.completion.imports.enabled` instead

Closes #330 