### PR TITLE
Handle renaming generic type parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ type Foo = {
 - Sync to upstream Luau 0.602
 - Overhauled command line argument parsing system to be more consistent and flexible
 
+### Fixed
+
+- Attempting to rename a generic type parameter now correctly renames it in all locations
+
 ## [1.25.0] - 2023-10-14
 
 ### Changed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,7 @@ target_sources(Luau.LanguageServer.Test PRIVATE
         tests/SemanticTokens.test.cpp
         tests/Sourcemap.test.cpp
         tests/References.test.cpp
+        tests/Rename.test.cpp
         tests/ColorProvider.test.cpp
         tests/LuauExt.test.cpp
         tests/CliConfigurationParser.test.cpp

--- a/src/include/Protocol/Structures.hpp
+++ b/src/include/Protocol/Structures.hpp
@@ -83,7 +83,7 @@ struct Range
     Position start;
     Position end;
 
-    bool operator==(const Range& other)
+    bool operator==(const Range& other) const
     {
         return start == other.start && end == other.end;
     }

--- a/src/operations/Rename.cpp
+++ b/src/operations/Rename.cpp
@@ -39,6 +39,178 @@ static void processReferences(
     }
 }
 
+static void buildResult(
+    lsp::WorkspaceEdit& result, const std::string& newName, const std::vector<Luau::Location>& locations, const TextDocument* textDocument)
+{
+    if (!contains(result.changes, textDocument->uri().toString()))
+        result.changes.insert_or_assign(textDocument->uri().toString(), std::vector<lsp::TextEdit>{});
+
+    for (const auto& location : locations)
+        result.changes.at(textDocument->uri().toString())
+            .emplace_back(lsp::TextEdit{{textDocument->convertPosition(location.begin), textDocument->convertPosition(location.end)}, newName});
+}
+
+class FindTypeParameterUsages : public Luau::AstVisitor
+{
+    Luau::AstName name;
+    bool initialNode = true;
+
+    bool visit(class Luau::AstType* node) override
+    {
+        return true;
+    }
+
+    bool visit(class Luau::AstTypeReference* node) override
+    {
+        if (node->name == name)
+            result.emplace_back(node->nameLocation);
+        initialNode = false;
+        return true;
+    }
+
+    bool visit(class Luau::AstTypeFunction* node) override
+    {
+        // Check to see the type parameter has not been redefined
+        for (auto t : node->generics)
+        {
+            if (t.name == name)
+            {
+                if (initialNode)
+                    result.emplace_back(t.location);
+                else
+                    return false;
+            }
+        }
+        for (auto t : node->genericPacks)
+        {
+            if (t.name == name)
+            {
+                if (initialNode)
+                    result.emplace_back(t.location);
+                else
+                    return false;
+            }
+        }
+        initialNode = false;
+        return true;
+    }
+
+    bool visit(class Luau::AstTypePack* node) override
+    {
+        return true;
+    }
+
+    bool visit(class Luau::AstTypePackGeneric* node) override
+    {
+        if (node->genericName == name)
+            // node location also consists of the three dots "...", so we need to remove them
+            result.emplace_back(Luau::Location{node->location.begin, {node->location.end.line, node->location.end.column - 3}});
+        initialNode = false;
+        return true;
+    }
+
+    bool visit(class Luau::AstStatTypeAlias* node) override
+    {
+        for (auto t : node->generics)
+            if (t.name == name)
+                result.emplace_back(t.location);
+        for (auto t : node->genericPacks)
+            if (t.name == name)
+                result.emplace_back(t.location);
+        initialNode = false;
+        return true;
+    }
+
+    bool visit(class Luau::AstExprFunction* node) override
+    {
+        for (auto t : node->generics)
+            if (t.name == name)
+                result.emplace_back(t.location);
+        for (auto t : node->genericPacks)
+            if (t.name == name)
+                result.emplace_back(t.location);
+        initialNode = false;
+        return true;
+    }
+
+public:
+    FindTypeParameterUsages(Luau::AstName name)
+        : name(name)
+    {
+    }
+    std::vector<Luau::Location> result;
+};
+
+
+// Determines whether the name matches a type reference in one of the provided generics
+// If so, we find the usages inside of that node and construct the rename list
+bool handleIfTypeReferenceByName(Luau::AstNode* node, Luau::AstArray<Luau::AstGenericType> generics,
+    Luau::AstArray<Luau::AstGenericTypePack> genericPacks, Luau::AstName name, lsp::WorkspaceEdit& result, const std::string& newName,
+    const TextDocument* textDocument)
+{
+    bool isTypeReference = false;
+    for (const auto t : generics)
+    {
+        if (t.name == name)
+        {
+            isTypeReference = true;
+            break;
+        }
+    }
+    for (const auto t : genericPacks)
+    {
+        if (t.name == name)
+        {
+            isTypeReference = true;
+            break;
+        }
+    }
+    if (!isTypeReference)
+        return false;
+
+    FindTypeParameterUsages visitor(name);
+    node->visit(&visitor);
+    buildResult(result, newName, visitor.result, textDocument);
+
+    return true;
+}
+
+// Determines whether the name matches a type reference in one of the provided generics
+// If so, we find the usages inside of that node and construct the rename list
+bool handleIfTypeReferenceByPosition(Luau::AstNode* node, Luau::AstArray<Luau::AstGenericType> generics,
+    Luau::AstArray<Luau::AstGenericTypePack> genericPacks, Luau::Position position, lsp::WorkspaceEdit& result, const std::string& newName,
+    const TextDocument* textDocument)
+{
+    Luau::AstName name;
+    bool isTypeReference = false;
+    for (const auto t : generics)
+    {
+        if (t.location.containsClosed(position))
+        {
+            name = t.name;
+            isTypeReference = true;
+            break;
+        }
+    }
+    for (const auto t : genericPacks)
+    {
+        if (t.location.containsClosed(position))
+        {
+            name = t.name;
+            isTypeReference = true;
+            break;
+        }
+    }
+    if (!isTypeReference)
+        return false;
+
+    FindTypeParameterUsages visitor(name);
+    node->visit(&visitor);
+    buildResult(result, newName, visitor.result, textDocument);
+
+    return true;
+}
+
 lsp::RenameResult WorkspaceFolder::rename(const lsp::RenameParams& params)
 {
     // Verify the new name is valid (is an identifier)
@@ -119,6 +291,13 @@ lsp::RenameResult WorkspaceFolder::rename(const lsp::RenameParams& params)
 
     if (auto typeDefinition = node->as<Luau::AstStatTypeAlias>())
     {
+        // Check to see whether the position was actually the type parameter: "S" in `type State<S> = ...`
+        if (handleIfTypeReferenceByPosition(
+                typeDefinition, typeDefinition->generics, typeDefinition->genericPacks, position, result, params.newName, textDocument))
+        {
+            return result;
+        }
+
         if (typeDefinition->exported)
         {
             // Type may potentially be used in other files, so we need to handle this globally
@@ -162,6 +341,36 @@ lsp::RenameResult WorkspaceFolder::rename(const lsp::RenameParams& params)
         }
         else
         {
+            // This could potentially be a generic type - so we want to rename that if so.
+            auto ancestry = Luau::findAstAncestryOfPosition(*sourceModule, position, /* includeTypes= */ true);
+            for (auto it = ancestry.rbegin(); it != ancestry.rend(); ++it)
+            {
+                if (auto typeAlias = (*it)->as<Luau::AstStatTypeAlias>())
+                {
+                    if (handleIfTypeReferenceByName(
+                            typeAlias, typeAlias->generics, typeAlias->genericPacks, reference->name, result, params.newName, textDocument))
+                        return result;
+                    break;
+                }
+                else if (auto typeFunction = (*it)->as<Luau::AstTypeFunction>())
+                {
+                    if (handleIfTypeReferenceByName(
+                            typeFunction, typeFunction->generics, typeFunction->genericPacks, reference->name, result, params.newName, textDocument))
+                        return result;
+                }
+                else if (auto func = (*it)->as<Luau::AstExprFunction>())
+                {
+                    if (handleIfTypeReferenceByName(func, func->generics, func->genericPacks, reference->name, result, params.newName, textDocument))
+                        return result;
+                    break;
+                }
+                else if (!(*it)->asType())
+                {
+                    // No longer inside a type, so no point going further
+                    break;
+                }
+            }
+
             std::vector<lsp::TextEdit> localChanges{};
             auto references = findTypeReferences(*sourceModule, reference->name.value, std::nullopt);
             localChanges.reserve(references.size() + 1);
@@ -186,6 +395,21 @@ lsp::RenameResult WorkspaceFolder::rename(const lsp::RenameParams& params)
 
             result.changes.insert_or_assign(params.textDocument.uri.toString(), localChanges);
 
+            return result;
+        }
+    }
+    else if (auto typeFunction = node->as<Luau::AstTypeFunction>())
+    {
+        if (handleIfTypeReferenceByPosition(
+                typeFunction, typeFunction->generics, typeFunction->genericPacks, position, result, params.newName, textDocument))
+        {
+            return result;
+        }
+    }
+    else if (auto func = node->as<Luau::AstExprFunction>())
+    {
+        if (handleIfTypeReferenceByPosition(func, func->generics, func->genericPacks, position, result, params.newName, textDocument))
+        {
             return result;
         }
     }

--- a/tests/Fixture.cpp
+++ b/tests/Fixture.cpp
@@ -117,10 +117,11 @@ Luau::ModuleName fromString(std::string_view name)
     return Luau::ModuleName(name);
 }
 
