### PR TITLE
Add paragraph break in generated documentation to ensure correct parsing

### DIFF
--- a/src/DocumentationParser.cpp
+++ b/src/DocumentationParser.cpp
@@ -197,7 +197,7 @@ std::string printMoonwaveDocumentation(const std::vector<std::string>& comments)
 
     if (!params.empty())
     {
-        result += "\n\n**Parameters**";
+        result += "\n\n**Parameters**\n";
         for (auto& param : params)
         {
             auto paramText = param.substr(7);
@@ -219,7 +219,7 @@ std::string printMoonwaveDocumentation(const std::vector<std::string>& comments)
 
     if (!returns.empty())
     {
-        result += "\n\n**Returns**";
+        result += "\n\n**Returns**\n";
         for (auto& ret : returns)
         {
             auto returnText = ret.substr(8);
@@ -241,7 +241,7 @@ std::string printMoonwaveDocumentation(const std::vector<std::string>& comments)
 
     if (!throws.empty())
     {
-        result += "\n\n**Throws**";
+        result += "\n\n**Throws**\n";
         for (auto& thr : throws)
         {
             auto throwText = thr.substr(7);

--- a/tests/Documentation.test.cpp
+++ b/tests/Documentation.test.cpp
@@ -399,9 +399,9 @@ TEST_CASE_FIXTURE(Fixture, "print_moonwave_documentation")
     auto documentation = printMoonwaveDocumentation(comments);
 
     CHECK_EQ(documentation, "Adds 5 to the input number\n"
-                            "\n\n**Parameters**"
+                            "\n\n**Parameters**\n"
                             "\n- `x` number -- Input number"
-                            "\n\n**Returns**"
+                            "\n\n**Returns**\n"
                             "\n- number");
 }
 
@@ -430,11 +430,11 @@ TEST_CASE_FIXTURE(Fixture, "print_throws_info")
     auto documentation = printMoonwaveDocumentation(comments);
 
     CHECK_EQ(documentation, "Adds 5 to the input number\n"
-                            "\n\n**Parameters**"
+                            "\n\n**Parameters**\n"
                             "\n- `x` number -- Input number"
-                            "\n\n**Returns**"
+                            "\n\n**Returns**\n"
                             "\n- number"
-                            "\n\n**Throws**"
+                            "\n\n**Throws**\n"
                             "\n- `NotANumber` -- Input is not a number");
 }
 
@@ -463,7 +463,7 @@ TEST_CASE_FIXTURE(Fixture, "ignored_tags")
     auto documentation = printMoonwaveDocumentation(comments);
 
     CHECK_EQ(documentation, "Adds 5 to the input number\n"
-                            "\n\n**Parameters**"
+                            "\n\n**Parameters**\n"
                             "\n- `x` number -- Testing");
 }
 


### PR DESCRIPTION
Some Markdown parsers require an explicit paragraph break between a list block and the previous block. Sublime's LSP appears to be one of them.

No explicit break:

```markdown
**Parameters**
- `foo`  Description of foo.
- `bar`  Description of bar.
```

Explicit break:

```markdown
**Parameters**

- `foo`  Description of foo.
- `bar`  Description of bar.
```

This change adds a single newline after each section header to create the paragraph break necessary for list blocks to be interpreted correctly. Markdown parsers that do not require this paragraph break should continue parse normally.