### PR TITLE
Add plugin feedback for plugin-server connection

### DIFF
--- a/plugin/src/init.server.lua
+++ b/plugin/src/init.server.lua
@@ -119,7 +119,7 @@ local function cleanup()
 	connected.Value = false
 end
 
-local function sendFullDMInfo()
+local function sendFullDMInfo(isSilent)
 	local tree = encodeInstance(game, filterServices)
 
 	local success, result = pcall(HttpService.RequestAsync, HttpService, {
@@ -142,6 +142,9 @@ local function sendFullDMInfo()
 		cleanup()
 	else
 		connected.Value = true
+		if not isSilent then
+			print(`[Luau Language Server] Successfully sent full DataModel info`)
+		end
 	end
 end
 
@@ -160,7 +163,7 @@ local function watchChanges(isSilent)
 			task.cancel(sendTask)
 		end
 		sendTask = task.delay(0.5, function()
-			sendFullDMInfo()
+			sendFullDMInfo(isSilent)
 			sendTask = nil
 		end)
 	end
@@ -177,7 +180,7 @@ local function watchChanges(isSilent)
 
 	table.insert(connections, game.DescendantAdded:Connect(descendantChanged))
 	table.insert(connections, game.DescendantRemoving:Connect(descendantChanged))
-	sendFullDMInfo()
+	sendFullDMInfo(isSilent)
 end
 
 function connectServer(isSilent: boolean?)


### PR DESCRIPTION
I think it was mentioned like a week ago that plugin connection feedback would probably be added eventually, so I propose a quick fix here.

Only changes made are the added message, and passing the isSilent parameter to use it as a condition for the message.

Keep in mind I haven't actually tested this, I just read the plugin code and coded the message where I think is most appropriate, since setting up the plugin testing environment is took much of a headache for me, since I've never done it.

At the very least if my implementation sucks, this is a reminder that this 'feature' should be simple to implement, and to put it in the to-do list. 