### PR TITLE
Add CFrame.lookAlong to each globalTypes entry

### DIFF
--- a/scripts/globalTypes.LocalUserSecurity.d.luau
+++ b/scripts/globalTypes.LocalUserSecurity.d.luau
@@ -9860,3 +9860,4 @@ declare plugin: Plugin
 declare script: LuaSourceContainer
 declare function settings(): GlobalSettings
 declare function UserSettings(): UserSettings
+

--- a/scripts/globalTypes.LocalUserSecurity.d.luau
+++ b/scripts/globalTypes.LocalUserSecurity.d.luau
@@ -9736,6 +9736,7 @@ declare CFrame: {
 	fromOrientation: ((rx: number, ry: number, rz: number) -> CFrame),
 	fromEulerAnglesXYZ: ((rx: number, ry: number, rz: number) -> CFrame),
 	lookAt: ((at: Vector3, target: Vector3, up: Vector3?) -> CFrame),
+	lookAlong: ((at: Vector3, direction: Vector3, up: Vector3?) -> CFrame),
 	new: (() -> CFrame) & ((pos: Vector3) -> CFrame) & ((pos: Vector3, lookAt: Vector3) -> CFrame) & ((x: number, y: number, z: number) -> CFrame) & ((x: number, y: number, z: number, qX: number, qY: number, qZ: number, qW: number) -> CFrame) & ((x: number, y: number, z: number, R00: number, R01: number, R02: number, R10: number, R11: number, R12: number, R20: number, R21: number, R22: number) -> CFrame),
 }
 
@@ -9859,4 +9860,3 @@ declare plugin: Plugin
 declare script: LuaSourceContainer
 declare function settings(): GlobalSettings
 declare function UserSettings(): UserSettings
-

--- a/scripts/globalTypes.None.d.luau
+++ b/scripts/globalTypes.None.d.luau
@@ -9793,3 +9793,4 @@ declare plugin: Plugin
 declare script: LuaSourceContainer
 declare function settings(): GlobalSettings
 declare function UserSettings(): UserSettings
+

--- a/scripts/globalTypes.None.d.luau
+++ b/scripts/globalTypes.None.d.luau
@@ -9669,6 +9669,7 @@ declare CFrame: {
 	fromOrientation: ((rx: number, ry: number, rz: number) -> CFrame),
 	fromEulerAnglesXYZ: ((rx: number, ry: number, rz: number) -> CFrame),
 	lookAt: ((at: Vector3, target: Vector3, up: Vector3?) -> CFrame),
+	lookAlong: ((at: Vector3, direction: Vector3, up: Vector3?) -> CFrame),
 	new: (() -> CFrame) & ((pos: Vector3) -> CFrame) & ((pos: Vector3, lookAt: Vector3) -> CFrame) & ((x: number, y: number, z: number) -> CFrame) & ((x: number, y: number, z: number, qX: number, qY: number, qZ: number, qW: number) -> CFrame) & ((x: number, y: number, z: number, R00: number, R01: number, R02: number, R10: number, R11: number, R12: number, R20: number, R21: number, R22: number) -> CFrame),
 }
 
@@ -9792,4 +9793,3 @@ declare plugin: Plugin
 declare script: LuaSourceContainer
 declare function settings(): GlobalSettings
 declare function UserSettings(): UserSettings
-

--- a/scripts/globalTypes.PluginSecurity.d.luau
+++ b/scripts/globalTypes.PluginSecurity.d.luau
@@ -10080,3 +10080,4 @@ declare plugin: Plugin
 declare script: LuaSourceContainer
 declare function settings(): GlobalSettings
 declare function UserSettings(): UserSettings
+

--- a/scripts/globalTypes.PluginSecurity.d.luau
+++ b/scripts/globalTypes.PluginSecurity.d.luau
@@ -9956,6 +9956,7 @@ declare CFrame: {
 	fromOrientation: ((rx: number, ry: number, rz: number) -> CFrame),
 	fromEulerAnglesXYZ: ((rx: number, ry: number, rz: number) -> CFrame),
 	lookAt: ((at: Vector3, target: Vector3, up: Vector3?) -> CFrame),
+	lookAlong: ((at: Vector3, direction: Vector3, up: Vector3?) -> CFrame),
 	new: (() -> CFrame) & ((pos: Vector3) -> CFrame) & ((pos: Vector3, lookAt: Vector3) -> CFrame) & ((x: number, y: number, z: number) -> CFrame) & ((x: number, y: number, z: number, qX: number, qY: number, qZ: number, qW: number) -> CFrame) & ((x: number, y: number, z: number, R00: number, R01: number, R02: number, R10: number, R11: number, R12: number, R20: number, R21: number, R22: number) -> CFrame),
 }
 
@@ -10079,4 +10080,3 @@ declare plugin: Plugin
 declare script: LuaSourceContainer
 declare function settings(): GlobalSettings
 declare function UserSettings(): UserSettings
-

--- a/scripts/globalTypes.RobloxScriptSecurity.d.luau
+++ b/scripts/globalTypes.RobloxScriptSecurity.d.luau
@@ -11555,3 +11555,4 @@ declare plugin: Plugin
 declare script: LuaSourceContainer
 declare function settings(): GlobalSettings
 declare function UserSettings(): UserSettings
