### PR TITLE
Be more clever about retaining type graphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+#### Changed
+
+- Significant improvements to memory usage in large workspaces when workspace indexing or diagnostics are enabled
+
 ## [1.21.0] - 2023-06-14
 
 ### Deprecated

--- a/src/LanguageServer.cpp
+++ b/src/LanguageServer.cpp
@@ -726,6 +726,7 @@ void LanguageServer::onDidChangeWatchedFiles(const lsp::DidChangeWatchedFilesPar
             }
 
             // Index the workspace on changes
+            // NOTE: we aren't indexing for types, only for the require graph right now
             if (config.index.enabled && workspace->isConfigured)
             {
                 auto moduleName = workspace->fileResolver.getModuleName(change.uri);
@@ -734,11 +735,11 @@ void LanguageServer::onDidChangeWatchedFiles(const lsp::DidChangeWatchedFilesPar
                 workspace->frontend.markDirty(moduleName, &markedDirty);
 
                 if (change.type == lsp::FileChangeType::Created)
-                    workspace->frontend.check(moduleName);
+                    workspace->checkSimple(moduleName);
 
                 // Re-check the reverse dependencies
                 for (const auto& moduleName : markedDirty)
-                    workspace->frontend.check(moduleName);
+                    workspace->checkSimple(moduleName);
             }
 
             // Clear the diagnostics for the file in case it was not managed

--- a/src/include/LSP/Workspace.hpp
+++ b/src/include/LSP/Workspace.hpp
@@ -13,6 +13,11 @@ struct Reference
 {
     const Luau::ModuleName moduleName;
     const Luau::Location location;
+
+    bool operator==(const Reference& other) const
+    {
+        return moduleName == other.moduleName && location == other.location;
+    }
 };
 
 class WorkspaceFolder

--- a/src/include/LSP/Workspace.hpp
+++ b/src/include/LSP/Workspace.hpp
@@ -33,8 +33,11 @@ public:
         , name(name)
         , rootUri(uri)
         , fileResolver(defaultConfig ? WorkspaceFileResolver(*defaultConfig) : WorkspaceFileResolver())
+        // TODO: we don't really need to retainFullTypeGraphs by default
+        // but it seems that the option specified here is the one used
+        // when calling Luau::autocomplete
         , frontend(Luau::Frontend(
-              &fileResolver, &fileResolver, {/* retainFullTypeGraphs: */ true, /* forAutocomplete: */ false, /* runLintChecks: */ true}))
+              &fileResolver, &fileResolver, {/* retainFullTypeGraphs: */ true, /* forAutocomplete: */ false, /* runLintChecks: */ false}))
     {
         fileResolver.client = client;
         fileResolver.rootUri = uri;
@@ -62,6 +65,9 @@ public:
     void clearDiagnosticsForFile(const lsp::DocumentUri& uri);
 
     void indexFiles(const ClientConfiguration& config);
+
+    Luau::CheckResult checkSimple(const Luau::ModuleName& moduleName, bool runLintChecks = false);
+    void checkStrict(const Luau::ModuleName& moduleName, bool forAutocomplete = true);
 
 private:
     void endAutocompletion(const lsp::CompletionParams& params);

--- a/src/operations/CallHierarchy.cpp
+++ b/src/operations/CallHierarchy.cpp
@@ -119,11 +119,7 @@ std::vector<lsp::CallHierarchyItem> WorkspaceFolder::prepareCallHierarchy(const 
     auto position = textDocument->convertPosition(params.position);
 
     // Run the type checker to ensure we are up to date
-    if (frontend.isDirty(moduleName))
-    {
-        Luau::FrontendOptions frontendOpts{true, true};
-        frontend.check(moduleName, frontendOpts);
-    }
+    checkStrict(moduleName);
 
     auto sourceModule = frontend.getSourceModule(moduleName);
     auto module = frontend.moduleResolverForAutocomplete.getModule(moduleName);

--- a/src/operations/CodeAction.cpp
+++ b/src/operations/CodeAction.cpp
@@ -12,8 +12,8 @@ lsp::WorkspaceEdit WorkspaceFolder::computeOrganiseRequiresEdit(const lsp::Docum
     if (!textDocument)
         throw JsonRpcException(lsp::ErrorCode::RequestFailed, "No managed text document for " + uri.toString());
 
-    if (frontend.isDirty(moduleName))
-        frontend.check(moduleName);
+    // TODO: we only need parsing and no type checking
+    checkSimple(moduleName);
 
     auto sourceModule = frontend.getSourceModule(moduleName);
     if (!sourceModule)
@@ -78,8 +78,8 @@ lsp::WorkspaceEdit WorkspaceFolder::computeOrganiseServicesEdit(const lsp::Docum
     if (!textDocument)
         throw JsonRpcException(lsp::ErrorCode::RequestFailed, "No managed text document for " + uri.toString());
 
-    if (frontend.isDirty(moduleName))
-        frontend.check(moduleName);
+    // TODO: we only need parsing and no type checking
+    checkSimple(moduleName);
 
     auto sourceModule = frontend.getSourceModule(moduleName);
     if (!sourceModule)

--- a/src/operations/ColorProvider.cpp
+++ b/src/operations/ColorProvider.cpp
@@ -257,9 +257,8 @@ lsp::DocumentColorResult WorkspaceFolder::documentColor(const lsp::DocumentColor
     if (!textDocument)
         throw JsonRpcException(lsp::ErrorCode::RequestFailed, "No managed text document for " + params.textDocument.uri.toString());
 
-    // Run the type checker to ensure we are up to date
-    if (frontend.isDirty(moduleName))
-        frontend.check(moduleName);
+    // TODO: we only need parsing and no type checking
+    checkSimple(moduleName);
 
     auto sourceModule = frontend.getSourceModule(moduleName);
     if (!sourceModule)

--- a/src/operations/Completion.cpp
+++ b/src/operations/Completion.cpp
@@ -65,8 +65,7 @@ void WorkspaceFolder::endAutocompletion(const lsp::CompletionParams& params)
         return;
     auto position = document->convertPosition(params.position);
 
-    if (frontend.isDirty(moduleName))
-        frontend.check(moduleName);
+    checkSimple(moduleName);
 
     auto sourceModule = frontend.getSourceModule(moduleName);
     if (!sourceModule)

--- a/src/operations/Diagnostics.cpp
+++ b/src/operations/Diagnostics.cpp
@@ -20,7 +20,8 @@ lsp::DocumentDiagnosticReport WorkspaceFolder::documentDiagnostics(const lsp::Do
     if (!textDocument)
         return report; // Bail early with empty report - file was likely closed
 
-    Luau::CheckResult cr = frontend.check(moduleName);
+    // Check the module. We do not need to store the type graphs
+    Luau::CheckResult cr = checkSimple(moduleName, /* runLintChecks: */ true);
 
     // If there was an error retrieving the source module
     // Bail early with an empty report - it is likely that the file was closed
@@ -121,7 +122,7 @@ lsp::WorkspaceDiagnosticReport WorkspaceFolder::workspaceDiagnostics(const lsp::
         }
 
         // Compute new check result
-        Luau::CheckResult cr = frontend.check(moduleName);
+        Luau::CheckResult cr = checkSimple(moduleName, /* runLintChecks: */ true);
 
         // If there was an error retrieving the source module, disregard this file
         // TODO: should we file a diagnostic?

--- a/src/operations/DocumentLink.cpp
+++ b/src/operations/DocumentLink.cpp
@@ -35,8 +35,8 @@ std::vector<lsp::DocumentLink> WorkspaceFolder::documentLink(const lsp::Document
     auto moduleName = fileResolver.getModuleName(params.textDocument.uri);
     std::vector<lsp::DocumentLink> result{};
 
-    // We need to parse the code, which is currently only done in the type checker
-    frontend.check(moduleName);
+    // TODO: we only need parsing and no type checking
+    checkSimple(moduleName);
 
     auto sourceModule = frontend.getSourceModule(moduleName);
     if (!sourceModule || !sourceModule->root)

--- a/src/operations/DocumentSymbol.cpp
+++ b/src/operations/DocumentSymbol.cpp
@@ -150,9 +150,8 @@ std::optional<std::vector<lsp::DocumentSymbol>> WorkspaceFolder::documentSymbol(
     if (!textDocument)
         throw JsonRpcException(lsp::ErrorCode::RequestFailed, "No managed text document for " + params.textDocument.uri.toString());
 
-    // Run the type checker to ensure we are up to date
-    if (frontend.isDirty(moduleName))
-        frontend.check(moduleName);
+    // TODO: we only need parsing and no type checking
+    checkSimple(moduleName);
 
     auto sourceModule = frontend.getSourceModule(moduleName);
     if (!sourceModule)

--- a/src/operations/FoldingRange.cpp
+++ b/src/operations/FoldingRange.cpp
@@ -95,9 +95,8 @@ std::vector<lsp::FoldingRange> WorkspaceFolder::foldingRange(const lsp::FoldingR
     if (!textDocument)
         throw JsonRpcException(lsp::ErrorCode::RequestFailed, "No managed text document for " + params.textDocument.uri.toString());
 
-    // Run the type checker to ensure we are up to date
-    if (frontend.isDirty(moduleName))
-        frontend.check(moduleName);
+    // TODO: we only need parsing and no type checking
+    checkSimple(moduleName);
 
     auto sourceModule = frontend.getSourceModule(moduleName);
     if (!sourceModule)

--- a/src/operations/GotoDefinition.cpp
+++ b/src/operations/GotoDefinition.cpp
@@ -15,12 +15,7 @@ lsp::DefinitionResult WorkspaceFolder::gotoDefinition(const lsp::DefinitionParam
     auto position = textDocument->convertPosition(params.position);
 
     // Run the type checker to ensure we are up to date
-    if (frontend.isDirty(moduleName))
-    {
-        // TODO: expressiveTypes - remove "forAutocomplete" once the types have been fixed
-        Luau::FrontendOptions frontendOpts{true, true};
-        frontend.check(moduleName, frontendOpts);
-    }
+    checkStrict(moduleName);
 
     auto sourceModule = frontend.getSourceModule(moduleName);
     // TODO: fix "forAutocomplete"
@@ -185,12 +180,7 @@ std::optional<lsp::Location> WorkspaceFolder::gotoTypeDefinition(const lsp::Type
     auto position = textDocument->convertPosition(params.position);
 
     // Run the type checker to ensure we are up to date
-    if (frontend.isDirty(moduleName))
-    {
-        // TODO: expressiveTypes - remove "forAutocomplete" once the types have been fixed
-        Luau::FrontendOptions frontendOpts{true, true};
-        frontend.check(moduleName, frontendOpts);
-    }
+    checkStrict(moduleName);
 
     auto sourceModule = frontend.getSourceModule(moduleName);
     // TODO: fix "forAutocomplete"

--- a/src/operations/Hover.cpp
+++ b/src/operations/Hover.cpp
@@ -28,8 +28,7 @@ std::optional<lsp::Hover> WorkspaceFolder::hover(const lsp::HoverParams& params)
 
     // Run the type checker to ensure we are up to date
     // TODO: expressiveTypes - remove "forAutocomplete" once the types have been fixed
-    Luau::FrontendOptions frontendOpts{/* retainFullTypeGraphs: */ true, /* forAutocomplete: */ config.hover.strictDatamodelTypes};
-    frontend.check(moduleName, frontendOpts);
+    checkStrict(moduleName, /* forAutocomplete: */ config.hover.strictDatamodelTypes);
 
     auto sourceModule = frontend.getSourceModule(moduleName);
     auto module = config.hover.strictDatamodelTypes ? frontend.moduleResolverForAutocomplete.getModule(moduleName)

--- a/src/operations/InlayHints.cpp
+++ b/src/operations/InlayHints.cpp
@@ -294,7 +294,7 @@ lsp::InlayHintResult WorkspaceFolder::inlayHint(const lsp::InlayHintParams& para
     std::vector<lsp::DocumentLink> result{};
 
     // TODO: expressiveTypes - remove "forAutocomplete" once the types have been fixed
-    frontend.check(moduleName, Luau::FrontendOptions{/* retainFullTypeGraphs: */ true, /* forAutocomplete: */ config.hover.strictDatamodelTypes});
+    checkStrict(moduleName, /* forAutocomplete: */ config.hover.strictDatamodelTypes);
 
     auto sourceModule = frontend.getSourceModule(moduleName);
     auto module = config.hover.strictDatamodelTypes ? frontend.moduleResolverForAutocomplete.getModule(moduleName)

--- a/src/operations/References.cpp
+++ b/src/operations/References.cpp
@@ -71,6 +71,8 @@ std::vector<Reference> WorkspaceFolder::findAllReferences(Luau::TypeId ty, std::
     // For every module, search for its referencing
     for (const auto& moduleName : dependents)
     {
+        // Run the typechecker over the dependency modules
+        checkStrict(moduleName);
         auto module = frontend.moduleResolverForAutocomplete.getModule(moduleName);
         if (!module)
             continue;
@@ -134,6 +136,7 @@ std::vector<Reference> WorkspaceFolder::findAllTypeReferences(const Luau::Module
         result.emplace_back(Reference{moduleName, location});
 
     // Find the actual declaration location
+    checkStrict(moduleName);
     auto module = frontend.moduleResolverForAutocomplete.getModule(moduleName);
     if (!module)
         return {};
@@ -150,6 +153,8 @@ std::vector<Reference> WorkspaceFolder::findAllTypeReferences(const Luau::Module
         if (dependencyModuleName == moduleName)
             continue;
 
+        // Run the typechecker over the dependency module
+        checkStrict(dependencyModuleName);
         auto sourceModule = frontend.getSourceModule(dependencyModuleName);
         auto module = frontend.moduleResolverForAutocomplete.getModule(dependencyModuleName);
         if (sourceModule)
@@ -217,7 +222,7 @@ lsp::ReferenceResult WorkspaceFolder::references(const lsp::ReferenceParams& par
 
     // Run the type checker to ensure we are up to date
     // We check for autocomplete here since autocomplete has stricter types
-    frontend.check(moduleName, Luau::FrontendOptions{/* retainFullTypeGraphs: */ true, /* forAutocomplete: */ true});
+    checkStrict(moduleName);
 
     auto sourceModule = frontend.getSourceModule(moduleName);
     if (!sourceModule)

--- a/src/operations/References.cpp
+++ b/src/operations/References.cpp
@@ -112,10 +112,16 @@ std::vector<Reference> WorkspaceFolder::findAllReferences(Luau::TypeId ty, std::
         }
     }
 
-    // If its a property, include its original declaration location
+    // If its a property, include its original declaration location if not yet found
     if (property)
+    {
         if (auto prop = lookupProp(ty, *property); prop && prop->location)
-            references.push_back(Reference{ttv->definitionModuleName, prop->location.value()});
+        {
+            auto reference = Reference{ttv->definitionModuleName, prop->location.value()};
+            if (!contains(references, reference))
+                references.push_back(reference);
+        }
+    }
 
     return references;
 }

--- a/src/operations/Rename.cpp
+++ b/src/operations/Rename.cpp
@@ -61,7 +61,7 @@ lsp::RenameResult WorkspaceFolder::rename(const lsp::RenameParams& params)
 
     // Run the type checker to ensure we are up to date
     // We check for autocomplete here since autocomplete has stricter types
-    frontend.check(moduleName, Luau::FrontendOptions{/* retainFullTypeGraphs: */ true, /* forAutocomplete: */ true});
+    checkStrict(moduleName);
 
     auto sourceModule = frontend.getSourceModule(moduleName);
     if (!sourceModule)

--- a/src/operations/SemanticTokens.cpp
+++ b/src/operations/SemanticTokens.cpp
@@ -399,11 +399,11 @@ std::optional<lsp::SemanticTokens> WorkspaceFolder::semanticTokens(const lsp::Se
         throw JsonRpcException(lsp::ErrorCode::RequestFailed, "No managed text document for " + params.textDocument.uri.toString());
 
     // Run the type checker to ensure we are up to date
-    if (frontend.isDirty(moduleName))
-        frontend.check(moduleName);
+    // TODO: this relies on the autocomplete typechecker, which we don't really need for semantic tokens
+    checkStrict(moduleName);
 
     auto sourceModule = frontend.getSourceModule(moduleName);
-    auto module = frontend.moduleResolver.getModule(moduleName);
+    auto module = frontend.moduleResolverForAutocomplete.getModule(moduleName);
     if (!sourceModule || !module)
         return std::nullopt;
 

--- a/src/operations/SignatureHelp.cpp
+++ b/src/operations/SignatureHelp.cpp
@@ -20,8 +20,7 @@ std::optional<lsp::SignatureHelp> WorkspaceFolder::signatureHelp(const lsp::Sign
 
     // Run the type checker to ensure we are up to date
     // TODO: expressiveTypes - remove "forAutocomplete" once the types have been fixed
-    Luau::FrontendOptions frontendOpts{true, true};
-    frontend.check(moduleName, frontendOpts);
+    checkStrict(moduleName);
 
     auto sourceModule = frontend.getSourceModule(moduleName);
     if (!sourceModule)

--- a/src/operations/WorkspaceSymbol.cpp
+++ b/src/operations/WorkspaceSymbol.cpp
@@ -108,8 +108,7 @@ std::optional<std::vector<lsp::WorkspaceSymbol>> WorkspaceFolder::workspaceSymbo
 
     for (const auto& [moduleName, sourceModule] : frontend.sourceModules)
     {
-        if (frontend.isDirty(moduleName))
-            frontend.check(moduleName);
+        checkSimple(moduleName);
 
         // Find relevant text document
         if (auto textDocument = fileResolver.getTextDocumentFromModuleName(moduleName))


### PR DESCRIPTION
Right now we retain all type graphs all the time, for both diagnostics and autocomplete typecheckers.
This causes *a lot* of types to be stored. For a standard sample workspace, I hit over 2GB of memory used. For a more complex workspace, this can increase several times further.

We update this by being more clever about retaining type graphs. We only retain type graphs if we later require the type information to power a Language Server feature. For example, when we indexed the whole workspace, we don't actually care about the types, but just about the require graph. In this case, we discard the type graph, and lazily compute the retain type graph in the actual Find All References operation. Similarly, workspace diagnostics does not require the type graph at all.

This leads to a significant memory improvement, from 2GB -> 100MB!