### PR TITLE
Support documentation in definition files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Changed the VSCode registered language and grammar ID from `lua` to `luau`. **NOTE:** this may affect existing custom themes!
 - Renamed `script/globalTypes.d.lua` to `script/globalTypes.d.luau` (the old file will be kept temporarily for compatibility)
 - Default security level of API types changed from `RobloxScriptSecurity` to `PluginSecurity` - set `luau-lsp.types.robloxSecurityLevel` to `RobloxScriptSecurity` to see original behaviour
+- Definitions files must now provide a name for the file in settings and command line: `--definitions:@roblox=path/to/globalTypes.d.luau`. Please update your LSP settings and command line arguments. Backwards compatibility has been temporarily preserved, with random names generated.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - Added configuration `luau-lsp.bytecode.vectorLib`, `luau-lsp.bytecode.vectorCtor` and `luau-lsp.bytecode.vectorType` to configure compiler options when generating bytecode
   - Custom editors should handle the `luau-lsp/bytecode` and `luau-lsp/compilerRemarks` LSP message to integrate compiler remarks info in their editor
 - Added `luau-lsp.types.robloxSecurityLevel` to select what security level to use for the API types, out of: `None`, `LocalUserSecurity`, `PluginSecurity` and `RobloxScriptSecurity`
+- Added support for documentation in definitions files
 
 ### Changed
 

--- a/editors/README.md
+++ b/editors/README.md
@@ -25,11 +25,11 @@ $ luau-lsp --help
 
 ## Configuring Definitions and Documentation
 
-You can add in built-in definitions by passing the `--definitions=PATH` argument.
+You can add in built-in definitions by passing the `--definitions:@name=PATH` argument. The `name` should be a unique reference to the definitions file.
 This can be done multiple times:
 
 ```sh
-$ luau-lsp lsp --definitions=/path/to/globalTypes.d.luau
+$ luau-lsp lsp --definitions:@roblox=/path/to/globalTypes.d.luau
 ```
 
 > NOTE: Definitions file syntax is unstable and undocumented. It may change at any time

--- a/src/AnalyzeCli.cpp
+++ b/src/AnalyzeCli.cpp
@@ -144,7 +144,7 @@ int startAnalyze(const argparse::ArgumentParser& program)
     ReportFormat format = ReportFormat::Default;
     bool annotate = program.is_used("--annotate");
     auto sourcemapPath = program.present<std::filesystem::path>("--sourcemap");
-    auto definitionsPaths = program.get<std::vector<std::filesystem::path>>("--definitions");
+    auto definitionsPaths = processDefinitionsFilePaths(program);
     auto ignoreGlobPatterns = program.get<std::vector<std::string>>("--ignore");
     auto baseLuaurc = program.present<std::filesystem::path>("--base-luaurc");
     auto settingsPath = program.present<std::filesystem::path>("--settings");
@@ -293,7 +293,7 @@ int startAnalyze(const argparse::ArgumentParser& program)
     Luau::registerBuiltinGlobals(frontend, frontend.globals, /* typeCheckForAutocomplete = */ false);
     Luau::registerBuiltinGlobals(frontend, frontend.globalsForAutocomplete, /* typeCheckForAutocomplete = */ true);
 
