### PR TITLE
Add getmemorycategory to type definitions

### DIFF
--- a/scripts/dumpRobloxTypes.py
+++ b/scripts/dumpRobloxTypes.py
@@ -555,6 +555,7 @@ declare debug: {
     traceback: ((string?, number?) -> string) & ((thread, string?, number?) -> string),
     profilebegin: (label: string) -> (),
     profileend: () -> (),
+    getmemorycategory: () -> string,
     setmemorycategory: (tag: string) -> (),
     resetmemorycategory: () -> (),
 }


### PR DESCRIPTION
this PR adds debug.getmemorycategory() to type definitions