### PR TITLE
Fix requiring `JSON` and `TOML` modules

### DIFF
--- a/src/platform/roblox/RobloxFileResolver.cpp
+++ b/src/platform/roblox/RobloxFileResolver.cpp
@@ -91,7 +91,7 @@ std::optional<std::string> RobloxPlatform::readSourceCode(const Luau::ModuleName
         }
     }
 
-    return std::nullopt;
+    return source;
 }
 
 /// Modify the context so that game/Players/LocalPlayer items point to the correct place


### PR DESCRIPTION
This quick fix solves this problem with the JSON and TOML files:
> Only click-to-follow feature works but the actual completion does not. Additionally, it throws TypeError: Unknown require error.

as discussed in #553.