### PR TITLE
Datatype type fixes

### DIFF
--- a/scripts/Corrections.json
+++ b/scripts/Corrections.json
@@ -1,0 +1,2330 @@
+{
+    "Classes": [
+        {
+            "Members": [
+                {
+                    "Name": "GetDescendants",
+                    "ReturnType": {
+                        "Name": "Objects"
+                    }
+                },
+                {
+                    "Name": "WaitForChild",
+                    "Parameters": [
+                        {
+                            "Name": "timeOut",
+                            "Default": "nil"
+                        }
+                    ]
+                }
+            ],
+            "Name": "Instance"
+        },
+        {
+            "Members": [
+                {
+                    "Name": "LocalPlayer",
+                    "ValueType": {
+                        "Name": "Player"
+                    }
+                },
+                {
+                    "Name": "GetPlayerFromCharacter",
+                    "Parameters": [
+                        {
+                            "Name": "character",
+                            "Type": {
+                                "Name": "Model"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "Player"
+                    }
+                },
+                {
+                    "Name": "GetPlayerByUserId",
+                    "ReturnType": {
+                        "Name": "Player"
+                    }
+                },
+                {
+                    "Name": "GetHumanoidDescriptionFromOutfitId",
+                    "ReturnType": {
+                        "Name": "HumanoidDescription"
+                    }
+                },
+                {
+                    "Name": "GetHumanoidDescriptionFromUserId",
+                    "ReturnType": {
+                        "Name": "HumanoidDescription"
+                    }
+                },
+                {
+                    "Name": "GetFriendsAsync",
+                    "ReturnType": {
+                        "Name": "FriendPages"
+                    }
+                },
+                {
+                    "Name": "CreateHumanoidModelFromUserId",
+                    "ReturnType": {
+                        "Name": "Model"
+                    }
+                },
+                {
+                    "Name": "CreateHumanoidModelFromDescription",
+                    "Parameters": [
+                        {
+                            "Name": "description",
+                            "Type": {
+                                "Name": "HumanoidDescription"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "Model"
+                    }
+                },
+                {
+                    "Name": "PlayerMembershipChanged",
+                    "Parameters": [
+                        {
+                            "Name": "player",
+                            "Type": {
+                                "Name": "Player"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "PlayerDisconnecting",
+                    "Parameters": [
+                        {
+                            "Name": "player",
+                            "Type": {
+                                "Name": "Player"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "PlayerChatted",
+                    "Parameters": [
+                        {
+                            "Name": "player",
+                            "Type": {
+                                "Name": "Player"
+                            }
+                        },
+                        {
+                            "Name": "targetPlayer",
+                            "Type": {
+                                "Name": "Player"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "PlayerRejoining",
+                    "Parameters": [
+                        {
+                            "Name": "player",
+                            "Type": {
+                                "Name": "Player"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "PlayerRemoving",
+                    "Parameters": [
+                        {
+                            "Name": "player",
+                            "Type": {
+                                "Name": "Player"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "PlayerConnecting",
+                    "Parameters": [
+                        {
+                            "Name": "player",
+                            "Type": {
+                                "Name": "Player"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "PlayerAdded",
+                    "Parameters": [
+                        {
+                            "Name": "player",
+                            "Type": {
+                                "Name": "Player"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "GetUserThumbnailAsync",
+                    "TupleReturns": [
+                        {
+                            "Name": "string"
+                        },
+                        {
+                            "Name": "boolean"
+                        }
+                    ]
+                },
+                {
+                    "Name": "GetPlayers",
+                    "ReturnType": {
+                        "Generic": "Player"
+                    }
+                }
+            ],
+            "Name": "Players"
+        },
+        {
+            "Members": [
+                {
+                    "Name": "GetMouse",
+                    "ReturnType": {
+                        "Name": "Mouse"
+                    }
+                },
+                {
+                    "Name": "LoadCharacterWithHumanoidDescription",
+                    "Parameters": [
+                        {
+                            "Name": "humanoidDescription",
+                            "Type": {
+                                "Name": "HumanoidDescription"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "CharacterRemoving",
+                    "Parameters": [
+                        {
+                            "Name": "character",
+                            "Type": {
+                                "Name": "Model"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "Chatted",
+                    "Parameters": [
+                        {
+                            "Name": "recipient",
+                            "Type": {
+                                "Name": "Player"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "CharacterAppearanceLoaded",
+                    "Parameters": [
+                        {
+                            "Name": "character",
+                            "Type": {
+                                "Name": "Model"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "CharacterAdded",
+                    "Parameters": [
+                        {
+                            "Name": "character",
+                            "Type": {
+                                "Name": "Model"
+                            }
+                        }
+                    ]
+                }
+            ],
+            "Name": "Player"
+        },
+        {
+            "Members": [
+                {
+                    "Name": "Terrain",
+                    "ValueType": {
+                        "Name": "Terrain"
+                    }
+                }
+            ],
+            "Name": "Workspace"
+        },
+        {
+            "Members": [
+                {
+                    "Name": "CopyRegion",
+                    "ReturnType": {
+                        "Name": "TerrainRegion"
+                    }
+                },
+                {
+                    "Name": "PasteRegion",
+                    "Parameters": [
+                        {
+                            "Name": "region",
+                            "Type": {
+                                "Name": "TerrainRegion"
+                            }
+                        }
+                    ]
+                }
+            ],
+            "Name": "Terrain"
+        },
+        {
+            "Members": [
+                {
+                    "Name": "ApplyMesh",
+                    "Parameters": [
+                        {
+                            "Name": "meshPart",
+                            "Type": {
+                                "Name": "MeshPart"
+                            }
+                        }
+                    ]
+                }
+            ],
+            "Name": "MeshPart"
+        },
+        {
+            "Members": [
+                {
+                    "Name": "CreatePath",
+                    "ReturnType": {
+                        "Name": "Path"
+                    }
+                },
+                {
+                    "Name": "FindPathAsync",
+                    "ReturnType": {
+                        "Name": "Path"
+                    }
+                }
+            ],
+            "Name": "PathfindingService"
+        },
+        {
+            "Members": [
+                {
+                    "Name": "CreateDockWidgetPluginGui",
+                    "ReturnType": {
+                        "Name": "DockWidgetPluginGui"
+                    }
+                },
+                {
+                    "Name": "CreatePluginAction",
+                    "ReturnType": {
+                        "Name": "PluginAction"
+                    }
+                },
+                {
+                    "Name": "CreatePluginMenu",
+                    "ReturnType": {
+                        "Name": "PluginMenu"
+                    }
+                },
+                {
+                    "Name": "CreateToolbar",
+                    "ReturnType": {
+                        "Name": "PluginToolbar"
+                    }
+                },
+                {
+                    "Name": "GetMouse",
+                    "ReturnType": {
+                        "Name": "PluginMouse"
+                    }
+                },
+                {
+                    "Name": "Union",
+                    "ReturnType": {
+                        "Name": "UnionOperation"
+                    }
+                },
+                {
+                    "Name": "Negate",
+                    "ReturnType": {
+                        "Generic": "NegateOperation"
+                    }
+                },
+                {
+                    "Name": "Separate",
+                    "ReturnType": {
+                        "Generic": "UnionOperation"
+                    }
+                },
+                {
+                    "Name": "OpenScript",
+                    "Parameters": [
+                        {
+                            "Name": "script",
+                            "Type": {
+                                "Name": "BaseScript"
+                            }
+                        }
+                    ]
+                }
+            ],
+            "Name": "Plugin"
+        },
+        {
+            "Members": [
+                {
+                    "Name": "CreateButton",
+                    "ReturnType": {
+                        "Name": "PluginToolbarButton"
+                    }
+                }
+            ],
+            "Name": "PluginToolbar"
+        },
+        {
+            "Members": [
+                {
+                    "Name": "AddNewAction",
+                    "ReturnType": {
+                        "Name": "PluginAction"
+                    }
+                },
+                {
+                    "Name": "AddAction",
+                    "Parameters": [
+                        {
+                            "Name": "action",
+                            "Type": {
+                                "Name": "PluginAction"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "AddMenu",
+                    "Parameters": [
+                        {
+                            "Name": "menu",
+                            "Type": {
+                                "Name": "PluginMenu"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "ShowAsync",
+                    "ReturnType": {
+                        "Name": "PluginAction"
+                    }
+                }
+            ],
+            "Name": "PluginMenu"
+        },
+        {
+            "Members": [
+                {
+                    "Name": "Create",
+                    "ReturnType": {
+                        "Name": "Tween"
+                    }
+                }
+            ],
+            "Name": "TweenService"
+        },
+        {
+            "Members": [
+                {
+                    "Name": "RegisterKeyframeSequence",
+                    "Parameters": [
+                        {
+                            "Name": "keyframeSequence",
+                            "Type": {
+                                "Name": "KeyframeSequence"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "AddKeyframe",
+                    "Parameters": [
+                        {
+                            "Name": "keyframe",
+                            "Type": {
+                                "Name": "Keyframe"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "RegisterActiveKeyframeSequence",
+                    "Parameters": [
+                        {
+                            "Name": "keyframeSequence",
+                            "Type": {
+                                "Name": "KeyframeSequence"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "RemoveKeyframe",
+                    "Parameters": [
+                        {
+                            "Name": "keyframe",
+                            "Type": {
+                                "Name": "Keyframe"
+                            }
+                        }
+                    ]
+                }
+            ],
+            "Name": "KeyframeSequence"
+        },
+        {
+            "Members": [
+                {
+                    "Name": "PromptGameInvite",
+                    "Parameters": [
+                        {
+                            "Name": "player",
+                            "Type": {
+                                "Name": "Player"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "CanSendGameInviteAsync",
+                    "Parameters": [
+                        {
+                            "Name": "player",
+                            "Type": {
+                                "Name": "Player"
+                            }
+                        }
+                    ]
+                }
+            ],
+            "Name": "SocialService"
+        },
+        {
+            "Members": [
+                {
+                    "Name": "Sit",
+                    "Parameters": [
+                        {
+                            "Name": "humanoid",
+                            "Type": {
+                                "Name": "Humanoid"
+                            }
+                        }
+                    ]
+                }
+            ],
+            "Name": "VehicleSeat"
+        },
+        {
+            "Members": [
+                {
+                    "Name": "CreatePlaceInPlayerInventoryAsync",
+                    "Parameters": [
+                        {
+                            "Name": "player",
+                            "Type": {
+                                "Name": "Player"
+                            }
+                        }
+                    ]
+                }
+            ],
+            "Name": "AssetService"
+        },
+        {
+            "Members": [
+                {
+                    "Name": "GetTranslatorForPlayer",
+                    "Parameters": [
+                        {
+                            "Name": "player",
+                            "Type": {
+                                "Name": "Player"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "Translator"
+                    }
+                },
+                {
+                    "Name": "GetCountryRegionForPlayerAsync",
+                    "Parameters": [
+                        {
+                            "Name": "player",
+                            "Type": {
+                                "Name": "Player"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "GetTranslatorForPlayerAsync",
+                    "Parameters": [
+                        {
+                            "Name": "player",
+                            "Type": {
+                                "Name": "Player"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "Translator"
+                    }
+                },
+                {
+                    "Name": "GetTranslatorForLocaleAsync",
+                    "ReturnType": {
+                        "Name": "Translator"
+                    }
+                }
+            ],
+            "Name": "LocalizationService"
+        },
+        {
+            "Members": [
+                {
+                    "Name": "GetTranslator",
+                    "ReturnType": {
+                        "Name": "Translator"
+                    }
+                }
+            ],
+            "Name": "LocalizationTable"
+        },
+        {
+            "Members": [
+                {
+                    "Name": "LoadAnimation",
+                    "Parameters": [
+                        {
+                            "Name": "animation",
+                            "Type": {
+                                "Name": "Animation"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "AnimationTrack"
+                    }
+                },
+                {
+                    "Name": "AnimationPlayed",
+                    "Parameters": [
+                        {
+                            "Name": "animationTrack",
+                            "Type": {
+                                "Name": "AnimationTrack"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "GetPlayingAnimationTracks",
+                    "ReturnType": {
+                        "Generic": "AnimationTrack"
+                    }
+                }
+            ],
+            "Name": "Animator"
+        },
+        {
+            "Members": [
+                {
+                    "Name": "InvokeClient",
+                    "Parameters": [
+                        {
+                            "Name": "player",
+                            "Type": {
+                                "Name": "Player"
+                            }
+                        }
+                    ]
+                }
+            ],
+            "Name": "RemoteFunction"
+        },
+        {
+            "Members": [
+                {
+                    "Name": "Teleport",
+                    "Parameters": [
+                        {
+                            "Name": "player",
+                            "Type": {
+                                "Name": "Player"
+                            }
+                        },
+                        {
+                            "Name": "customLoadingScreen",
+                            "Type": {
+                                "Name": "GuiObject"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "TeleportToPlaceInstance",
+                    "Parameters": [
+                        {
+                            "Name": "player",
+                            "Type": {
+                                "Name": "Player"
+                            }
+                        },
+                        {
+                            "Name": "customLoadingScreen",
+                            "Type": {
+                                "Name": "GuiObject"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "SetTeleportGui",
+                    "Parameters": [
+                        {
+                            "Name": "gui",
+                            "Type": {
+                                "Name": "GuiObject"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "TeleportToPrivateServer",
+                    "Parameters": [
+                        {
+                            "Name": "players",
+                            "Type": {
+                                "Generic": "Player"
+                            }
+                        },
+                        {
+                            "Name": "customLoadingScreen",
+                            "Type": {
+                                "Name": "GuiObject"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "TeleportAsync",
+                    "Parameters": [
+                        {
+                            "Name": "players",
+                            "Type": {
+                                "Generic": "Player"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "TeleportAsyncResult"
+                    }
+                },
+                {
+                    "Name": "TeleportToSpawnByName",
+                    "Parameters": [
+                        {
+                            "Name": "player",
+                            "Type": {
+                                "Name": "Player"
+                            }
+                        },
+                        {
+                            "Name": "customLoadingScreen",
+                            "Type": {
+                                "Name": "GuiObject"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "TeleportPartyAsync",
+                    "Parameters": [
+                        {
+                            "Name": "players",
+                            "Type": {
+                                "Generic": "Player"
+                            }
+                        },
+                        {
+                            "Name": "customLoadingScreen",
+                            "Type": {
+                                "Name": "GuiObject"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "GetArrivingTeleportGui",
+                    "ReturnType": {
+                        "Name": "ScreenGui"
+                    }
+                },
+                {
+                    "Name": "GetPlayerPlaceInstanceAsync",
+                    "TupleReturns": [
+                        {
+                            "Name": "boolean"
+                        },
+                        {
+                            "Name": "number"
+                        },
+                        {
+                            "Name": "string"
+                        }
+                    ]
+                }
+            ],
+            "Name": "TeleportService"
+        },
+        {
+            "Members": [
+                {
+                    "Name": "PlayLocalSound",
+                    "Parameters": [
+                        {
+                            "Name": "sound",
+                            "Type": {
+                                "Name": "Sound"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "GetListener",
+                    "TupleReturns": [
+                        {
+                            "Category": "Enum",
+                            "Name": "ListenerType"
+                        },
+                        {
+                            "Name": "any"
+                        }
+                    ]
+                }
+            ],
+            "Name": "SoundService"
+        },
+        {
+            "Members": [
+                {
+                    "Name": "FilterStringAsync",
+                    "Parameters": [
+                        {
+                            "Name": "playerTo",
+                            "Type": {
+                                "Name": "Player"
+                            }
+                        },
+                        {
+                            "Name": "playerFrom",
+                            "Type": {
+                                "Name": "Player"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "FilterStringForBroadcast",
+                    "Parameters": [
+                        {
+                            "Name": "playerFrom",
+                            "Type": {
+                                "Name": "Player"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "Chatted",
+                    "Parameters": [
+                        {
+                            "Name": "part",
+                            "Type": {
+                                "Name": "BasePart"
+                            }
+                        }
+                    ]
+                }
+            ],
+            "Name": "Chat"
+        },
+        {
+            "Members": [
+                {
+                    "Name": "FireClient",
+                    "Parameters": [
+                        {
+                            "Name": "player",
+                            "Type": {
+                                "Name": "Player"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "OnServerEvent",
+                    "Parameters": [
+                        {
+                            "Name": "player",
+                            "Type": {
+                                "Name": "Player"
+                            }
+                        }
+                    ]
+                }
+            ],
+            "Name": "RemoteEvent"
+        },
+        {
+            "Members": [
+                {
+                    "Name": "AddSubPose",
+                    "Parameters": [
+                        {
+                            "Name": "pose",
+                            "Type": {
+                                "Name": "Pose"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "RemoveSubPose",
+                    "Parameters": [
+                        {
+                            "Name": "pose",
+                            "Type": {
+                                "Name": "Pose"
+                            }
+                        }
+                    ]
+                }
+            ],
+            "Name": "Pose"
+        },
+        {
+            "Members": [
+                {
+                    "Name": "GetPolicyInfoForPlayerAsync",
+                    "Parameters": [
+                        {
+                            "Name": "player",
+                            "Type": {
+                                "Name": "Player"
+                            }
+                        }
+                    ]
+                }
+            ],
+            "Name": "PolicyService"
+        },
+        {
+            "Members": [
+                {
+                    "Name": "InspectPlayerFromHumanoidDescription",
+                    "Parameters": [
+                        {
+                            "Name": "humanoidDescription",
+                            "Type": {
+                                "Name": "HumanoidDescription"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "GetGuiInset",
+                    "TupleReturns": [
+                        {
+                            "Name": "Vector2"
+                        },
+                        {
+                            "Name": "Vector2"
+                        }
+                    ]
+                }
+            ],
+            "Name": "GuiService"
+        },
+        {
+            "Members": [
+                {
+                    "Name": "MoveTo",
+                    "Parameters": [
+                        {
+                            "Name": "part",
+                            "Type": {
+                                "Name": "BasePart"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "ApplyDescription",
+                    "Parameters": [
+                        {
+                            "Name": "humanoidDescription",
+                            "Type": {
+                                "Name": "HumanoidDescription"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "GetAppliedDescription",
+                    "ReturnType": {
+                        "Name": "HumanoidDescription"
+                    }
+                },
+                {
+                    "Name": "EquipTool",
+                    "Parameters": [
+                        {
+                            "Name": "tool",
+                            "Type": {
+                                "Name": "Tool"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "GetBodyPartR15",
+                    "Parameters": [
+                        {
+                            "Name": "part",
+                            "Type": {
+                                "Name": "BasePart"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "ReplaceBodyPartR15",
+                    "Parameters": [
+                        {
+                            "Name": "part",
+                            "Type": {
+                                "Name": "BasePart"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "AddAccessory",
+                    "Parameters": [
+                        {
+                            "Name": "accessory",
+                            "Type": {
+                                "Name": "Accessory"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "LoadAnimation",
+                    "Parameters": [
+                        {
+                            "Name": "animation",
+                            "Type": {
+                                "Name": "Animation"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "GetLimb",
+                    "Parameters": [
+                        {
+                            "Name": "part",
+                            "Type": {
+                                "Name": "BasePart"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "AnimationPlayed",
+                    "Parameters": [
+                        {
+                            "Name": "animationTrack",
+                            "Type": {
+                                "Name": "AnimationTrack"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "Seated",
+                    "Parameters": [
+                        {
+                            "Name": "currentSeatPart",
+                            "Type": {
+                                "Name": "Seat"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "Touched",
+                    "Parameters": [
+                        {
+                            "Name": "touchingPart",
+                            "Type": {
+                                "Name": "BasePart"
+                            }
+                        },
+                        {
+                            "Name": "humanoidPart",
+                            "Type": {
+                                "Name": "BasePart"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "GetPlayingAnimationTracks",
+                    "ReturnType": {
+                        "Generic": "AnimationTrack"
+                    }
+                },
+                {
+                    "Name": "GetAccessories",
+                    "ReturnType": {
+                        "Generic": "Accessory"
+                    }
+                }
+            ],
+            "Name": "Humanoid"
+        },
+        {
+            "Members": [
+                {
+                    "Name": "Sit",
+                    "Parameters": [
+                        {
+                            "Name": "humanoid",
+                            "Type": {
+                                "Name": "Humanoid"
+                            }
+                        }
+                    ]
+                }
+            ],
+            "Name": "Seat"
+        },
+        {
+            "Members": [
+                {
+                    "Name": "CanCollideWith",
+                    "Parameters": [
+                        {
+                            "Name": "part",
+                            "Type": {
+                                "Name": "BasePart"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "SetNetworkOwner",
+                    "Parameters": [
+                        {
+                            "Name": "playerInstance",
+                            "Type": {
+                                "Name": "Player"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "GetNetworkOwner",
+                    "ReturnType": {
+                        "Name": "Player"
+                    }
+                },
+                {
+                    "Name": "GetRootPart",
+                    "ReturnType": {
+                        "Name": "BasePart"
+                    }
+                },
+                {
+                    "Name": "SubtractAsync",
+                    "ReturnType": {
+                        "Name": "UnionOperation"
+                    }
+                },
+                {
+                    "Name": "UnionAsync",
+                    "ReturnType": {
+                        "Name": "UnionOperation"
+                    }
+                },
+                {
+                    "Name": "TouchEnded",
+                    "Parameters": [
+                        {
+                            "Name": "otherPart",
+                            "Type": {
+                                "Name": "BasePart"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "Touched",
+                    "Parameters": [
+                        {
+                            "Name": "otherPart",
+                            "Type": {
+                                "Name": "BasePart"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "CanSetNetworkOwnership",
+                    "TupleReturns": [
+                        {
+                            "Name": "boolean"
+                        },
+                        {
+                            "Name": "string"
+                        }
+                    ]
+                },
+                {
+                    "Name": "GetConnectedParts",
+                    "ReturnType": {
+                        "Generic": "BasePart"
+                    }
+                },
+                {
+                    "Name": "GetJoints",
+                    "ReturnType": {
+                        "Generic": "JointInstance"
+                    }
+                },
+                {
+                    "Name": "GetTouchingParts",
+                    "ReturnType": {
+                        "Generic": "BasePart"
+                    }
+                }
+            ],
+            "Name": "BasePart"
+        },
+        {
+            "Members": [
+                {
+                    "Name": "RemoveMarker",
+                    "Parameters": [
+                        {
+                            "Name": "market",
+                            "Type": {
+                                "Name": "KeyframeMarker"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "AddMarker",
+                    "Parameters": [
+                        {
+                            "Name": "marker",
+                            "Type": {
+                                "Name": "KeyframeMarker"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "AddPose",
+                    "Parameters": [
+                        {
+                            "Name": "pose",
+                            "Type": {
+                                "Name": "Pose"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "RemovePose",
+                    "Parameters": [
+                        {
+                            "Name": "pose",
+                            "Type": {
+                                "Name": "Pose"
+                            }
+                        }
+                    ]
+                }
+            ],
+            "Name": "Keyframe"
+        },
+        {
+            "Members": [
+                {
+                    "Name": "LoadAnimation",
+                    "Parameters": [
+                        {
+                            "Name": "animation",
+                            "Type": {
+                                "Name": "Animation"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "AnimationPlayed",
+                    "Parameters": [
+                        {
+                            "Name": "animationTrack",
+                            "Type": {
+                                "Name": "AnimationTrack"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "GetPlayingAnimationTracks",
+                    "ReturnType": {
+                        "Generic": "AnimationTrack"
+                    }
+                }
+            ],
+            "Name": "AnimationController"
+        },
+        {
+            "Members": [
+                {
+                    "Name": "PromptPurchase",
+                    "Parameters": [
+                        {
+                            "Name": "player",
+                            "Type": {
+                                "Name": "Player"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "PromptProductPurchase",
+                    "Parameters": [
+                        {
+                            "Name": "player",
+                            "Type": {
+                                "Name": "Player"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "PromptPremiumPurchase",
+                    "Parameters": [
+                        {
+                            "Name": "player",
+                            "Type": {
+                                "Name": "Player"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "PlayerOwnsAsset",
+                    "Parameters": [
+                        {
+                            "Name": "player",
+                            "Type": {
+                                "Name": "Player"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "PromptGamePassPurchase",
+                    "Parameters": [
+                        {
+                            "Name": "player",
+                            "Type": {
+                                "Name": "Player"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "PromptSubscriptionPurchase",
+                    "Parameters": [
+                        {
+                            "Name": "player",
+                            "Type": {
+                                "Name": "Player"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "IsPlayerSubscribed",
+                    "Parameters": [
+                        {
+                            "Name": "player",
+                            "Type": {
+                                "Name": "Player"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "PromptSubscriptionCancellation",
+                    "Parameters": [
+                        {
+                            "Name": "player",
+                            "Type": {
+                                "Name": "Player"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "PromptSubscriptionPurchaseRequested",
+                    "Parameters": [
+                        {
+                            "Name": "player",
+                            "Type": {
+                                "Name": "Player"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "PromptGamePassPurchaseRequested",
+                    "Parameters": [
+                        {
+                            "Name": "player",
+                            "Type": {
+                                "Name": "Player"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "PromptSubscriptionPurchaseFinished",
+                    "Parameters": [
+                        {
+                            "Name": "player",
+                            "Type": {
+                                "Name": "Player"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "PromptSubscriptionCancellationFinished",
+                    "Parameters": [
+                        {
+                            "Name": "player",
+                            "Type": {
+                                "Name": "Player"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "PromptProductPurchaseRequested",
+                    "Parameters": [
+                        {
+                            "Name": "player",
+                            "Type": {
+                                "Name": "Player"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "PromptGamePassPurchaseFinished",
+                    "Parameters": [
+                        {
+                            "Name": "player",
+                            "Type": {
+                                "Name": "Player"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "PromptBundlePurchase",
+                    "Parameters": [
+                        {
+                            "Name": "player",
+                            "Type": {
+                                "Name": "Player"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "GetDeveloperProductsAsync",
+                    "ReturnType": {
+                        "Name": "Pages"
+                    }
+                },
+                {
+                    "Name": "NativePurchaseFinished",
+                    "Parameters": [
+                        {
+                            "Name": "player",
+                            "Type": {
+                                "Name": "Player"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "PromptPurchaseRequested",
+                    "Parameters": [
+                        {
+                            "Name": "player",
+                            "Type": {
+                                "Name": "Player"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "PromptPurchaseFinished",
+                    "Parameters": [
+                        {
+                            "Name": "player",
+                            "Type": {
+                                "Name": "Player"
+                            }
+                        }
+                    ]
+                }
+            ],
+            "Name": "MarketplaceService"
+        },
+        {
+            "Members": [
+                {
+                    "Name": "Activated",
+                    "Parameters": [
+                        {
+                            "Name": "inputObject",
+                            "Type": {
+                                "Name": "InputObject"
+                            }
+                        }
+                    ]
+                }
+            ],
+            "Name": "GuiButton"
+        },
+        {
+            "Members": [
+                {
+                    "Name": "Equipped",
+                    "Parameters": [
+                        {
+                            "Name": "mouse",
+                            "Type": {
+                                "Name": "Mouse"
+                            }
+                        }
+                    ]
+                }
+            ],
+            "Name": "Tool"
+        },
+        {
+            "Members": [
+                {
+                    "Name": "TouchMoved",
+                    "Parameters": [
+                        {
+                            "Name": "touch",
+                            "Type": {
+                                "Name": "InputObject"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "TextBoxFocusReleased",
+                    "Parameters": [
+                        {
+                            "Name": "textboxReleased",
+                            "Type": {
+                                "Name": "TextBox"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "TextBoxFocused",
+                    "Parameters": [
+                        {
+                            "Name": "textboxFocused",
+                            "Type": {
+                                "Name": "TextBox"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "InputChanged",
+                    "Parameters": [
+                        {
+                            "Name": "input",
+                            "Type": {
+                                "Name": "InputObject"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "InputEnded",
+                    "Parameters": [
+                        {
+                            "Name": "input",
+                            "Type": {
+                                "Name": "InputObject"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "TouchEnded",
+                    "Parameters": [
+                        {
+                            "Name": "touch",
+                            "Type": {
+                                "Name": "InputObject"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "InputBegan",
+                    "Parameters": [
+                        {
+                            "Name": "input",
+                            "Type": {
+                                "Name": "InputObject"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "TouchStarted",
+                    "Parameters": [
+                        {
+                            "Name": "touch",
+                            "Type": {
+                                "Name": "InputObject"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "GetDeviceRotation",
+                    "TupleReturns": [
+                        {
+                            "Name": "number"
+                        },
+                        {
+                            "Name": "CFrame"
+                        }
+                    ]
+                },
+                {
+                    "Name": "GetConnectedGamepads",
+                    "ReturnType": {
+                        "Generic": "Enum.UserInputType"
+                    }
+                },
+                {
+                    "Name": "GetGamepadState",
+                    "ReturnType": {
+                        "Generic": "InputObject"
+                    }
+                },
+                {
+                    "Name": "GetKeysPressed",
+                    "ReturnType": {
+                        "Generic": "InputObject"
+                    }
+                },
+                {
+                    "Name": "GetMouseButtonsPressed",
+                    "ReturnType": {
+                        "Generic": "InputObject"
+                    }
+                },
+                {
+                    "Name": "GetNavigationGamepads",
+                    "ReturnType": {
+                        "Generic": "InputObject"
+                    }
+                },
+                {
+                    "Name": "GetSupportedGamepadKeyCodes",
+                    "ReturnType": {
+                        "Generic": "Enum.KeyCode"
+                    }
+                },
+                {
+                    "Name": "TouchLongPress",
+                    "Parameters": [
+                        {
+                            "Name": "touchPositions",
+                            "Type": {
+                                "Generic": "Vector2"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "TouchPan",
+                    "Parameters": [
+                        {
+                            "Name": "touchPositions",
+                            "Type": {
+                                "Generic": "Vector2"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "TouchPinch",
+                    "Parameters": [
+                        {
+                            "Name": "touchPositions",
+                            "Type": {
+                                "Generic": "Vector2"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "TouchRotate",
+                    "Parameters": [
+                        {
+                            "Name": "touchPositions",
+                            "Type": {
+                                "Generic": "Vector2"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "TouchTap",
+                    "Parameters": [
+                        {
+                            "Name": "touchPositions",
+                            "Type": {
+                                "Generic": "Vector2"
+                            }
+                        }
+                    ]
+                }
+            ],
+            "Name": "UserInputService"
+        },
+        {
+            "Members": [
+                {
+                    "Name": "Hit",
+                    "Parameters": [
+                        {
+                            "Name": "part",
+                            "Type": {
+                                "Name": "BasePart"
+                            }
+                        }
+                    ]
+                }
+            ],
+            "Name": "Explosion"
+        },
+        {
+            "Members": [
+                {
+                    "Name": "LocalToolEquipped",
+                    "Parameters": [
+                        {
+                            "Name": "toolEquipped",
+                            "Type": {
+                                "Name": "Tool"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "LocalToolUnequipped",
+                    "Parameters": [
+                        {
+                            "Name": "toolUnequipped",
+                            "Type": {
+                                "Name": "Tool"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "GetButton",
+                    "ReturnType": {
+                        "Name": "ImageButton"
+                    }
+                }
+            ],
+            "Name": "ContextActionService"
+        },
+        {
+            "Members": [
+                {
+                    "Name": "GetSortedAsync",
+                    "ReturnType": {
+                        "Name": "DataStorePages"
+                    }
+                }
+            ],
+            "Name": "OrderedDataStore"
+        },
+        {
+            "Members": [
+                {
+                    "Name": "MouseHoverEnter",
+                    "Parameters": [
+                        {
+                            "Name": "playerWhoHovered",
+                            "Type": {
+                                "Name": "Player"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "MouseHoverLeave",
+                    "Parameters": [
+                        {
+                            "Name": "playerWhoHovered",
+                            "Type": {
+                                "Name": "Player"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "RightMouseClick",
+                    "Parameters": [
+                        {
+                            "Name": "playerWhoClicked",
+                            "Type": {
+                                "Name": "Player"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "MouseClick",
+                    "Parameters": [
+                        {
+                            "Name": "playerWhoClicked",
+                            "Type": {
+                                "Name": "Player"
+                            }
+                        }
+                    ]
+                }
+            ],
+            "Name": "ClickDetector"
+        },
+        {
+            "Members": [
+                {
+                    "Name": "InputChanged",
+                    "Parameters": [
+                        {
+                            "Name": "input",
+                            "Type": {
+                                "Name": "InputObject"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "InputEnded",
+                    "Parameters": [
+                        {
+                            "Name": "input",
+                            "Type": {
+                                "Name": "InputObject"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "InputBegan",
+                    "Parameters": [
+                        {
+                            "Name": "input",
+                            "Type": {
+                                "Name": "InputObject"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "TouchLongPress",
+                    "Parameters": [
+                        {
+                            "Name": "touchPositions",
+                            "Type": {
+                                "Generic": "Vector2"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "TouchPan",
+                    "Parameters": [
+                        {
+                            "Name": "touchPositions",
+                            "Type": {
+                                "Generic": "Vector2"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "TouchPinch",
+                    "Parameters": [
+                        {
+                            "Name": "touchPositions",
+                            "Type": {
+                                "Generic": "Vector2"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "TouchRotate",
+                    "Parameters": [
+                        {
+                            "Name": "touchPositions",
+                            "Type": {
+                                "Generic": "Vector2"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "TouchTap",
+                    "Parameters": [
+                        {
+                            "Name": "touchPositions",
+                            "Type": {
+                                "Generic": "Vector2"
+                            }
+                        }
+                    ]
+                }
+            ],
+            "Name": "GuiObject"
+        },
+        {
+            "Members": [
+                {
+                    "Name": "DialogChoiceSelected",
+                    "Parameters": [
+                        {
+                            "Name": "player",
+                            "Type": {
+                                "Name": "Player"
+                            }
+                        },
+                        {
+                            "Name": "dialogChoice",
+                            "Type": {
+                                "Name": "DialogChoice"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "GetCurrentPlayers",
+                    "ReturnType": {
+                        "Generic": "Player"
+                    }
+                }
+            ],
+            "Name": "Dialog"
+        },
+        {
+            "Members": [
+                {
+                    "Name": "FocusLost",
+                    "Parameters": [
+                        {
+                            "Name": "inputThatCausedFocusLoss",
+                            "Type": {
+                                "Name": "InputObject"
+                            }
+                        }
+                    ]
+                }
+            ],
+            "Name": "TextBox"
+        },
+        {
+            "Members": [
+                {
+                    "Name": "PlayerRemoved",
+                    "Parameters": [
+                        {
+                            "Name": "player",
+                            "Type": {
+                                "Name": "Player"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "PlayerAdded",
+                    "Parameters": [
+                        {
+                            "Name": "player",
+                            "Type": {
+                                "Name": "Player"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "GetPlayers",
+                    "ReturnType": {
+                        "Generic": "Player"
+                    }
+                }
+            ],
+            "Name": "Team"
+        },
+        {
+            "Members": [
+                {
+                    "Name": "WorldToScreenPoint",
+                    "TupleReturns": [
+                        {
+                            "Name": "Vector3"
+                        },
+                        {
+                            "Name": "boolean"
+                        }
+                    ]
+                },
+                {
+                    "Name": "WorldToViewportPoint",
+                    "TupleReturns": [
+                        {
+                            "Name": "Vector3"
+                        },
+                        {
+                            "Name": "boolean"
+                        }
+                    ]
+                },
+                {
+                    "Name": "GetPartsObscuringTarget",
+                    "Parameters": [
+                        {
+                            "Name": "castPoints",
+                            "Type": {
+                                "Generic": "Vector3"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Generic": "BasePart"
+                    }
+                }
+            ],
+            "Name": "Camera"
+        },
+        {
+            "Members": [
+                {
+                    "Name": "GetBoundingBox",
+                    "TupleReturns": [
+                        {
+                            "Name": "CFrame"
+                        },
+                        {
+                            "Name": "Vector3"
+                        }
+                    ]
+                }
+            ],
+            "Name": "Model"
+        },
+        {
+            "Members": [
+                {
+                    "Name": "FindPartOnRay",
+                    "TupleReturns": [
+                        {
+                            "Name": "BasePart"
+                        },
+                        {
+                            "Name": "Vector3"
+                        },
+                        {
+                            "Name": "Vector3"
+                        },
+                        {
+                            "Category": "Enum",
+                            "Name": "Material"
+                        }
+                    ]
+                },
+                {
+                    "Name": "FindPartOnRayWithIgnoreList",
+                    "TupleReturns": [
+                        {
+                            "Name": "BasePart"
+                        },
+                        {
+                            "Name": "Vector3"
+                        },
+                        {
+                            "Name": "Vector3"
+                        },
+                        {
+                            "Category": "Enum",
+                            "Name": "Material"
+                        }
+                    ]
+                },
+                {
+                    "Name": "FindPartOnRayWithWhiteList",
+                    "TupleReturns": [
+                        {
+                            "Name": "BasePart"
+                        },
+                        {
+                            "Name": "Vector3"
+                        },
+                        {
+                            "Name": "Vector3"
+                        },
+                        {
+                            "Category": "Enum",
+                            "Name": "Material"
+                        }
+                    ]
+                },
+                {
+                    "Name": "findPartOnRay",
+                    "TupleReturns": [
+                        {
+                            "Name": "BasePart"
+                        },
+                        {
+                            "Name": "Vector3"
+                        },
+                        {
+                            "Name": "Vector3"
+                        },
+                        {
+                            "Category": "Enum",
+                            "Name": "Material"
+                        }
+                    ]
+                },
+                {
+                    "Name": "FindPartsInRegion3",
+                    "ReturnType": {
+                        "Generic": "BasePart"
+                    }
+                },
+                {
+                    "Name": "FindPartsInRegion3WithIgnoreList",
+                    "ReturnType": {
+                        "Generic": "BasePart"
+                    }
+                },
+                {
+                    "Name": "FindPartsInRegion3WithWhiteList",
+                    "ReturnType": {
+                        "Generic": "BasePart"
+                    }
+                },
+                {
+                    "Name": "GetPartBoundsInBox",
+                    "ReturnType": {
+                        "Generic": "BasePart"
+                    }
+                },
+                {
+                    "Name": "GetPartBoundsInRadius",
+                    "ReturnType": {
+                        "Generic": "BasePart"
+                    }
+                },
+                {
+                    "Name": "GetPartsInPart",
+                    "ReturnType": {
+                        "Generic": "BasePart"
+                    }
+                }
+            ],
+            "Name": "WorldRoot"
+        },
+        {
+            "Members": [
+                {
+                    "Name": "OnServerInvoke",
+                    "Parameters": [
+                        {
+                            "Name": "player",
+                            "Type": {
+                                "Name": "Player"
+                            }
+                        }
+                    ]
+                }
+            ],
+            "Name": "RemoteFunction"
+        },
+        {
+            "Members": [
+                {
+                    "Name": "GetGuiObjectsAtPosition",
+                    "ReturnType": {
+                        "Generic": "GuiObject"
+                    }
+                }
+            ],
+            "Name": "BasePlayerGui"
+        },
+        {
+            "Members": [
+                {
+                    "Name": "GetTags",
+                    "ReturnType": {
+                        "Generic": "string"
+                    }
+                }
+            ],
+            "Name": "CollectionService"
+        },
+        {
+            "Members": [
+                {
+                    "Name": "GetUserIds",
+                    "ReturnType": {
+                        "Generic": "number"
+                    }
+                }
+            ],
+            "Name": "DataStoreKeyInfo"
+        },
+        {
+            "Members": [
+                {
+                    "Name": "GetAccessories",
+                    "ReturnType": {
+                        "Generic": "Accessory"
+                    }
+                }
+            ],
+            "Name": "HumanoidDescription"
+        },
+        {
+            "Members": [
+                {
+                    "Name": "IncrementAsync",
+                    "Parameters": [
+                        {
+                            "Name": "userIds",
+                            "Type": {
+                                "Generic": "number"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "SetAsync",
+                    "Parameters": [
+                        {
+                            "Name": "userIds",
+                            "Type": {
+                                "Generic": "number"
+                            }
+                        }
+                    ]
+                }
+            ],
+            "Name": "GlobalDataStore"
+        },
+        {
+            "Members": [
+                {
+                    "Name": "GetWaypoints",
+                    "ReturnType": {
+                        "Generic": "PathWaypoint"
+                    }
+                }
+            ],
+            "Name": "Path"
+        },
+        {
+            "Members": [
+                {
+                    "Name": "GetTeams",
+                    "ReturnType": {
+                        "Generic": "Team"
+                    }
+                }
+            ],
+            "Name": "Teams"
+        },
+        {
+            "Members": [
+                {
+                    "Name": "GetDataStore",
+                    "ReturnType": {
+                        "Name": "DataStore"
+                    }
+                }
+            ],
+            "Name": "DataStoreService"
+        }
+    ]
+}

--- a/scripts/DataTypes.json
+++ b/scripts/DataTypes.json
@@ -344,6 +344,40 @@
                     "ValueType": {
                         "Name": "Vector2"
                     }
+                },
+                {
+                    "MemberType":"Function",
+                    "Name":"min",
+                    "Parameters": [
+                        {
+                        "Name": "other",
+                        "Type":{
+                            "Variadic":{
+                                "Name":"Vector2"
+                            }
+                        }
+                        }
+                    ],
+                    "ReturnType":{
+                        "Name":"Vector2"
+                    }
+                },
+                {
+                    "MemberType":"Function",
+                    "Name":"max",
+                    "Parameters": [
+                        {
+                        "Name": "other",
+                        "Type":{
+                            "Variadic":{
+                                "Name":"Vector2"
+                            }
+                        }
+                        }
+                    ],
+                    "ReturnType":{
+                        "Name":"Vector2"
+                    }
                 }
             ],
             "Name": "Vector2"
@@ -1486,6 +1520,40 @@
                     "Name": "zAxis",
                     "ValueType": {
                         "Name": "Vector3"
+                    }
+                },
+                {
+                    "MemberType":"Function",
+                    "Name":"min",
+                    "Parameters": [
+                        {
+                        "Name": "other",
+                        "Type":{
+                            "Variadic":{
+                                "Name":"Vector3"
+                            }
+                        }
+                        }
+                    ],
+                    "ReturnType":{
+                        "Name":"Vector3"
+                    }
+                },
+                {
+                    "MemberType":"Function",
+                    "Name":"max",
+                    "Parameters": [
+                        {
+                        "Name": "other",
+                        "Type":{
+                            "Variadic":{
+                                "Name":"Vector3"
+                            }
+                        }
+                        }
+                    ],
+                    "ReturnType":{
+                        "Name":"Vector3"
                     }
                 }
             ],

--- a/scripts/DataTypes.json
+++ b/scripts/DataTypes.json
@@ -3816,6 +3816,42 @@
                 },
                 {
                     "MemberType": "Function",
+                    "Name": "Abs",
+                    "Parameters": [
+                    ],
+                    "ReturnType": {
+                        "Name": "Vector3"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "Ceil",
+                    "Parameters": [
+                    ],
+                    "ReturnType": {
+                        "Name": "Vector3"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "Floor",
+                    "Parameters": [
+                    ],
+                    "ReturnType": {
+                        "Name": "Vector3"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "Sign",
+                    "Parameters": [
+                    ],
+                    "ReturnType": {
+                        "Name": "Vector3"
+                    }
+                },
+                {
+                    "MemberType": "Function",
                     "Name": "FuzzyEq",
                     "Parameters": [
                         {

--- a/scripts/DataTypes.json
+++ b/scripts/DataTypes.json
@@ -112,6 +112,13 @@
                                 "Category": "Enum",
                                 "Name": "PathWaypointAction"
                             }
+                        },
+                        {
+                            "Name": "label",
+                            "Default": "",
+                            "Type": {
+                                "Name": "string"
+                            }
                         }
                     ],
                     "ReturnType": {
@@ -2313,6 +2320,13 @@
                     "ValueType": {
                         "Category": "Enum",
                         "Name": "PathWaypointAction"
+                    }
+                },
+                {
+                    "MemberType":"Property",
+                    "Name":"Label",
+                    "ValueType":{
+                        "Name":"string"
                     }
                 }
             ],

--- a/scripts/DataTypes.json
+++ b/scripts/DataTypes.json
@@ -2263,7 +2263,12 @@
                 }
             ],
             "Name": "SharedTable"
+        },
+        {
+            "Members":[],
+            "Name": "Secret"
         }
+
     ],
     "DataTypes": [
         {
@@ -4920,6 +4925,41 @@
                 }
             ],
             "Name": "SharedTable"
+        },
+        {
+            "Members":[
+                {
+                    "MemberType": "Function",
+                    "Name": "AddPrefix",
+                    "Parameters": [
+                        {
+                            "Name": "prefix",
+                            "Type": {
+                                "Name": "string"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "Secret"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "AddSuffix",
+                    "Parameters": [
+                        {
+                            "Name": "suffix",
+                            "Type": {
+                                "Name": "string"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "Secret"
+                    }
+                }
+            ],
+            "Name": "Secret"
         }
     ]
 }

--- a/scripts/DataTypes.json
+++ b/scripts/DataTypes.json
@@ -2503,6 +2503,63 @@
                 },
                 {
                     "MemberType": "Function",
+                    "Name": "Abs",
+                    "Parameters": [
+                    ],
+                    "ReturnType": {
+                        "Name": "Vector2"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "Ceil",
+                    "Parameters": [
+                    ],
+                    "ReturnType": {
+                        "Name": "Vector2"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "Floor",
+                    "Parameters": [
+                    ],
+                    "ReturnType": {
+                        "Name": "Vector2"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "Sign",
+                    "Parameters": [
+                    ],
+                    "ReturnType": {
+                        "Name": "Vector2"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "Angle",
+                    "Parameters": [
+                        {
+                            "Name":"other",
+                            "Type":{
+                                "Name":"Vector2"
+                            }
+                        },
+                        {
+                            "Name":"isSigned",
+                            "Type":{
+                                "Name":"bool"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "Vector2"
+                    }
+                },
+                {
+                    "MemberType": "Function",
                     "Name": "Max",
                     "Parameters": [
                         {

--- a/scripts/DataTypes.json
+++ b/scripts/DataTypes.json
@@ -1,0 +1,4788 @@
+{
+    "Constructors": [
+        {
+            "Members": [
+                {
+                    "MemberType": "Function",
+                    "Name": "new",
+                    "Parameters": [
+                        {
+                            "Name": "className",
+                            "Type": {
+                                "Name": "string"
+                            }
+                        },
+                        {
+                            "Default": "nil",
+                            "Name": "parent",
+                            "Type": {
+                                "Name": "Instance"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "Instance"
+                    }
+                }
+            ],
+            "Name": "Instance"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Function",
+                    "Name": "new",
+                    "Parameters": [
+                        {
+                            "Name": "Origin",
+                            "Type": {
+                                "Name": "Vector3"
+                            }
+                        },
+                        {
+                            "Name": "Direction",
+                            "Type": {
+                                "Name": "Vector3"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "Ray"
+                    }
+                }
+            ],
+            "Name": "Ray"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Function",
+                    "Name": "new",
+                    "Parameters": [
+                        {
+                            "Name": "value",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "NumberRange"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "new",
+                    "Parameters": [
+                        {
+                            "Name": "min",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Name": "max",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "NumberRange"
+                    }
+                }
+            ],
+            "Name": "NumberRange"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Function",
+                    "Name": "new",
+                    "Parameters": [
+                        {
+                            "Name": "position",
+                            "Type": {
+                                "Name": "Vector3"
+                            }
+                        },
+                        {
+                            "Name": "action",
+                            "Type": {
+                                "Category": "Enum",
+                                "Name": "PathWaypointAction"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "PathWaypoint"
+                    }
+                }
+            ],
+            "Name": "PathWaypoint"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Function",
+                    "Name": "Red",
+                    "Parameters": [],
+                    "ReturnType": {
+                        "Name": "BrickColor"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "Yellow",
+                    "Parameters": [],
+                    "ReturnType": {
+                        "Name": "BrickColor"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "Blue",
+                    "Parameters": [],
+                    "ReturnType": {
+                        "Name": "BrickColor"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "Gray",
+                    "Parameters": [],
+                    "ReturnType": {
+                        "Name": "BrickColor"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "DarkGray",
+                    "Parameters": [],
+                    "ReturnType": {
+                        "Name": "BrickColor"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "White",
+                    "Parameters": [],
+                    "ReturnType": {
+                        "Name": "BrickColor"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "random",
+                    "Parameters": [],
+                    "ReturnType": {
+                        "Name": "BrickColor"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "Green",
+                    "Parameters": [],
+                    "ReturnType": {
+                        "Name": "BrickColor"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "Black",
+                    "Parameters": [],
+                    "ReturnType": {
+                        "Name": "BrickColor"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "palette",
+                    "Parameters": [
+                        {
+                            "Name": "paletteValue",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "BrickColor"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "new",
+                    "Parameters": [
+                        {
+                            "Name": "val",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "BrickColor"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "new",
+                    "Parameters": [
+                        {
+                            "Name": "r",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Name": "g",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Name": "b",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "BrickColor"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "new",
+                    "Parameters": [
+                        {
+                            "Name": "val",
+                            "Type": {
+                                "Name": "string"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "BrickColor"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "new",
+                    "Parameters": [
+                        {
+                            "Name": "color",
+                            "Type": {
+                                "Name": "Color3"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "BrickColor"
+                    }
+                }
+            ],
+            "Name": "BrickColor"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Function",
+                    "Name": "new",
+                    "Parameters": [
+                        {
+                            "Name": "x",
+                            "Default": "0",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Name": "y",
+                            "Default": "0",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "Vector2"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "zero",
+                    "ValueType": {
+                        "Name": "Vector2"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "one",
+                    "ValueType": {
+                        "Name": "Vector2"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "xAxis",
+                    "ValueType": {
+                        "Name": "Vector2"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "yAxis",
+                    "ValueType": {
+                        "Name": "Vector2"
+                    }
+                }
+            ],
+            "Name": "Vector2"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Function",
+                    "Name": "new",
+                    "Parameters": [
+                        {
+                            "Name": "x",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Name": "y",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "Vector2int16"
+                    }
+                }
+            ],
+            "Name": "Vector2int16"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Function",
+                    "Name": "fromRGB",
+                    "Parameters": [
+                        {
+                            "Default": "0",
+                            "Name": "red",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Default": "0",
+                            "Name": "green",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Default": "0",
+                            "Name": "blue",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "Color3"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "fromHSV",
+                    "Parameters": [
+                        {
+                            "Name": "hue",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Name": "saturation",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Name": "value",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "Color3"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "toHSV",
+                    "Deprecated": true,
+                    "Parameters": [
+                        {
+                            "Name": "color",
+                            "Type": {
+                                "Name": "Color3"
+                            }
+                        }
+                    ],
+                    "TupleReturns": [
+                        {
+                            "Name": "number"
+                        },
+                        {
+                            "Name": "number"
+                        },
+                        {
+                            "Name": "number"
+                        }
+                    ]
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "new",
+                    "Parameters": [
+                        {
+                            "Default": "0",
+                            "Name": "red",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Default": "0",
+                            "Name": "green",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Default": "0",
+                            "Name": "blue",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "Color3"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "fromHex",
+                    "Parameters": [
+                        {
+                            "Name": "hex",
+                            "Type": {
+                                "Name": "string"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "Color3"
+                    }
+                }
+            ],
+            "Name": "Color3"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Function",
+                    "Name": "new",
+                    "Parameters": [
+                        {
+                            "Name": "Scale",
+                            "Default": "0",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Name": "Offset",
+                            "Default": "0",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "UDim"
+                    }
+                }
+            ],
+            "Name": "UDim"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Function",
+                    "Name": "new",
+                    "Parameters": [
+                        {
+                            "Name": "material",
+                            "Type": {
+                                "Category": "Enum",
+                                "Name": "Material"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "PhysicalProperties"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "new",
+                    "Parameters": [
+                        {
+                            "Name": "density",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Name": "friction",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Name": "elasticity",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Name": "frictionWeight",
+                            "Default": "nil",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Name": "elasticityWeight",
+                            "Default": "nil",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "PhysicalProperties"
+                    }
+                }
+            ],
+            "Name": "PhysicalProperties"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Function",
+                    "Name": "new",
+                    "Parameters": [
+                        {
+                            "Name": "axes",
+                            "Type": {
+                                "Name": "Tuple"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "Axes"
+                    }
+                }
+            ],
+            "Name": "Axes"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Function",
+                    "Name": "new",
+                    "Parameters": [
+                        {
+                            "Name": "min",
+                            "Type": {
+                                "Name": "Vector3"
+                            }
+                        },
+                        {
+                            "Name": "max",
+                            "Type": {
+                                "Name": "Vector3"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "Region3"
+                    }
+                }
+            ],
+            "Name": "Region3"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Function",
+                    "Name": "new",
+                    "Parameters": [
+                        {
+                            "Name": "min",
+                            "Type": {
+                                "Name": "Vector3int16"
+                            }
+                        },
+                        {
+                            "Name": "max",
+                            "Type": {
+                                "Name": "Vector3int16"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "Region3int16"
+                    }
+                }
+            ],
+            "Name": "Region3int16"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Function",
+                    "Name": "fromScale",
+                    "Parameters": [
+                        {
+                            "Name": "xScale",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Name": "yScale",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "UDim2"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "fromOffset",
+                    "Parameters": [
+                        {
+                            "Name": "xOffset",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Name": "yOffset",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "UDim2"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "new",
+                    "Parameters": [
+                        {
+                            "Name": "x",
+                            "Type": {
+                                "Name": "UDim"
+                            }
+                        },
+                        {
+                            "Name": "y",
+                            "Type": {
+                                "Name": "UDim"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "UDim2"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "new",
+                    "Parameters": [
+                        {
+                            "Name": "xScale",
+                            "Default": "0",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Name": "xOffset",
+                            "Default": "0",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Name": "yScale",
+                            "Default": "0",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Name": "yOffset",
+                            "Default": "0",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "UDim2"
+                    }
+                }
+            ],
+            "Name": "UDim2"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Function",
+                    "Name": "fromEulerAnglesYXZ",
+                    "Parameters": [
+                        {
+                            "Name": "rx",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Name": "ry",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Name": "rz",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "CFrame"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "Angles",
+                    "Parameters": [
+                        {
+                            "Name": "rx",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Name": "ry",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Name": "rz",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "CFrame"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "fromMatrix",
+                    "Parameters": [
+                        {
+                            "Name": "pos",
+                            "Type": {
+                                "Name": "Vector3"
+                            }
+                        },
+                        {
+                            "Name": "vX",
+                            "Type": {
+                                "Name": "Vector3"
+                            }
+                        },
+                        {
+                            "Name": "vY",
+                            "Type": {
+                                "Name": "Vector3"
+                            }
+                        },
+                        {
+                            "Name": "vZ",
+                            "Type": {
+                                "Name": "Vector3"
+                            },
+                            "Default": "nil"
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "CFrame"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "fromAxisAngle",
+                    "Parameters": [
+                        {
+                            "Name": "v",
+                            "Type": {
+                                "Name": "Vector3"
+                            }
+                        },
+                        {
+                            "Name": "r",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "CFrame"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "fromOrientation",
+                    "Parameters": [
+                        {
+                            "Name": "rx",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Name": "ry",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Name": "rz",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "CFrame"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "fromEulerAnglesXYZ",
+                    "Parameters": [
+                        {
+                            "Name": "rx",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Name": "ry",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Name": "rz",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "CFrame"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "lookAt",
+                    "Parameters": [
+                        {
+                            "Name": "at",
+                            "Type": {
+                                "Name": "Vector3"
+                            }
+                        },
+                        {
+                            "Name": "target",
+                            "Type": {
+                                "Name": "Vector3"
+                            }
+                        },
+                        {
+                            "Name": "up",
+                            "Default": "(0, 1, 0)",
+                            "Type": {
+                                "Name": "Vector3"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "CFrame"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "new",
+                    "Parameters": [],
+                    "ReturnType": {
+                        "Name": "CFrame"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "new",
+                    "Parameters": [
+                        {
+                            "Name": "pos",
+                            "Type": {
+                                "Name": "Vector3"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "CFrame"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "new",
+                    "Parameters": [
+                        {
+                            "Name": "pos",
+                            "Type": {
+                                "Name": "Vector3"
+                            }
+                        },
+                        {
+                            "Name": "lookAt",
+                            "Type": {
+                                "Name": "Vector3"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "CFrame"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "new",
+                    "Parameters": [
+                        {
+                            "Name": "x",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Name": "y",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Name": "z",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "CFrame"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "new",
+                    "Parameters": [
+                        {
+                            "Name": "x",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Name": "y",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Name": "z",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Name": "qX",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Name": "qY",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Name": "qZ",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Name": "qW",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "CFrame"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "new",
+                    "Parameters": [
+                        {
+                            "Name": "x",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Name": "y",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Name": "z",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Name": "R00",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Name": "R01",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Name": "R02",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Name": "R10",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Name": "R11",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Name": "R12",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Name": "R20",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Name": "R21",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Name": "R22",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "CFrame"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "identity",
+                    "ValueType": {
+                        "Name": "CFrame"
+                    }
+                }
+            ],
+            "Name": "CFrame"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Function",
+                    "Name": "new",
+                    "Parameters": [
+                        {
+                            "Name": "normalIds",
+                            "Type": {
+                                "Name": "Tuple"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "Faces"
+                    }
+                }
+            ],
+            "Name": "Faces"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Function",
+                    "Name": "new",
+                    "Parameters": [
+                        {
+                            "Name": "min",
+                            "Type": {
+                                "Name": "Vector2"
+                            }
+                        },
+                        {
+                            "Name": "max",
+                            "Type": {
+                                "Name": "Vector2"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "Rect"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "new",
+                    "Parameters": [
+                        {
+                            "Name": "minX",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Name": "minY",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Name": "maxX",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Name": "maxY",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "Rect"
+                    }
+                }
+            ],
+            "Name": "Rect"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Function",
+                    "Name": "fromNormalId",
+                    "Parameters": [
+                        {
+                            "Name": "normal",
+                            "Type": {
+                                "Category": "Enum",
+                                "Name": "NormalId"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "Vector3"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "fromAxis",
+                    "Parameters": [
+                        {
+                            "Name": "axis",
+                            "Type": {
+                                "Category": "Enum",
+                                "Name": "Axis"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "Vector3"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "FromNormalId",
+                    "Deprecated": false,
+                    "Parameters": [
+                        {
+                            "Name": "normal",
+                            "Type": {
+                                "Category": "Enum",
+                                "Name": "NormalId"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "Vector3"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "FromAxis",
+                    "Deprecated": false,
+                    "Parameters": [
+                        {
+                            "Name": "axis",
+                            "Type": {
+                                "Category": "Enum",
+                                "Name": "Axis"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "Vector3"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "new",
+                    "Parameters": [
+                        {
+                            "Default": "0",
+                            "Name": "x",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Default": "0",
+                            "Name": "y",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Default": "0",
+                            "Name": "z",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "Vector3"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "zero",
+                    "ValueType": {
+                        "Name": "Vector3"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "one",
+                    "ValueType": {
+                        "Name": "Vector3"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "xAxis",
+                    "ValueType": {
+                        "Name": "Vector3"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "yAxis",
+                    "ValueType": {
+                        "Name": "Vector3"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "zAxis",
+                    "ValueType": {
+                        "Name": "Vector3"
+                    }
+                }
+            ],
+            "Name": "Vector3"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Function",
+                    "Name": "new",
+                    "Parameters": [
+                        {
+                            "Default": "0",
+                            "Name": "x",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Default": "0",
+                            "Name": "y",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Default": "0",
+                            "Name": "z",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "Vector3int16"
+                    }
+                }
+            ],
+            "Name": "Vector3int16"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Function",
+                    "Name": "new",
+                    "Parameters": [
+                        {
+                            "Name": "seed",
+                            "Default": "nil",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "Random"
+                    }
+                }
+            ],
+            "Name": "Random"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Function",
+                    "Name": "new",
+                    "Parameters": [
+                        {
+                            "Default": "1.0",
+                            "Name": "time",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Default": "Quad",
+                            "Name": "easingStyle",
+                            "Type": {
+                                "Category": "Enum",
+                                "Name": "EasingStyle"
+                            }
+                        },
+                        {
+                            "Default": "Out",
+                            "Name": "easingDirection",
+                            "Type": {
+                                "Category": "Enum",
+                                "Name": "EasingDirection"
+                            }
+                        },
+                        {
+                            "Default": "0",
+                            "Name": "repeatCount",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Default": "false",
+                            "Name": "reverses",
+                            "Type": {
+                                "Name": "bool"
+                            }
+                        },
+                        {
+                            "Default": "0",
+                            "Name": "delayTime",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "TweenInfo"
+                    }
+                }
+            ],
+            "Name": "TweenInfo"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Function",
+                    "Name": "now",
+                    "Parameters": [],
+                    "ReturnType": {
+                        "Name": "DateTime"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "fromUnixTimestamp",
+                    "Parameters": [
+                        {
+                            "Name": "unixTimestamp",
+                            "Type": {
+                                "Name": "int"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "DateTime"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "fromUnixTimestampMillis",
+                    "Parameters": [
+                        {
+                            "Name": "unixTimestampMillis",
+                            "Type": {
+                                "Name": "int"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "DateTime"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "fromUniversalTime",
+                    "Parameters": [
+                        {
+                            "Default": "1970",
+                            "Name": "year",
+                            "Type": {
+                                "Name": "int"
+                            }
+                        },
+                        {
+                            "Default": "1",
+                            "Name": "month",
+                            "Type": {
+                                "Name": "int"
+                            }
+                        },
+                        {
+                            "Default": "1",
+                            "Name": "day",
+                            "Type": {
+                                "Name": "int"
+                            }
+                        },
+                        {
+                            "Default": "0",
+                            "Name": "hour",
+                            "Type": {
+                                "Name": "int"
+                            }
+                        },
+                        {
+                            "Default": "0",
+                            "Name": "minute",
+                            "Type": {
+                                "Name": "int"
+                            }
+                        },
+                        {
+                            "Default": "0",
+                            "Name": "second",
+                            "Type": {
+                                "Name": "int"
+                            }
+                        },
+                        {
+                            "Default": "0",
+                            "Name": "millisecond",
+                            "Type": {
+                                "Name": "int"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "DateTime"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "fromLocalTime",
+                    "Parameters": [
+                        {
+                            "Default": "1970",
+                            "Name": "year",
+                            "Type": {
+                                "Name": "int"
+                            }
+                        },
+                        {
+                            "Default": "1",
+                            "Name": "month",
+                            "Type": {
+                                "Name": "int"
+                            }
+                        },
+                        {
+                            "Default": "1",
+                            "Name": "day",
+                            "Type": {
+                                "Name": "int"
+                            }
+                        },
+                        {
+                            "Default": "0",
+                            "Name": "hour",
+                            "Type": {
+                                "Name": "int"
+                            }
+                        },
+                        {
+                            "Default": "0",
+                            "Name": "minute",
+                            "Type": {
+                                "Name": "int"
+                            }
+                        },
+                        {
+                            "Default": "0",
+                            "Name": "second",
+                            "Type": {
+                                "Name": "int"
+                            }
+                        },
+                        {
+                            "Default": "0",
+                            "Name": "millisecond",
+                            "Type": {
+                                "Name": "int"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "DateTime"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "fromIsoDate",
+                    "Parameters": [
+                        {
+                            "Name": "isoDate",
+                            "Type": {
+                                "Name": "string"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "DateTime"
+                    }
+                }
+            ],
+            "Name": "DateTime"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Function",
+                    "Name": "new",
+                    "Parameters": [
+                        {
+                            "Name": "n",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "NumberSequence"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "new",
+                    "Parameters": [
+                        {
+                            "Name": "n0",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Name": "n1",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "NumberSequence"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "new",
+                    "Parameters": [
+                        {
+                            "Name": "keypoints",
+                            "Type": {
+                                "Name": "Array",
+                                "Generic": "NumberSequenceKeypoint"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "NumberSequence"
+                    }
+                }
+            ],
+            "Name": "NumberSequence"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Function",
+                    "Name": "new",
+                    "Parameters": [
+                        {
+                            "Name": "c",
+                            "Type": {
+                                "Name": "Color3"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "ColorSequence"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "new",
+                    "Parameters": [
+                        {
+                            "Name": "c0",
+                            "Type": {
+                                "Name": "Color3"
+                            }
+                        },
+                        {
+                            "Name": "c1",
+                            "Type": {
+                                "Name": "Color3"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "ColorSequence"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "new",
+                    "Parameters": [
+                        {
+                            "Name": "keypoints",
+                            "Type": {
+                                "Name": "Array",
+                                "Generic": "ColorSequenceKeypoint"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "ColorSequence"
+                    }
+                }
+            ],
+            "Name": "ColorSequence"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Function",
+                    "Name": "new",
+                    "Parameters": [
+                        {
+                            "Name": "time",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Name": "value",
+                            "Type": {
+                                "Name":  "number"
+                            }
+                        },
+                        {
+                            "Name": "envelop",
+                            "Default": "nil",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "NumberSequenceKeypoint"
+                    }
+                }
+            ],
+            "Name": "NumberSequenceKeypoint"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Function",
+                    "Name": "new",
+                    "Parameters": [
+                        {
+                            "Name": "time",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Name": "color",
+                            "Type": {
+                                "Name": "Color3"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "ColorSequenceKeypoint"
+                    }
+                }
+            ],
+            "Name": "ColorSequenceKeypoint"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Function",
+                    "Name": "new",
+                    "Parameters": [],
+                    "ReturnType": {
+                        "Name": "RaycastParams"
+                    }
+                }
+            ],
+            "Name": "RaycastParams"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Function",
+                    "Name": "new",
+                    "Parameters": [],
+                    "ReturnType": {
+                        "Name": "OverlapParams"
+                    }
+                }
+            ],
+            "Name": "OverlapParams"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Function",
+                    "Name": "new",
+                    "Parameters": [
+                        {
+                            "Name": "initDockState",
+                            "Default": "Right",
+                            "Type": {
+                                "Category": "Enum",
+                                "Name": "InitialDockState"
+                            }
+                        },
+                        {
+                            "Name": "initEnabled",
+                            "Default": "false",
+                            "Type": {
+                                "Name": "boolean"
+                            }
+                        },
+                        {
+                            "Name": "overrideEnabledRestore",
+                            "Default": "false",
+                            "Type": {
+                                "Name": "boolean"
+                            }
+                        },
+                        {
+                            "Name": "floatXSize",
+                            "Default": "0",
+                            "Type": {
+                                "Name": "int"
+                            }
+                        },
+                        {
+                            "Name": "floatYSize",
+                            "Default": "0",
+                            "Type": {
+                                "Name": "int"
+                            }
+                        },
+                        {
+                            "Name": "minWidth",
+                            "Default": "0",
+                            "Type": {
+                                "Name": "int"
+                            }
+                        },
+                        {
+                            "Name": "minHeight",
+                            "Default": "0",
+                            "Type": {
+                                "Name": "int"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "DockWidgetPluginGuiInfo"
+                    }
+                }
+            ],
+            "Name": "DockWidgetPluginGuiInfo"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Function",
+                    "Name": "new",
+                    "Parameters": [],
+                    "ReturnType": {
+                        "Category": "",
+                        "Name": "CatalogSearchParams"
+                    }
+                }
+            ],
+            "Name": "CatalogSearchParams"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Function",
+                    "Name": "new",
+                    "Parameters": [
+                        {
+                            "Name": "family",
+                            "Type": {
+                                "Name": "string"
+                            }
+                        },
+                        {
+                            "Name": "weight",
+                            "Default": "Regular",
+                            "Type": {
+                                "Category": "Enum",
+                                "Name": "FontWeight"
+                            }
+                        },
+                        {
+                            "Name": "style",
+                            "Default": "Normal",
+                            "Type": {
+                                "Category": "Enum",
+                                "Name": "FontStyle"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "Font"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "fromEnum",
+                    "Parameters": [
+                        {
+                            "Name": "font",
+                            "Type": {
+                                "Category": "Enum",
+                                "Name": "Font"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "Font"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "fromName",
+                    "Parameters": [
+                        {
+                            "Name": "name",
+                            "Type": {
+                                "Name": "string"
+                            }
+                        },
+                        {
+                            "Name": "weight",
+                            "Default": "Regular",
+                            "Type": {
+                                "Category": "Enum",
+                                "Name": "FontWeight"
+                            }
+                        },
+                        {
+                            "Name": "style",
+                            "Default": "Normal",
+                            "Type": {
+                                "Category": "Enum",
+                                "Name": "FontStyle"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "Font"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "fromId",
+                    "Parameters": [
+                        {
+                            "Name": "id",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Name": "weight",
+                            "Default": "Regular",
+                            "Type": {
+                                "Category": "Enum",
+                                "Name": "FontWeight"
+                            }
+                        },
+                        {
+                            "Name": "style",
+                            "Default": "Normal",
+                            "Type": {
+                                "Category": "Enum",
+                                "Name": "FontStyle"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "Font"
+                    }
+                }
+            ],
+            "Name": "Font"
+        },
+        {
+            "Members": [
+                    {
+                        "MemberType": "Function",
+                        "Name": "new",
+                        "Parameters": [
+                            {
+                                "Name": "time",
+                                "Type": {
+                                    "Name": "number"
+                                }
+                            },
+                            {
+                                "Name": "value",
+                                "Type": {
+                                    "Name": "number"
+                                }
+                            },
+                            {
+                                "Name": "Interpolation",
+                                "Type": {
+                                    "Category": "Enum",
+                                    "Name": "KeyInterpolationMode"
+                                }
+                            }
+                        ],
+                        "ReturnType": {
+                            "Name": "FloatCurveKey"
+                        }
+                    }
+            ],
+            "Name": "FloatCurveKey"
+        },
+        {
+            "Members": [
+                    {
+                        "MemberType": "Function",
+                        "Name": "new",
+                        "Parameters": [
+                            {
+                                "Name": "time",
+                                "Type": {
+                                    "Name": "number"
+                                }
+                            },
+                            {
+                                "Name": "value",
+                                "Type": {
+                                    "Name": "CFrame"
+                                }
+                            },
+                            {
+                                "Name": "Interpolation",
+                                "Type": {
+                                    "Category": "Enum",
+                                    "Name": "KeyInterpolationMode"
+                                }
+                            }
+                        ],
+                        "ReturnType": {
+                            "Name": "RotationCurveKey"
+                        }
+                    }
+            ],
+            "Name": "RotationCurveKey"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Function",
+                    "Name": "new",
+                    "Parameters": [],
+                    "ReturnType": {
+                        "Name": "SharedTable"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "new",
+                    "Parameters": [
+                        {
+                            "Name": "value",
+                            "Type": {
+                                "Name": "table"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "SharedTable"
+                    }
+                }
+            ],
+            "Name": "SharedTable"
+        }
+    ],
+    "DataTypes": [
+        {
+            "Members": [
+                {
+                    "MemberType": "Function",
+                    "Name": "ClosestPoint",
+                    "Parameters": [
+                        {
+                            "Name": "point",
+                            "Type": {
+                                "Name": "Vector3"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "Vector3"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "Origin",
+                    "ValueType": {
+                        "Name": "Vector3"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "Unit",
+                    "ValueType": {
+                        "Name": "Ray"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "Distance",
+                    "Parameters": [
+                        {
+                            "Name": "point",
+                            "Type": {
+                                "Name": "Vector3"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "number"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "Direction",
+                    "ValueType": {
+                        "Name": "Vector3"
+                    }
+                }
+            ],
+            "Name": "Ray"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Property",
+                    "Name": "Max",
+                    "ValueType": {
+                        "Name": "number"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "Min",
+                    "ValueType": {
+                        "Name": "number"
+                    }
+                }
+            ],
+            "Name": "NumberRange"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Property",
+                    "Name": "Position",
+                    "ValueType": {
+                        "Name": "Vector3"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "Action",
+                    "ValueType": {
+                        "Category": "Enum",
+                        "Name": "PathWaypointAction"
+                    }
+                }
+            ],
+            "Name": "PathWaypoint"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Property",
+                    "Name": "r",
+                    "ValueType": {
+                        "Name": "number"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "Name",
+                    "ValueType": {
+                        "Name": "string"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "Number",
+                    "ValueType": {
+                        "Name": "number"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "Color",
+                    "ValueType": {
+                        "Name": "Color3"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "b",
+                    "ValueType": {
+                        "Name": "number"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "g",
+                    "ValueType": {
+                        "Name": "number"
+                    }
+                }
+            ],
+            "Name": "BrickColor"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Property",
+                    "Name": "Y",
+                    "ValueType": {
+                        "Name": "number"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "X",
+                    "ValueType": {
+                        "Name": "number"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "Unit",
+                    "ValueType": {
+                        "Name": "Vector2"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "Magnitude",
+                    "ValueType": {
+                        "Name": "number"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "Lerp",
+                    "Parameters": [
+                        {
+                            "Name": "v",
+                            "Type": {
+                                "Name": "Vector2"
+                            }
+                        },
+                        {
+                            "Name": "alpha",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "Vector2"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "Cross",
+                    "Parameters": [
+                        {
+                            "Name": "other",
+                            "Type": {
+                                "Name": "Vector2"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "number"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "Dot",
+                    "Parameters": [
+                        {
+                            "Name": "v",
+                            "Type": {
+                                "Name": "Vector2"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "number"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "Max",
+                    "Parameters": [
+                        {
+                            "Name": "other",
+                            "Type": {
+                                "Tuple": {
+                                    "Name": "Vector2"
+                                }
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "Vector2"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "Min",
+                    "Parameters": [
+                        {
+                            "Name": "other",
+                            "Type": {
+                                "Tuple": {
+                                    "Name": "Vector2"
+                                }
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "Vector2"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "y",
+                    "Deprecated": true,
+                    "ValueType": {
+                        "Name": "number"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "x",
+                    "Deprecated": true,
+                    "ValueType": {
+                        "Name": "number"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "unit",
+                    "Deprecated": true,
+                    "ValueType": {
+                        "Name": "Vector2"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "magnitude",
+                    "Deprecated": true,
+                    "ValueType": {
+                        "Name": "number"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "lerp",
+                    "Deprecated": true,
+                    "Parameters": [
+                        {
+                            "Name": "v",
+                            "Type": {
+                                "Name": "Vector2"
+                            }
+                        },
+                        {
+                            "Name": "alpha",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "Vector2"
+                    }
+                }
+            ],
+            "Name": "Vector2"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Property",
+                    "Name": "R",
+                    "ValueType": {
+                        "Name": "number"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "B",
+                    "ValueType": {
+                        "Name": "number"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "G",
+                    "ValueType": {
+                        "Name": "number"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "ToHSV",
+                    "Parameters": [],
+                    "TupleReturns": [
+                        {
+                            "Name": "number"
+                        },
+                        {
+                            "Name": "number"
+                        },
+                        {
+                            "Name": "number"
+                        }
+                    ]
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "ToHex",
+                    "Parameters": [],
+                    "ReturnType": {
+                        "Name": "string"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "Lerp",
+                    "Parameters": [
+                        {
+                            "Name": "color",
+                            "Type": {
+                                "Name": "Color3"
+                            }
+                        },
+                        {
+                            "Name": "alpha",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "Color3"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "r",
+                    "Deprecated": true,
+                    "ValueType": {
+                        "Name": "number"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "g",
+                    "Deprecated": true,
+                    "ValueType": {
+                        "Name": "number"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "b",
+                    "Deprecated": true,
+                    "ValueType": {
+                        "Name": "number"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "lerp",
+                    "Deprecated": true,
+                    "Parameters": [
+                        {
+                            "Name": "color",
+                            "Type": {
+                                "Name": "Color3"
+                            }
+                        },
+                        {
+                            "Name": "alpha",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "Color3"
+                    }
+                }
+            ],
+            "Name": "Color3"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Property",
+                    "Name": "Scale",
+                    "ValueType": {
+                        "Name": "number"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "Offset",
+                    "ValueType": {
+                        "Name": "int"
+                    }
+                }
+            ],
+            "Name": "UDim"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Property",
+                    "Name": "ElasticityWeight",
+                    "ValueType": {
+                        "Name": "number"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "Elasticity",
+                    "ValueType": {
+                        "Name": "number"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "Density",
+                    "ValueType": {
+                        "Name": "number"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "FrictionWeight",
+                    "ValueType": {
+                        "Name": "number"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "Friction",
+                    "ValueType": {
+                        "Name": "number"
+                    }
+                }
+            ],
+            "Name": "PhysicalProperties"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Property",
+                    "Name": "Z",
+                    "ValueType": {
+                        "Name": "bool"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "Y",
+                    "ValueType": {
+                        "Name": "bool"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "Top",
+                    "ValueType": {
+                        "Name": "bool"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "Left",
+                    "ValueType": {
+                        "Name": "bool"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "X",
+                    "ValueType": {
+                        "Name": "bool"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "Right",
+                    "ValueType": {
+                        "Name": "bool"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "Bottom",
+                    "ValueType": {
+                        "Name": "bool"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "Front",
+                    "ValueType": {
+                        "Name": "bool"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "Back",
+                    "ValueType": {
+                        "Name": "bool"
+                    }
+                }
+            ],
+            "Name": "Axes"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Property",
+                    "Name": "CFrame",
+                    "ValueType": {
+                        "Name": "CFrame"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "ExpandToGrid",
+                    "Parameters": [
+                        {
+                            "Name": "Region",
+                            "Type": {
+                                "Name": "int"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "Region3"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "Size",
+                    "ValueType": {
+                        "Name": "Vector3"
+                    }
+                }
+            ],
+            "Name": "Region3"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Property",
+                    "Name": "Y",
+                    "ValueType": {
+                        "Name": "UDim"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "Lerp",
+                    "Parameters": [
+                        {
+                            "Name": "goal",
+                            "Type": {
+                                "Name": "UDim2"
+                            }
+                        },
+                        {
+                            "Name": "alpha",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "UDim2"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "Height",
+                    "ValueType": {
+                        "Name": "UDim"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "X",
+                    "ValueType": {
+                        "Name": "UDim"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "Width",
+                    "ValueType": {
+                        "Name": "UDim"
+                    }
+                }
+            ],
+            "Name": "UDim2"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Property",
+                    "Name": "Z",
+                    "ValueType": {
+                        "Name": "number"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "Y",
+                    "ValueType": {
+                        "Name": "number"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "X",
+                    "ValueType": {
+                        "Name": "number"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "PointToObjectSpace",
+                    "Parameters": [
+                        {
+                            "Name": "v3",
+                            "Type": {
+                                "Name": "Vector3"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "Vector3"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "YVector",
+                    "ValueType": {
+                        "Name": "Vector3"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "XVector",
+                    "ValueType": {
+                        "Name": "Vector3"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "ZVector",
+                    "ValueType": {
+                        "Name": "Vector3"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "Position",
+                    "ValueType": {
+                        "Name": "Vector3"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "Rotation",
+                    "ValueType": {
+                        "Name": "CFrame"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "RightVector",
+                    "ValueType": {
+                        "Name": "Vector3"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "VectorToWorldSpace",
+                    "Parameters": [
+                        {
+                            "Name": "v3",
+                            "Type": {
+                                "Name": "Vector3"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "Vector3"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "ToAxisAngle",
+                    "Parameters": [],
+                    "TupleReturns": [
+                        {
+                            "Name": "Vector3"
+                        },
+                        {
+                            "Name": "number"
+                        }
+                    ]
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "ToOrientation",
+                    "Parameters": [],
+                    "TupleReturns": [
+                        {
+                            "Name": "number"
+                        },
+                        {
+                            "Name": "number"
+                        },
+                        {
+                            "Name": "number"
+                        }
+                    ]
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "ToEulerAnglesYXZ",
+                    "Parameters": [],
+                    "TupleReturns": [
+                        {
+                            "Name": "number"
+                        },
+                        {
+                            "Name": "number"
+                        },
+                        {
+                            "Name": "number"
+                        }
+                    ]
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "Inverse",
+                    "Parameters": [],
+                    "ReturnType": {
+                        "Name": "CFrame"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "UpVector",
+                    "ValueType": {
+                        "Name": "Vector3"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "Lerp",
+                    "Parameters": [
+                        {
+                            "Name": "goal",
+                            "Type": {
+                                "Name": "CFrame"
+                            }
+                        },
+                        {
+                            "Name": "alpha",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "CFrame"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "GetComponents",
+                    "Parameters": [],
+                    "TupleReturns": [
+                        {
+                            "Name": "number"
+                        },
+                        {
+                            "Name": "number"
+                        },
+                        {
+                            "Name": "number"
+                        },
+                        {
+                            "Name": "number"
+                        },
+                        {
+                            "Name": "number"
+                        },
+                        {
+                            "Name": "number"
+                        },
+                        {
+                            "Name": "number"
+                        },
+                        {
+                            "Name": "number"
+                        },
+                        {
+                            "Name": "number"
+                        },
+                        {
+                            "Name": "number"
+                        },
+                        {
+                            "Name": "number"
+                        },
+                        {
+                            "Name": "number"
+                        }
+                    ]
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "VectorToObjectSpace",
+                    "Parameters": [
+                        {
+                            "Name": "v3",
+                            "Type": {
+                                "Name": "Vector3"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "Vector3"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "LookVector",
+                    "ValueType": {
+                        "Name": "Vector3"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "PointToWorldSpace",
+                    "Parameters": [
+                        {
+                            "Name": "v3",
+                            "Type": {
+                                "Name": "Vector3"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "Vector3"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "ToWorldSpace",
+                    "Parameters": [
+                        {
+                            "Name": "cf",
+                            "Type": {
+                                "Name": "CFrame"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "CFrame"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "ToObjectSpace",
+                    "Parameters": [
+                        {
+                            "Name": "cf",
+                            "Type": {
+                                "Name": "CFrame"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "CFrame"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "ToEulerAnglesXYZ",
+                    "Parameters": [],
+                    "TupleReturns": [
+                        {
+                            "Name": "number"
+                        },
+                        {
+                            "Name": "number"
+                        },
+                        {
+                            "Name": "number"
+                        }
+                    ]
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "Orthonormalize",
+                    "Parameters": [],
+                    "ReturnType": {
+                        "Name": "CFrame"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "z",
+                    "Deprecated": true,
+                    "ValueType": {
+                        "Name": "number"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "y",
+                    "Deprecated": true,
+                    "ValueType": {
+                        "Name": "number"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "x",
+                    "Deprecated": true,
+                    "ValueType": {
+                        "Name": "number"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "pointToObjectSpace",
+                    "Deprecated": true,
+                    "Parameters": [
+                        {
+                            "Name": "v3",
+                            "Type": {
+                                "Name": "Vector3"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "Vector3"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "p",
+                    "Deprecated": true,
+                    "ValueType": {
+                        "Name": "Vector3"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Deprecated": true,
+                    "Name": "rightVector",
+                    "ValueType": {
+                        "Name": "Vector3"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Deprecated": true,
+                    "Name": "vectorToWorldSpace",
+                    "Parameters": [
+                        {
+                            "Name": "v3",
+                            "Type": {
+                                "Name": "Vector3"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "Vector3"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "toAxisAngle",
+                    "Deprecated": true,
+                    "Parameters": [],
+                    "TupleReturns": [
+                        {
+                            "Name": "Vector3"
+                        },
+                        {
+                            "Name": "number"
+                        }
+                    ]
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "inverse",
+                    "Deprecated": true,
+                    "Parameters": [],
+                    "ReturnType": {
+                        "Name": "CFrame"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "upVector",
+                    "Deprecated": true,
+                    "ValueType": {
+                        "Name": "Vector3"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "lerp",
+                    "Deprecated": true,
+                    "Parameters": [
+                        {
+                            "Name": "goal",
+                            "Type": {
+                                "Name": "CFrame"
+                            }
+                        },
+                        {
+                            "Name": "alpha",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "CFrame"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "vectorToObjectSpace",
+                    "Deprecated": true,
+                    "Parameters": [
+                        {
+                            "Name": "v3",
+                            "Type": {
+                                "Name": "Vector3"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "Vector3"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "lookVector",
+                    "Deprecated": true,
+                    "ValueType": {
+                        "Name": "Vector3"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "pointToWorldSpace",
+                    "Deprecated": true,
+                    "Parameters": [
+                        {
+                            "Name": "v3",
+                            "Type": {
+                                "Name": "Vector3"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "Vector3"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "toWorldSpace",
+                    "Deprecated": true,
+                    "Parameters": [
+                        {
+                            "Name": "cf",
+                            "Type": {
+                                "Name": "CFrame"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "CFrame"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "toObjectSpace",
+                    "Deprecated": true,
+                    "Parameters": [
+                        {
+                            "Name": "cf",
+                            "Type": {
+                                "Name": "CFrame"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "CFrame"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "toEulerAnglesXYZ",
+                    "Deprecated": true,
+                    "Parameters": [],
+                    "TupleReturns": [
+                        {
+                            "Name": "number"
+                        },
+                        {
+                            "Name": "number"
+                        },
+                        {
+                            "Name": "number"
+                        }
+                    ]
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "components",
+                    "Deprecated": true,
+                    "Parameters": [],
+                    "TupleReturns": [
+                        {
+                            "Name": "number"
+                        },
+                        {
+                            "Name": "number"
+                        },
+                        {
+                            "Name": "number"
+                        },
+                        {
+                            "Name": "number"
+                        },
+                        {
+                            "Name": "number"
+                        },
+                        {
+                            "Name": "number"
+                        },
+                        {
+                            "Name": "number"
+                        },
+                        {
+                            "Name": "number"
+                        },
+                        {
+                            "Name": "number"
+                        },
+                        {
+                            "Name": "number"
+                        },
+                        {
+                            "Name": "number"
+                        },
+                        {
+                            "Name": "number"
+                        }
+                    ]
+                }
+            ],
+            "Name": "CFrame"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Property",
+                    "Name": "Bottom",
+                    "ValueType": {
+                        "Name": "bool"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "Top",
+                    "ValueType": {
+                        "Name": "bool"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "Front",
+                    "ValueType": {
+                        "Name": "bool"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "Left",
+                    "ValueType": {
+                        "Name": "bool"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "Right",
+                    "ValueType": {
+                        "Name": "bool"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "Back",
+                    "ValueType": {
+                        "Name": "bool"
+                    }
+                }
+            ],
+            "Name": "Faces"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Function",
+                    "Name": "IsA",
+                    "Parameters": [
+                        {
+                            "Name": "enumName",
+                            "Type": {
+                                "Name": "string"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "bool"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "EnumType",
+                    "ValueType": {
+                        "Name": "Enum"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "Value",
+                    "ValueType": {
+                        "Name": "int"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "Name",
+                    "ValueType": {
+                        "Name": "string"
+                    }
+                }
+            ],
+            "Name": "EnumItem"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Function",
+                    "Name": "GetEnumItems",
+                    "Parameters": [],
+                    "ReturnType": {
+                        "Name": "Array",
+                        "Generic": "EnumItem"
+                    }
+                }
+            ],
+            "Name": "Enum"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Function",
+                    "Name": "GetEnums",
+                    "Parameters": [],
+                    "ReturnType": {
+                        "Name": "Array",
+                        "Generic": "Enum"
+                    }
+                }
+            ],
+            "Name": "Enums"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Property",
+                    "Name": "Max",
+                    "ValueType": {
+                        "Name": "Vector2"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "Min",
+                    "ValueType": {
+                        "Name": "Vector2"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "Height",
+                    "ValueType": {
+                        "Name": "number"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "Width",
+                    "ValueType": {
+                        "Name": "number"
+                    }
+                }
+            ],
+            "Name": "Rect"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Property",
+                    "Name": "Z",
+                    "ValueType": {
+                        "Name": "number"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "Y",
+                    "ValueType": {
+                        "Name": "number"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "X",
+                    "ValueType": {
+                        "Name": "number"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "Unit",
+                    "ValueType": {
+                        "Name": "Vector3"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "Magnitude",
+                    "ValueType": {
+                        "Name": "number"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "Dot",
+                    "Parameters": [
+                        {
+                            "Name": "other",
+                            "Type": {
+                                "Name": "Vector3"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "number"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "Lerp",
+                    "Parameters": [
+                        {
+                            "Name": "goal",
+                            "Type": {
+                                "Name": "Vector3"
+                            }
+                        },
+                        {
+                            "Name": "alpha",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "Vector3"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "Cross",
+                    "Parameters": [
+                        {
+                            "Name": "other",
+                            "Type": {
+                                "Name": "Vector3"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "Vector3"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "FuzzyEq",
+                    "Parameters": [
+                        {
+                            "Name": "other",
+                            "Type": {
+                                "Name": "Vector3"
+                            }
+                        },
+                        {
+                            "Name": "epsilon",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "bool"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "Angle",
+                    "Parameters": [
+                        {
+                            "Name": "other",
+                            "Type": {
+                                "Name": "Vector3"
+                            }
+                        },
+                        {
+                            "Name": "axis",
+                            "Type": {
+                                "Name": "Vector3"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "number"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "Max",
+                    "Parameters": [
+                        {
+                            "Name": "other",
+                            "Type": {
+                                "Tuple": {
+                                    "Name": "Vector3"
+                                }
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "Vector3"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "Min",
+                    "Parameters": [
+                        {
+                            "Name": "other",
+                            "Type": {
+                                "Tuple": {
+                                    "Name": "Vector3"
+                                }
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "Vector3"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "lerp",
+                    "Deprecated": true,
+                    "Parameters": [
+                        {
+                            "Name": "goal",
+                            "Type": {
+                                "Name": "Vector3"
+                            }
+                        },
+                        {
+                            "Name": "alpha",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "Vector3"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Deprecated": true,
+                    "Name": "z",
+                    "ValueType": {
+                        "Name": "number"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Deprecated": true,
+                    "Name": "y",
+                    "ValueType": {
+                        "Name": "number"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Deprecated": true,
+                    "Name": "x",
+                    "ValueType": {
+                        "Name": "number"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Deprecated": true,
+                    "Name": "unit",
+                    "ValueType": {
+                        "Name": "Vector3"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Deprecated": true,
+                    "Name": "magnitude",
+                    "ValueType": {
+                        "Name": "number"
+                    }
+                }
+            ],
+            "Name": "Vector3"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Function",
+                    "Name": "NextInteger",
+                    "Parameters": [
+                        {
+                            "Name": "min",
+                            "Type": {
+                                "Name": "int"
+                            }
+                        },
+                        {
+                            "Name": "max",
+                            "Type": {
+                                "Name": "int"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "int"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "NextNumber",
+                    "Parameters": [],
+                    "ReturnType": {
+                        "Name": "number"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "NextNumber",
+                    "Parameters": [
+                        {
+                            "Name": "min",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Name": "max",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "number"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "NextUnitVector",
+                    "Parameters": [],
+                    "ReturnType": {
+                        "Name": "Vector3"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "Clone",
+                    "Parameters": [],
+                    "ReturnType": {
+                        "Name": "Random"
+                    }
+                }
+            ],
+            "Name": "Random"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Property",
+                    "Name": "DelayTime",
+                    "ValueType": {
+                        "Name": "number"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "Time",
+                    "ValueType": {
+                        "Name": "number"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "EasingDirection",
+                    "ValueType": {
+                        "Category": "Enum",
+                        "Name": "EasingDirection"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "RepeatCount",
+                    "ValueType": {
+                        "Name": "number"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "EasingStyle",
+                    "ValueType": {
+                        "Category": "Enum",
+                        "Name": "EasingStyle"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "Reverses",
+                    "ValueType": {
+                        "Name": "bool"
+                    }
+                }
+            ],
+            "Name": "TweenInfo"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Function",
+                    "Name": "Disconnect",
+                    "Parameters": [],
+                    "ReturnType": {
+                        "Name": "void"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "Connected",
+                    "ValueType": {
+                        "Name": "bool"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "disconnect",
+                    "Deprecated": true,
+                    "Parameters": [],
+                    "ReturnType": {
+                        "Name": "void"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "connected",
+                    "Deprecated": true,
+                    "ValueType": {
+                        "Name": "bool"
+                    }
+                }
+            ],
+            "Name": "RBXScriptConnection"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Function",
+                    "Name": "Wait",
+                    "Parameters": [],
+                    "ReturnType": {
+                        "Name": "Variant"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "Connect",
+                    "Parameters": [
+                        {
+                            "Name": "callback",
+                            "Type": {
+                                "Name": "function"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "RBXScriptConnection"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "Once",
+                    "Parameters": [
+                        {
+                            "Name": "callback",
+                            "Type": {
+                                "Name": "function"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "RBXScriptConnection"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "ConnectParallel",
+                    "Parameters": [
+                        {
+                            "Name": "callback",
+                            "Type": {
+                                "Name": "function"
+                            }
+                        }
+                    ],
+                    "Tags": [
+                        "Hidden"
+                    ],
+                    "ReturnType": {
+                        "Name": "RBXScriptConnection"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "wait",
+                    "Deprecated": true,
+                    "Parameters": [],
+                    "ReturnType": {
+                        "Name": "Variant"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "connect",
+                    "Deprecated": true,
+                    "Parameters": [
+                        {
+                            "Name": "callback",
+                            "Type": {
+                                "Name": "function"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "RBXScriptConnection"
+                    }
+                }
+            ],
+            "Name": "RBXScriptSignal"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Property",
+                    "Name": "UnixTimestamp",
+                    "ValueType": {
+                        "Name": "int"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "UnixTimestampMillis",
+                    "ValueType": {
+                        "Name": "int"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "ToUniversalTime",
+                    "Parameters": [],
+                    "ReturnType": {
+                        "Name": "table"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "ToLocalTime",
+                    "Parameters": [],
+                    "ReturnType": {
+                        "Name": "table"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "ToIsoDate",
+                    "Parameters": [],
+                    "ReturnType": {
+                        "Name": "string"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "FormatUniversalTime",
+                    "Parameters": [
+                        {
+                            "Name": "format",
+                            "Type": {
+                                "Name": "string"
+                            }
+                        },
+                        {
+                            "Name": "locale",
+                            "Type": {
+                                "Name": "string"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "string"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "FormatLocalTime",
+                    "Parameters": [
+                        {
+                            "Name": "format",
+                            "Type": {
+                                "Name": "string"
+                            }
+                        },
+                        {
+                            "Name": "locale",
+                            "Type": {
+                                "Name": "string"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "string"
+                    }
+                }
+            ],
+            "Name": "DateTime"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Property",
+                    "Name": "Keypoints",
+                    "ValueType": {
+                        "Name": "Array",
+                        "Generic": "NumberSequenceKeypoint"
+                    }
+                }
+            ],
+            "Name": "NumberSequence"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Property",
+                    "Name": "Keypoints",
+                    "ValueType": {
+                        "Name": "Array",
+                        "Generic": "ColorSequenceKeypoint"
+                    }
+                }
+            ],
+            "Name": "ColorSequence"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Property",
+                    "Name": "Envelope",
+                    "ValueType": {
+                        "Name": "number"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "Time",
+                    "ValueType": {
+                        "Name": "number"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "Value",
+                    "ValueType": {
+                        "Name": "number"
+                    }
+                }
+            ],
+            "Name": "NumberSequenceKeypoint"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Property",
+                    "Name": "Time",
+                    "ValueType": {
+                        "Name": "number"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "Value",
+                    "ValueType": {
+                        "Name": "Color3"
+                    }
+                }
+            ],
+            "Name": "ColorSequenceKeypoint"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Property",
+                    "Name": "FilterDescendantsInstances",
+                    "ValueType": {
+                        "Name": "Objects"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "FilterType",
+                    "ValueType": {
+                        "Category": "Enum",
+                        "Name": "RaycastFilterType"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "IgnoreWater",
+                    "ValueType": {
+                        "Name": "boolean"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "CollisionGroup",
+                    "ValueType": {
+                        "Name": "string"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "RespectCanCollide",
+                    "ValueType": {
+                        "Name": "boolean"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "BruteForceAllSlow",
+                    "ValueType": {
+                        "Name": "boolean"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "AddToFilter",
+                    "Parameters": [
+                        {
+                            "Name": "instances",
+                            "Type": {
+                                "Union": [
+                                    {
+                                        "Name": "Instance"
+                                    },
+                                    {
+                                        "Name": "Objects"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "nil"
+                    }
+                }
+            ],
+            "Name": "RaycastParams"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Property",
+                    "Name": "FilterDescendantsInstances",
+                    "ValueType": {
+                        "Name": "Objects"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "FilterType",
+                    "ValueType": {
+                        "Category": "Enum",
+                        "Name": "RaycastFilterType"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "CollisionGroup",
+                    "ValueType": {
+                        "Name": "string"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "MaxParts",
+                    "ValueType": {
+                        "Name": "number"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "RespectCanCollide",
+                    "ValueType": {
+                        "Name": "boolean"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "BruteForceAllSlow",
+                    "ValueType": {
+                        "Name": "boolean"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "AddToFilter",
+                    "Parameters": [
+                        {
+                            "Name": "instances",
+                            "Type": {
+                                "Union": [
+                                    {
+                                        "Name": "Instance"
+                                    },
+                                    {
+                                        "Name": "Objects"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "nil"
+                    }
+                }
+            ],
+            "Name": "OverlapParams"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Property",
+                    "Name": "Distance",
+                    "ValueType": {
+                        "Name": "number"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "Instance",
+                    "ValueType": {
+                        "Name": "Instance"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "Position",
+                    "ValueType": {
+                        "Name": "Vector3"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "Material",
+                    "ValueType": {
+                        "Category": "Enum",
+                        "Name": "Material"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "Normal",
+                    "ValueType": {
+                        "Name": "Vector3"
+                    }
+                }
+            ],
+            "Name": "RaycastResult"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Property",
+                    "Name": "InitialEnabled",
+                    "ValueType": {
+                        "Name": "boolean"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "InitialEnabledShouldOverrideRestore",
+                    "ValueType": {
+                        "Name": "boolean"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "FloatingXSize",
+                    "ValueType": {
+                        "Name": "int"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "FloatingYSize",
+                    "ValueType": {
+                        "Name": "int"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "MinWidth",
+                    "ValueType": {
+                        "Name": "int"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "MinHeight",
+                    "ValueType": {
+                        "Name": "int"
+                    }
+                }
+            ],
+            "Name": "DockWidgetPluginGuiInfo"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Property",
+                    "Name": "X",
+                    "ValueType": {
+                        "Name": "number"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "Y",
+                    "ValueType": {
+                        "Name": "number"
+                    }
+                }
+            ],
+            "Name": "Vector2int16"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Property",
+                    "Name": "X",
+                    "ValueType": {
+                        "Name": "number"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "Y",
+                    "ValueType": {
+                        "Name": "number"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "Z",
+                    "ValueType": {
+                        "Name": "number"
+                    }
+                }
+            ],
+            "Name": "Vector3int16"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Property",
+                    "Name": "Min",
+                    "ValueType": {
+                        "Name": "Vector3int16"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "Max",
+                    "ValueType": {
+                        "Name": "Vector3int16"
+                    }
+                }
+            ],
+            "Name": "Region3int16"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Property",
+                    "Name": "SearchKeyword",
+                    "ValueType": {
+                        "Name": "string"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "MinPrice",
+                    "ValueType": {
+                        "Name": "number"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "MaxPrice",
+                    "ValueType": {
+                        "Name": "number"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "SortType",
+                    "ValueType": {
+                        "Category": "Enum",
+                        "Name": "CatalogSortType"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "CategoryFilter",
+                    "ValueType": {
+                        "Category": "Enum",
+                        "Name": "CatalogCategoryFilter"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "BundleType",
+                    "ValueType": {
+                        "Name": "Array",
+                        "Generic": "Enum.BundleType"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "AssetTypes",
+                    "ValueType": {
+                        "Name": "Array",
+                        "Generic": "Enum.AssetType"
+                    }
+                }
+            ],
+            "Name": "CatalogSearchParams"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Property",
+                    "Name": "Family",
+                    "ValueType": {
+                        "Name": "string"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "Bold",
+                    "ValueType": {
+                        "Name": "boolean"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "Weight",
+                    "ValueType": {
+                        "Category": "Enum",
+                        "Name": "FontWeight"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "Style",
+                    "ValueType": {
+                        "Category": "Enum",
+                        "Name": "FontStyle"
+                    }
+                }
+            ],
+            "Name": "Font"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Property",
+                    "Name": "Interpolation",
+                    "ValueType": {
+                        "Category": "Enum",
+                        "Name": "KeyInterpolationMode"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "Time",
+                    "ValueType": {
+                        "Name": "number"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "Value",
+                    "ValueType": {
+                        "Name": "number"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "RightTangent",
+                    "ValueType": {
+                        "Name": "number"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "LeftTangent",
+                    "ValueType": {
+                        "Name": "number"
+                    }
+                }
+            ],
+            "Name": "FloatCurveKey"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Property",
+                    "Name": "Interpolation",
+                    "ValueType": {
+                        "Category": "Enum",
+                        "Name": "KeyInterpolationMode"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "Time",
+                    "ValueType": {
+                        "Name": "number"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "Value",
+                    "ValueType": {
+                        "Name": "CFrame"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "RightTangent",
+                    "ValueType": {
+                        "Name": "number"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "LeftTangent",
+                    "ValueType": {
+                        "Name": "number"
+                    }
+                }
+            ],
+            "Name": "RotationCurveKey"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Function",
+                    "Name": "clear",
+                    "Parameters": [
+                        {
+                            "Name": "st",
+                            "Type": {
+                                "Name": "SharedTable"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "void"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "clone",
+                    "Parameters": [
+                        {
+                            "Name": "st",
+                            "Type": {
+                                "Name": "SharedTable"
+                            }
+                        },
+                        {
+                            "Name": "deep",
+                            "Default": "nil",
+                            "Type": {
+                                "Name": "boolean"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "SharedTable"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "cloneAndFreeze",
+                    "Parameters": [
+                        {
+                            "Name": "st",
+                            "Type": {
+                                "Name": "SharedTable"
+                            }
+                        },
+                        {
+                            "Name": "deep",
+                            "Default": "nil",
+                            "Type": {
+                                "Name": "boolean"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "SharedTable"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "increment",
+                    "Parameters": [
+                        {
+                            "Name": "st",
+                            "Type": {
+                                "Name": "SharedTable"
+                            }
+                        },
+                        {
+                            "Name": "key",
+                            "Type": {
+                                "Union": [
+                                    {
+                                        "Name": "string"
+                                    },
+                                    {
+                                        "Name": "number"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "Name": "delta",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "number"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "isFrozen",
+                    "Parameters": [
+                        {
+                            "Name": "st",
+                            "Type": {
+                                "Name": "SharedTable"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "boolean"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "size",
+                    "Parameters": [
+                        {
+                            "Name": "st",
+                            "Type": {
+                                "Name": "SharedTable"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "number"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "update",
+                    "Parameters": [
+                        {
+                            "Name": "st",
+                            "Type": {
+                                "Name": "SharedTable"
+                            }
+                        },
+                        {
+                            "Name": "key",
+                            "Type": {
+                                "Union": [
+                                    {
+                                        "Name": "string"
+                                    },
+                                    {
+                                        "Name": "number"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "Name": "f",
+                            "Type": {
+                                "Name": "function"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "void"
+                    }
+                }
+            ],
+            "Name": "SharedTable"
+        }
+    ]
+}

--- a/scripts/DataTypes.json
+++ b/scripts/DataTypes.json
@@ -796,6 +796,40 @@
                 },
                 {
                     "MemberType": "Function",
+                    "Name": "fromEulerAngles",
+                    "Parameters": [
+                        {
+                            "Name": "rx",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Name": "ry",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Name": "rz",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Name": "order",
+                            "Type": {
+                                "Category": "Enum",
+                                "Name": "RotationOrder"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "CFrame"
+                    }
+                },
+                {
+                    "MemberType": "Function",
                     "Name": "Angles",
                     "Parameters": [
                         {
@@ -942,6 +976,34 @@
                         },
                         {
                             "Name": "target",
+                            "Type": {
+                                "Name": "Vector3"
+                            }
+                        },
+                        {
+                            "Name": "up",
+                            "Default": "(0, 1, 0)",
+                            "Type": {
+                                "Name": "Vector3"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "CFrame"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "lookAlong",
+                    "Parameters": [
+                        {
+                            "Name": "at",
+                            "Type": {
+                                "Name": "Vector3"
+                            }
+                        },
+                        {
+                            "Name": "direction",
                             "Type": {
                                 "Name": "Vector3"
                             }
@@ -2935,6 +2997,31 @@
                     "MemberType": "Function",
                     "Name": "ToEulerAnglesYXZ",
                     "Parameters": [],
+                    "TupleReturns": [
+                        {
+                            "Name": "number"
+                        },
+                        {
+                            "Name": "number"
+                        },
+                        {
+                            "Name": "number"
+                        }
+                    ]
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "ToEulerAngles",
+                    "Parameters": [
+                        {
+                            "Name": "order",
+                            "Default":"XYZ",
+                            "Type": {
+                                "Category": "Enum",
+                                "Name": "RotationOrder"
+                            }
+                        }
+                    ],
                     "TupleReturns": [
                         {
                             "Name": "number"

--- a/scripts/DataTypes.json
+++ b/scripts/DataTypes.json
@@ -591,6 +591,33 @@
                     "ReturnType": {
                         "Name": "PhysicalProperties"
                     }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "new",
+                    "Parameters": [
+                        {
+                            "Name": "density",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Name": "friction",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Name": "elasticity",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "PhysicalProperties"
+                    }
                 }
             ],
             "Name": "PhysicalProperties"

--- a/scripts/DataTypes.json
+++ b/scripts/DataTypes.json
@@ -1293,6 +1293,15 @@
                     "MemberType": "Function",
                     "Name": "new",
                     "Parameters": [
+                    ],
+                    "ReturnType": {
+                        "Name": "Rect"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "new",
+                    "Parameters": [
                         {
                             "Name": "min",
                             "Type": {

--- a/scripts/dumpRobloxTypes.py
+++ b/scripts/dumpRobloxTypes.py
@@ -637,6 +637,16 @@ type HumanoidDescriptionAccessory = {
 # More hardcoded types, but go at the end of the file
 # Useful if they rely on previously defined types
 END_BASE = """
+declare Vector2: {
+	zero: Vector2,
+	one: Vector2,
+	xAxis: Vector2,
+	yAxis: Vector2,
+	new: ((x: number?, y: number?) -> Vector2),
+	max: ((...Vector2) -> Vector2),
+	min: ((...Vector2) -> Vector2),
+}
+
 declare class GlobalSettings extends GenericSettings
     Lua: LuaSettings
     Game: GameSettings

--- a/scripts/dumpRobloxTypes.py
+++ b/scripts/dumpRobloxTypes.py
@@ -637,31 +637,6 @@ type HumanoidDescriptionAccessory = {
 # More hardcoded types, but go at the end of the file
 # Useful if they rely on previously defined types
 END_BASE = """
-declare Vector2: {
-	zero: Vector2,
-	one: Vector2,
-	xAxis: Vector2,
-	yAxis: Vector2,
-	new: ((x: number?, y: number?) -> Vector2),
-	max: ((...Vector2) -> Vector2),
-	min: ((...Vector2) -> Vector2),
-}
-
-declare Vector3: {
-	zero: Vector3,
-	one: Vector3,
-	xAxis: Vector3,
-	yAxis: Vector3,
-	zAxis: Vector3,
-	fromNormalId: ((normal: EnumNormalId) -> Vector3),
-	fromAxis: ((axis: EnumAxis) -> Vector3),
-	FromNormalId: ((normal: EnumNormalId) -> Vector3),
-	FromAxis: ((axis: EnumAxis) -> Vector3),
-	new: ((x: number?, y: number?, z: number?) -> Vector3),
-    max: ((...Vector3) -> Vector3),
-	min: ((...Vector3) -> Vector3),
-}
-
 declare class GlobalSettings extends GenericSettings
     Lua: LuaSettings
     Game: GameSettings
@@ -908,6 +883,9 @@ def resolveType(type: Union[ApiValueType, CorrectionsValueType]) -> str:
     if "Tuple" in type and type["Tuple"] is not None:
         subtype = resolveType(type["Tuple"])
         return f"...({subtype})"
+    if "Variadic" in type and type["Variadic"] is not None:
+        subtype = resolveType(type["Variadic"])
+        return f"...{subtype}"
 
     name, category = (
         type["Name"],
@@ -929,6 +907,9 @@ def resolveParameter(param: ApiParameter):
     isVariadic = paramType.startswith("...")
     if isVariadic:
         actualType = paramType[3:]
+        if "Variadic" in param["Type"] and  param["Type"]["Variadic"] is not None:
+            return f"...{actualType}"
+        
         return f"...: {actualType}"
     return f"{escapeName(param['Name'])}: {paramType}{'?' if 'Default' in param and not isOptional else ''}"
 

--- a/scripts/dumpRobloxTypes.py
+++ b/scripts/dumpRobloxTypes.py
@@ -647,6 +647,21 @@ declare Vector2: {
 	min: ((...Vector2) -> Vector2),
 }
 
+declare Vector3: {
+	zero: Vector3,
+	one: Vector3,
+	xAxis: Vector3,
+	yAxis: Vector3,
+	zAxis: Vector3,
+	fromNormalId: ((normal: EnumNormalId) -> Vector3),
+	fromAxis: ((axis: EnumAxis) -> Vector3),
+	FromNormalId: ((normal: EnumNormalId) -> Vector3),
+	FromAxis: ((axis: EnumAxis) -> Vector3),
+	new: ((x: number?, y: number?, z: number?) -> Vector3),
+    max: ((...Vector3) -> Vector3),
+	min: ((...Vector3) -> Vector3),
+}
+
 declare class GlobalSettings extends GenericSettings
     Lua: LuaSettings
     Game: GameSettings

--- a/scripts/dumpRobloxTypes.py
+++ b/scripts/dumpRobloxTypes.py
@@ -8,9 +8,9 @@ import json
 import sys
 
 # API Endpoints
-DATA_TYPES_URL = "https://raw.githubusercontent.com/NightrainsRbx/RobloxLsp/master/server/api/DataTypes.json"
+DATA_TYPES = open("DataTypes.json","r")
+CORRECTIONS = open("Corrections.json","r")
 API_DUMP_URL = "https://raw.githubusercontent.com/CloneTrooper1019/Roblox-Client-Tracker/roblox/API-Dump.json"
-CORRECTIONS_URL = "https://raw.githubusercontent.com/NightrainsRbx/RobloxLsp/master/server/api/Corrections.json"
 BRICK_COLORS_URL = "https://gist.githubusercontent.com/Anaminus/49ac255a68e7a7bc3cdd72b602d5071f/raw/f1534dcae312dbfda716b7677f8ac338b565afc3/BrickColor.json"
 
 INCLUDE_DEPRECATED_METHODS = False
@@ -1217,14 +1217,14 @@ brickColors = json.loads(requests.get(BRICK_COLORS_URL).text)
 processBrickColors(brickColors)
 
 # Print global types
-dataTypes: DataTypesDump = json.loads(requests.get(DATA_TYPES_URL).text)
+dataTypes: DataTypesDump = json.load(DATA_TYPES)
 dump: ApiDump = json.loads(requests.get(API_DUMP_URL).text)
 
 # Load services and creatable instances
 loadClassesIntoStructures(dump)
 
 # Apply any corrections on the dump
-corrections: CorrectionsDump = json.loads(requests.get(CORRECTIONS_URL).text)
+corrections: CorrectionsDump = json.load(CORRECTIONS)
 applyCorrections(dump, corrections)
 
 printJsonPrologue()


### PR DESCRIPTION
This PR fixes missing/wrong datatype types
Changes:
```
- CFrame  
	- CFrame.LookAlong(at: Vector3,direction: Vector3,up: Vector3) 
	- CFrame.fromEulerAngles(rx: number,ry: number,rz: number,order: Enum.RotationOrder) 
	- CFrame.new():ToEulerAngles(order: Enum.RotationOrder):number,number,number 
- PathWayPoint 
	- PathWayPoint.new().Label (and 3rd arg of new was missing)
- PhysicalProperties 
	-  new(density: number,friction: number,elasticity: number) is missing 
- Rect 
	-  Rect.new() (params are not required) 

- Secret 
	-  Secret is not in the list at all
	-  HttpService:GetSecret():AddPrefix 
	- HttpService:GetSecret():AddSuffix 

- Vector2 
	- Vector2.max 
	- Vector2.min 
	- Vector2.new():Abs 
	- Vector2.new():Ceil 
	- Vector2.new():Floor 
	- Vector2.new():Sign 
	- Vector2.new():Angle 
- Vector3 
	- Vector3.max 
	- Vector3.min 
	- Vector3.new():Abs 
	- Vector3.new():Ceil 
	- Vector3.new():Floor 
	- Vector3.new():Sign 
```
can be tested with :
```lua
--!strict
CFrame.lookAlong(Vector3.zero,Vector3.zero)
CFrame.fromEulerAngles(1,1,1,Enum.RotationOrder.XYZ)
CFrame.new():ToEulerAngles()

local _ = PathWaypoint.new(Vector3.zero,Enum.PathWaypointAction.Jump,"custom label")

PhysicalProperties.new(1,1,1)

Rect.new()

local sc= game:GetService("HttpService"):GetSecret()
sc:AddPrefix()
sc:AddSuffix()

Vector2.max(Vector2.zero,Vector2.zero)
Vector2.min(Vector2.zero,Vector2.zero)
Vector2.new():Abs()
Vector2.new():Ceil()
Vector2.new():Floor()
Vector2.new():Sign()
Vector2.new():Angle(Vector2.zero,false)


Vector3.max(Vector3.zero,Vector3.zero)
Vector3.min(Vector3.zero,Vector3.zero)
Vector3.new():Abs()
Vector3.new():Ceil()
Vector3.new():Floor()
Vector3.new():Sign()
```
###### (vector2/vector3 max,min functions are in dump script instead of json due to some weird type generation on vararg functions)