### PR TITLE
Fix bulk CFrame operation types

### DIFF
--- a/scripts/dumpRobloxTypes.py
+++ b/scripts/dumpRobloxTypes.py
@@ -202,6 +202,14 @@ IGNORED_MEMBERS = {
         "Part0",
         "Part1",
     ],
+    "CFrame": [
+        "PointToObjectSpace",
+        "PointToWorldSpace",
+        "ToObjectSpace",
+        "ToWorldSpace",
+        "VectorToObjectSpace",
+        "VectorToWorldSpace",
+    ]
 }
 
 # Extra members to add in to classes, commonly used to add in metamethods, and add corrections

--- a/scripts/dumpRobloxTypes.py
+++ b/scripts/dumpRobloxTypes.py
@@ -250,6 +250,12 @@ EXTRA_MEMBERS = {
         "function __sub(self, other: Vector3): CFrame",
         "function __mul(self, other: CFrame): CFrame",
         "function __mul(self, other: Vector3): Vector3",
+        "function PointToObjectSpace(self, ...: Vector3): ...Vector3",
+        "function PointToWorldSpace(self, ...: Vector3): ...Vector3",
+        "function ToObjectSpace(self, ...: CFrame): ...CFrame",
+        "function ToWorldSpace(self, ...: CFrame): ...CFrame",
+        "function VectorToObjectSpace(self, ...: Vector3): ...Vector3",
+        "function VectorToWorldSpace(self, ...: Vector3): ...Vector3",
     ],
     "UserSettings": [
         "GameSettings: UserGameSettings",

--- a/scripts/globalTypes.d.lua
+++ b/scripts/globalTypes.d.lua
@@ -3890,15 +3890,21 @@ declare class CFrame
 	function Inverse(self): CFrame
 	function Lerp(self, goal: CFrame, alpha: number): CFrame
 	function Orthonormalize(self): CFrame
+	function PointToObjectSpace(self, ...: Vector3): ...Vector3
 	function PointToObjectSpace(self, v3: Vector3): Vector3
+	function PointToWorldSpace(self, ...: Vector3): ...Vector3
 	function PointToWorldSpace(self, v3: Vector3): Vector3
 	function ToAxisAngle(self): (Vector3, number)
 	function ToEulerAnglesXYZ(self): (number, number, number)
 	function ToEulerAnglesYXZ(self): (number, number, number)
+	function ToObjectSpace(self, ...: CFrame): ...CFrame
 	function ToObjectSpace(self, cf: CFrame): CFrame
 	function ToOrientation(self): (number, number, number)
+	function ToWorldSpace(self, ...: CFrame): ...CFrame
 	function ToWorldSpace(self, cf: CFrame): CFrame
+	function VectorToObjectSpace(self, ...: Vector3): ...Vector3
 	function VectorToObjectSpace(self, v3: Vector3): Vector3
+	function VectorToWorldSpace(self, ...: Vector3): ...Vector3
 	function VectorToWorldSpace(self, v3: Vector3): Vector3
 	function __add(self, other: Vector3): CFrame
 	function __mul(self, other: CFrame): CFrame

--- a/scripts/globalTypes.d.lua
+++ b/scripts/globalTypes.d.lua
@@ -3891,21 +3891,15 @@ declare class CFrame
 	function Lerp(self, goal: CFrame, alpha: number): CFrame
 	function Orthonormalize(self): CFrame
 	function PointToObjectSpace(self, ...: Vector3): ...Vector3
-	function PointToObjectSpace(self, v3: Vector3): Vector3
 	function PointToWorldSpace(self, ...: Vector3): ...Vector3
-	function PointToWorldSpace(self, v3: Vector3): Vector3
 	function ToAxisAngle(self): (Vector3, number)
 	function ToEulerAnglesXYZ(self): (number, number, number)
 	function ToEulerAnglesYXZ(self): (number, number, number)
 	function ToObjectSpace(self, ...: CFrame): ...CFrame
-	function ToObjectSpace(self, cf: CFrame): CFrame
 	function ToOrientation(self): (number, number, number)
 	function ToWorldSpace(self, ...: CFrame): ...CFrame
-	function ToWorldSpace(self, cf: CFrame): CFrame
 	function VectorToObjectSpace(self, ...: Vector3): ...Vector3
-	function VectorToObjectSpace(self, v3: Vector3): Vector3
 	function VectorToWorldSpace(self, ...: Vector3): ...Vector3
-	function VectorToWorldSpace(self, v3: Vector3): Vector3
 	function __add(self, other: Vector3): CFrame
 	function __mul(self, other: CFrame): CFrame
 	function __mul(self, other: Vector3): Vector3


### PR DESCRIPTION
```lua
--!strict
local a = CFrame.new()
local b = Vector3.new()
print(a:PointToObjectSpace(b, b))
print(a:PointToWorldSpace(b, b))
print(a:ToObjectSpace(a, a))
print(a:ToWorldSpace(a, a))
print(a:VectorToObjectSpace(b, b))
print(a:VectorToWorldSpace(b, b))
```