-void Fixture::newDocument(const std::string& name, const std::string& source)
+Uri Fixture::newDocument(const std::string& name, const std::string& source)
 {
     Uri uri("file", "", name);
     workspace.openTextDocument(uri, {{uri, "luau", 0, source}});
+    return uri;
 }
 
 Luau::AstStatBlock* Fixture::parse(const std::string& source, const Luau::ParseOptions& parseOptions)

--- a/tests/Fixture.h
+++ b/tests/Fixture.h
@@ -31,7 +31,7 @@ struct Fixture
     explicit Fixture();
     ~Fixture();
 
-    void newDocument(const std::string& name, const std::string& source);
+    Uri newDocument(const std::string& name, const std::string& source);
 
     Luau::AstStatBlock* parse(const std::string& source, const Luau::ParseOptions& parseOptions = {});
     Luau::LoadDefinitionFileResult loadDefinition(const std::string& source);

--- a/tests/Rename.test.cpp
+++ b/tests/Rename.test.cpp
@@ -1,0 +1,235 @@
+#include "doctest.h"
+#include "Fixture.h"
+
+static std::string applyEdit(const std::string& source, const std::vector<lsp::TextEdit>& edits)
+{
+    std::string newSource;
+
+    lsp::Position currentPos{0, 0};
+    std::optional<lsp::Position> editEndPos = std::nullopt;
+    for (const auto& c : source)
+    {
+        if (c == '\n')
+        {
+            currentPos.line += 1;
+            currentPos.character = 0;
+        }
+        else
+        {
+            currentPos.character += 1;
+        }
+
+        if (editEndPos)
+        {
+            if (currentPos == *editEndPos)
+                editEndPos = std::nullopt;
+        }
+        else
+            newSource += c;
+
+        for (const auto& edit : edits)
+        {
+            if (currentPos == edit.range.start)
+            {
+                newSource += edit.newText;
+                editEndPos = edit.range.end;
+            }
+        }
+    }
+
+    return newSource;
+}
+
+TEST_SUITE_BEGIN("Rename");
+
+TEST_CASE_FIXTURE(Fixture, "rename_generic_type_parameter")
+{
+    // https://github.com/JohnnyMorganz/luau-lsp/issues/488
+    // Renaming: "S" inside of <S>
+
+    auto source = R"(
+        type LayerBuilder<S> = S & { ... }
+    )";
+
+    auto uri = newDocument("foo.luau", source);
+
+    lsp::RenameParams params;
+    params.textDocument = lsp::TextDocumentIdentifier{uri};
+    params.position = lsp::Position{1, 26};
+    params.newName = "State";
+
+    auto result = workspace.rename(params);
+    REQUIRE(result);
+    REQUIRE(result->changes.size() == 1);
+
+    auto documentEdits = result->changes.begin()->second;
+    CHECK(applyEdit(source, documentEdits) == R"(
+        type LayerBuilder<State> = State & { ... }
+    )");
+}
+
+TEST_CASE_FIXTURE(Fixture, "rename_generic_type_parameter_used_inside_of_type_alias")
+{
+    // https://github.com/JohnnyMorganz/luau-lsp/issues/488
+    // Renaming: "S" inside of assignment `S & { ... }`
+
+    auto source = R"(
+        type LayerBuilder<S> = S & { ... }
+    )";
+
+    auto uri = newDocument("foo.luau", source);
+
+    lsp::RenameParams params;
+    params.textDocument = lsp::TextDocumentIdentifier{uri};
+    params.position = lsp::Position{1, 31};
+    params.newName = "State";
+
+    auto result = workspace.rename(params);
+    REQUIRE(result);
+    REQUIRE(result->changes.size() == 1);
+
+    auto documentEdits = result->changes.begin()->second;
+    CHECK_EQ(applyEdit(source, documentEdits), R"(
+        type LayerBuilder<State> = State & { ... }
+    )");
+}
+
+TEST_CASE_FIXTURE(Fixture, "rename_generic_type_parameter_used_as_another_generic")
+{
+    auto source = R"(
+        type Baz<S...> = Bar<S...>
+    )";
+
+    auto uri = newDocument("foo.luau", source);
+
+    lsp::RenameParams params;
+    params.textDocument = lsp::TextDocumentIdentifier{uri};
+    params.position = lsp::Position{1, 17};
+    params.newName = "State";
+
+    auto result = workspace.rename(params);
+    REQUIRE(result);
+    REQUIRE(result->changes.size() == 1);
+
+    auto documentEdits = result->changes.begin()->second;
+    CHECK_EQ(applyEdit(source, documentEdits), R"(
+        type Baz<State...> = Bar<State...>
+    )");
+}
+
+TEST_CASE_FIXTURE(Fixture, "rename_generic_type_parameter_in_function_definition")
+{
+    auto source = R"(
+        function foo<T>(x: T, y: string)
+        end
+    )";
+
+    auto uri = newDocument("foo.luau", source);
+
+    lsp::RenameParams params;
+    params.textDocument = lsp::TextDocumentIdentifier{uri};
+    params.position = lsp::Position{1, 21};
+    params.newName = "Value";
+
+    auto result = workspace.rename(params);
+    REQUIRE(result);
+    REQUIRE(result->changes.size() == 1);
+
+    auto documentEdits = result->changes.begin()->second;
+    CHECK_EQ(applyEdit(source, documentEdits), R"(
+        function foo<Value>(x: Value, y: string)
+        end
+    )");
+}
+
+TEST_CASE_FIXTURE(Fixture, "rename_generic_type_correctly_handle_shadowing_1")
+{
+    // Renaming "T" in Foo<T>
+    auto source = R"(
+        type Foo<T> = {
+            x: T,
+            fn: <T>(T, T) -> T
+        }
+    )";
+
+    auto uri = newDocument("foo.luau", source);
+
+    lsp::RenameParams params;
+    params.textDocument = lsp::TextDocumentIdentifier{uri};
+    params.position = lsp::Position{2, 15};
+    params.newName = "Value";
+
+    auto result = workspace.rename(params);
+    REQUIRE(result);
+    REQUIRE(result->changes.size() == 1);
+
+    auto documentEdits = result->changes.begin()->second;
+    CHECK_EQ(applyEdit(source, documentEdits), R"(
+        type Foo<Value> = {
+            x: Value,
+            fn: <T>(T, T) -> T
+        }
+    )");
+}
+
+TEST_CASE_FIXTURE(Fixture, "rename_generic_type_correctly_handle_shadowing_2")
+{
+    // Renaming first "T" in <T>(T, T) -> T
+    auto source = R"(
+        type Foo<T> = {
+            x: T,
+            fn: <T>(T, T) -> T
+        }
+    )";
+
+    auto uri = newDocument("foo.luau", source);
+
+    lsp::RenameParams params;
+    params.textDocument = lsp::TextDocumentIdentifier{uri};
+    params.position = lsp::Position{3, 17};
+    params.newName = "Value";
+
+    auto result = workspace.rename(params);
+    REQUIRE(result);
+    REQUIRE(result->changes.size() == 1);
+
+    auto documentEdits = result->changes.begin()->second;
+    CHECK_EQ(applyEdit(source, documentEdits), R"(
+        type Foo<T> = {
+            x: T,
+            fn: <Value>(Value, Value) -> Value
+        }
+    )");
+}
+
+TEST_CASE_FIXTURE(Fixture, "rename_generic_type_correctly_handle_shadowing_3")
+{
+    // Renaming second "T" in <T>(T, T) -> T
+    auto source = R"(
+        type Foo<T> = {
+            x: T,
+            fn: <T>(T, T) -> T
+        }
+    )";
+
+    auto uri = newDocument("foo.luau", source);
+
+    lsp::RenameParams params;
+    params.textDocument = lsp::TextDocumentIdentifier{uri};
+    params.position = lsp::Position{3, 20};
+    params.newName = "Value";
+
+    auto result = workspace.rename(params);
+    REQUIRE(result);
+    REQUIRE(result->changes.size() == 1);
+
+    auto documentEdits = result->changes.begin()->second;
+    CHECK_EQ(applyEdit(source, documentEdits), R"(
+        type Foo<T> = {
+            x: T,
+            fn: <Value>(Value, Value) -> Value
+        }
+    )");
+}
+
+TEST_SUITE_END();


### PR DESCRIPTION
Fixes #488 and some other test cases

A generic type parameter can be defined in three locations:
- A type alias definition `type Foo<S> = ...`
- A type function `<T>(T) -> T`
- A function expression `function foo<T>(x: T)`

We handle renaming type parameters in these cases.
To do so, we check to see whether the provided position is within one of the relevant spots, and if so, use a visitor to find all usages of the type parameter.

A type parameter can also be shadowed in one way in particular: a type function embedded inside of a type alias definition / function expression. We handle this case as well.

There is a special case when the node found to be renamed is a `AstTypeReference` - in this case, we compute the Ast ancestry to find the top level where the generic type was defined.