-    for (auto& definitionsPath : definitionsPaths)
+    for (auto& [packageName, definitionsPath] : definitionsPaths)
     {
         if (!std::filesystem::exists(definitionsPath))
         {
@@ -308,8 +308,8 @@ int startAnalyze(const argparse::ArgumentParser& program)
             return 1;
         }
 
-        auto loadResult = types::registerDefinitions(frontend, frontend.globals, *definitionsContents, /* typeCheckForAutocomplete = */ false,
-            types::parseDefinitionsFileMetadata(*definitionsContents));
+        auto loadResult = types::registerDefinitions(frontend, frontend.globals, packageName, *definitionsContents,
+            /* typeCheckForAutocomplete = */ false, types::parseDefinitionsFileMetadata(*definitionsContents));
         if (!loadResult.success)
         {
             fprintf(stderr, "Failed to load definitions\n");

--- a/src/include/Analyze/AnalyzeCli.hpp
+++ b/src/include/Analyze/AnalyzeCli.hpp
@@ -1,7 +1,9 @@
 #pragma once
 #include <unordered_map>
 #include <string>
+#include <filesystem>
 #include "argparse/argparse.hpp"
 
 void registerFastFlags(std::unordered_map<std::string, std::string>& fastFlags);
+std::unordered_map<std::string, std::filesystem::path> processDefinitionsFilePaths(const argparse::ArgumentParser& program);
 int startAnalyze(const argparse::ArgumentParser& program);

--- a/src/include/LSP/Client.hpp
+++ b/src/include/LSP/Client.hpp
@@ -29,7 +29,7 @@ public:
     lsp::ClientCapabilities capabilities;
     lsp::TraceValue traceMode = lsp::TraceValue::Off;
     /// A registered definitions file passed by the client
-    std::vector<std::filesystem::path> definitionsFiles{};
+    std::unordered_map<std::string, std::filesystem::path> definitionsFiles{};
     /// A registered documentation file passed by the client
     std::vector<std::filesystem::path> documentationFiles{};
     /// Parsed documentation database

--- a/src/include/LSP/ClientConfiguration.hpp
+++ b/src/include/LSP/ClientConfiguration.hpp
@@ -31,9 +31,10 @@ struct ClientTypesConfiguration
     /// Whether Roblox-related definitions should be supported
     bool roblox = true;
     /// Any definition files to load globally
-    std::vector<std::filesystem::path> definitionFiles{};
+    // TODO: commented out due to backwards compatibility. uncomment if needed later once all settings have converted
+    // std::unordered_map<std::string, std::filesystem::path> definitionFiles{};
 };
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(ClientTypesConfiguration, roblox, definitionFiles);
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(ClientTypesConfiguration, roblox); // definitionFiles
 
 enum struct InlayHintsParameterNamesConfig
 {

--- a/src/include/LSP/LanguageServer.hpp
+++ b/src/include/LSP/LanguageServer.hpp
@@ -32,9 +32,9 @@ private:
     std::vector<WorkspaceFolderPtr> workspaceFolders;
 
 public:
-    explicit LanguageServer(ClientPtr client, std::optional<Luau::Config> defaultConfig)
-        : client(std::move(client))
-        , defaultConfig(std::move(defaultConfig))
+    explicit LanguageServer(ClientPtr aClient, std::optional<Luau::Config> aDefaultConfig)
+        : client(std::move(aClient))
+        , defaultConfig(std::move(aDefaultConfig))
         , nullWorkspace(std::make_shared<WorkspaceFolder>(client, "$NULL_WORKSPACE", Uri(), defaultConfig))
     {
     }

--- a/src/include/LSP/LuauExt.hpp
+++ b/src/include/LSP/LuauExt.hpp
@@ -26,8 +26,8 @@ std::optional<DefinitionsFileMetadata> parseDefinitionsFileMetadata(const std::s
 
 void registerInstanceTypes(Luau::Frontend& frontend, const Luau::GlobalTypes& globals, Luau::TypeArena& arena,
     const WorkspaceFileResolver& fileResolver, bool expressiveTypes);
-Luau::LoadDefinitionFileResult registerDefinitions(Luau::Frontend& frontend, Luau::GlobalTypes& globals, const std::string& definitions,
-    bool typeCheckForAutocomplete = false, std::optional<DefinitionsFileMetadata> metadata = std::nullopt);
+Luau::LoadDefinitionFileResult registerDefinitions(Luau::Frontend& frontend, Luau::GlobalTypes& globals, const std::string& packageName,
+    const std::string& definitions, bool typeCheckForAutocomplete = false, std::optional<DefinitionsFileMetadata> metadata = std::nullopt);
 
 using NameOrExpr = std::variant<std::string, Luau::AstExpr*>;
 

--- a/src/include/LSP/Workspace.hpp
+++ b/src/include/LSP/Workspace.hpp
@@ -24,6 +24,9 @@ struct Reference
 
 class WorkspaceFolder
 {
+private:
+    std::unordered_map<std::string, std::pair<TextDocument, Luau::SourceModule>> definitionsSourceModules;
+
 public:
     std::shared_ptr<Client> client;
     std::string name;


### PR DESCRIPTION
TODO:
- Blocked on https://github.com/luau-lang/luau/pull/1136
- Currently AstStatDeclareFunction doesn't store definitions, this is missing.
- Need a way to handle AstStatDeclareGlobal definitions (globals store a binding which we need to use to get location)
- Update VSCode extension to require package name for documentation files (add backwards compatibility converter from list -> object)