+

--- a/scripts/globalTypes.RobloxScriptSecurity.d.luau
+++ b/scripts/globalTypes.RobloxScriptSecurity.d.luau
@@ -11431,6 +11431,7 @@ declare CFrame: {
 	fromOrientation: ((rx: number, ry: number, rz: number) -> CFrame),
 	fromEulerAnglesXYZ: ((rx: number, ry: number, rz: number) -> CFrame),
 	lookAt: ((at: Vector3, target: Vector3, up: Vector3?) -> CFrame),
+	lookAlong: ((at: Vector3, direction: Vector3, up: Vector3?) -> CFrame),
 	new: (() -> CFrame) & ((pos: Vector3) -> CFrame) & ((pos: Vector3, lookAt: Vector3) -> CFrame) & ((x: number, y: number, z: number) -> CFrame) & ((x: number, y: number, z: number, qX: number, qY: number, qZ: number, qW: number) -> CFrame) & ((x: number, y: number, z: number, R00: number, R01: number, R02: number, R10: number, R11: number, R12: number, R20: number, R21: number, R22: number) -> CFrame),
 }
 
@@ -11554,4 +11555,3 @@ declare plugin: Plugin
 declare script: LuaSourceContainer
 declare function settings(): GlobalSettings
 declare function UserSettings(): UserSettings
-

--- a/scripts/globalTypes.d.lua
+++ b/scripts/globalTypes.d.lua
@@ -11555,3 +11555,4 @@ declare plugin: Plugin
 declare script: LuaSourceContainer
 declare function settings(): GlobalSettings
 declare function UserSettings(): UserSettings
+

--- a/scripts/globalTypes.d.lua
+++ b/scripts/globalTypes.d.lua
@@ -11431,6 +11431,7 @@ declare CFrame: {
 	fromOrientation: ((rx: number, ry: number, rz: number) -> CFrame),
 	fromEulerAnglesXYZ: ((rx: number, ry: number, rz: number) -> CFrame),
 	lookAt: ((at: Vector3, target: Vector3, up: Vector3?) -> CFrame),
+	lookAlong: ((at: Vector3, direction: Vector3, up: Vector3?) -> CFrame),
 	new: (() -> CFrame) & ((pos: Vector3) -> CFrame) & ((pos: Vector3, lookAt: Vector3) -> CFrame) & ((x: number, y: number, z: number) -> CFrame) & ((x: number, y: number, z: number, qX: number, qY: number, qZ: number, qW: number) -> CFrame) & ((x: number, y: number, z: number, R00: number, R01: number, R02: number, R10: number, R11: number, R12: number, R20: number, R21: number, R22: number) -> CFrame),
 }
 
@@ -11554,4 +11555,3 @@ declare plugin: Plugin
 declare script: LuaSourceContainer
 declare function settings(): GlobalSettings
 declare function UserSettings(): UserSettings
-

--- a/scripts/globalTypes.d.luau
+++ b/scripts/globalTypes.d.luau
@@ -11555,3 +11555,4 @@ declare plugin: Plugin
 declare script: LuaSourceContainer
 declare function settings(): GlobalSettings
 declare function UserSettings(): UserSettings
+

--- a/scripts/globalTypes.d.luau
+++ b/scripts/globalTypes.d.luau
@@ -11431,6 +11431,7 @@ declare CFrame: {
 	fromOrientation: ((rx: number, ry: number, rz: number) -> CFrame),
 	fromEulerAnglesXYZ: ((rx: number, ry: number, rz: number) -> CFrame),
 	lookAt: ((at: Vector3, target: Vector3, up: Vector3?) -> CFrame),
+	lookAlong: ((at: Vector3, direction: Vector3, up: Vector3?) -> CFrame),
 	new: (() -> CFrame) & ((pos: Vector3) -> CFrame) & ((pos: Vector3, lookAt: Vector3) -> CFrame) & ((x: number, y: number, z: number) -> CFrame) & ((x: number, y: number, z: number, qX: number, qY: number, qZ: number, qW: number) -> CFrame) & ((x: number, y: number, z: number, R00: number, R01: number, R02: number, R10: number, R11: number, R12: number, R20: number, R21: number, R22: number) -> CFrame),
 }
 
@@ -11554,4 +11555,3 @@ declare plugin: Plugin
 declare script: LuaSourceContainer
 declare function settings(): GlobalSettings
 declare function UserSettings(): UserSettings
-


### PR DESCRIPTION
## Problem
CFrame.lookAlong is a valid CFrame constructor recently added to the Roblox API, though it is not a valid constructor when using the lsp

## Solution
Add the new constructor to each of the globalTypes entry

It doesnt look like we require testing for the globalTypes entries, though I've attached screenshots of what my local extension build looks like with this change for clarity:
![image](https://github.com/JohnnyMorganz/luau-lsp/assets/5725602/2190dbdb-6433-46aa-a8ec-dc3c144d3036)
<img width="739" alt="image" src="https://github.com/JohnnyMorganz/luau-lsp/assets/5725602/1eaf48b9-3b07-48ad-aeba-69126abb76be">
