### PR TITLE
fix "BundleType"

### DIFF
--- a/scripts/DataTypes.json
+++ b/scripts/DataTypes.json
@@ -4862,7 +4862,7 @@
                 },
                 {
                     "MemberType": "Property",
-                    "Name": "BundleType",
+                    "Name": "BundleTypes",
                     "ValueType": {
                         "Name": "Array",
                         "Generic": "Enum.BundleType"


### PR DESCRIPTION
`BundleType` isn't actually a valid member of a `CatalogSearchParams`.