### PR TITLE
Support textDocument/prepareRename & textDocument/documentHighlight, improve accuracy of reference finding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ target_sources(Luau.LanguageServer PRIVATE
         src/platform/roblox/RobloxStudioPlugin.cpp
         src/operations/Diagnostics.cpp
         src/operations/Completion.cpp
+        src/operations/DocumentHighlight.cpp
         src/operations/DocumentSymbol.cpp
         src/operations/DocumentLink.cpp
         src/operations/ColorProvider.cpp

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Install the binary and run `luau-lsp --help` for more information.
 - [x] Go To Definition
 - [x] Go To Type Definition
 - [x] Find References
+- [x] Document Highlight
 - [x] Document Link
 - [x] Document Symbol
 - [x] Color Provider
@@ -87,7 +88,6 @@ They can be investigated at a later time:
 - [ ] Go To Declaration (do not apply)
 - [ ] Go To Implementation (do not apply)
 - [ ] Code Lens (not necessary)
-- [ ] Document Highlight (not necessary - editor highlighting is sufficient)
 - [ ] Selection Range (not necessary - editor selection is sufficient)
 - [ ] Inline Value (applies for debuggers only)
 - [ ] Moniker

--- a/src/LanguageServer.cpp
+++ b/src/LanguageServer.cpp
@@ -73,6 +73,8 @@ lsp::ServerCapabilities LanguageServer::getServerCapabilities()
     capabilities.implementationProvider = false; // TODO: does this apply to Luau?
     // Find References Provider
     capabilities.referencesProvider = true;
+    // Document Highlight Provider
+    capabilities.documentHighlightProvider = true;
     // Document Symbol Provider
     capabilities.documentSymbolProvider = true;
     // Color Provider
@@ -82,7 +84,7 @@ lsp::ServerCapabilities LanguageServer::getServerCapabilities()
     // Code Action Provider
     capabilities.codeActionProvider = {std::vector<lsp::CodeActionKind>{lsp::CodeActionKind::SourceOrganizeImports}, /* resolveProvider: */ false};
     // Rename Provider
-    capabilities.renameProvider = true;
+    capabilities.renameProvider = {true};
     // Folding Range Provider
     capabilities.foldingRangeProvider = true;
     // Inlay Hint Provider
@@ -159,6 +161,14 @@ void LanguageServer::onRequest(const id_type& id, const std::string& method, std
     else if (method == "textDocument/rename")
     {
         response = rename(JSON_REQUIRED_PARAMS(baseParams, "textDocument/rename"));
+    }
+    else if (method == "textDocument/prepareRename")
+    {
+        response = prepareRename(JSON_REQUIRED_PARAMS(baseParams, "textDocument/prepareRename"));
+    }
+    else if (method == "textDocument/documentHighlight")
+    {
+        response = documentHighlight(JSON_REQUIRED_PARAMS(baseParams, "textDocument/documentHighlight"));
     }
     else if (method == "textDocument/documentSymbol")
     {

--- a/src/include/LSP/LanguageServer.hpp
+++ b/src/include/LSP/LanguageServer.hpp
@@ -90,6 +90,8 @@ private:
     lsp::ReferenceResult references(const lsp::ReferenceParams& params);
     std::optional<std::vector<lsp::DocumentSymbol>> documentSymbol(const lsp::DocumentSymbolParams& params);
     lsp::RenameResult rename(const lsp::RenameParams& params);
+    lsp::PrepareRenameResult prepareRename(const lsp::PrepareRenameParams& params);
+    lsp::DocumentHighlightResult documentHighlight(const lsp::DocumentHighlightParams& params);
     lsp::InlayHintResult inlayHint(const lsp::InlayHintParams& params);
     std::optional<lsp::SemanticTokens> semanticTokens(const lsp::SemanticTokensParams& params);
     lsp::DocumentDiagnosticReport documentDiagnostic(const lsp::DocumentDiagnosticParams& params);

--- a/src/include/LSP/LuauExt.hpp
+++ b/src/include/LSP/LuauExt.hpp
@@ -47,7 +47,20 @@ Luau::AstNode* findNodeOrTypeAtPosition(const Luau::SourceModule& source, Luau::
 Luau::AstNode* findNodeOrTypeAtPositionClosed(const Luau::SourceModule& source, Luau::Position pos);
 Luau::ExprOrLocal findExprOrLocalAtPositionClosed(const Luau::SourceModule& source, Luau::Position pos);
 std::vector<Luau::Location> findSymbolReferences(const Luau::SourceModule& source, Luau::Symbol symbol);
+std::pair<std::vector<Luau::Location>, std::vector<lsp::DocumentHighlightKind>> findSymbolReferencesWithKinds(
+    const Luau::SourceModule& source, Luau::Symbol symbol);
+std::vector<Luau::Location> findPropertyReferences(
+    const Luau::SourceModule& source, const Luau::Name& property, Luau::TypeId ty, Luau::DenseHashMap<const Luau::AstExpr*, Luau::TypeId> astTypes);
+std::pair<std::vector<Luau::Location>, std::vector<lsp::DocumentHighlightKind>> findPropertyReferencesWithKinds(
+    const Luau::SourceModule& source, const Luau::Name& property, Luau::TypeId ty, Luau::DenseHashMap<const Luau::AstExpr*, Luau::TypeId> astTypes);
 std::vector<Luau::Location> findTypeReferences(const Luau::SourceModule& source, const Luau::Name& typeName, std::optional<const Luau::Name> prefix);
+std::vector<Luau::Location> findTypeParameterUsages(Luau::AstNode& node, Luau::AstName name);
+std::pair<std::vector<Luau::Location>, std::vector<lsp::DocumentHighlightKind>> findTypeParameterUsagesWithKinds(
+    Luau::AstNode& node, Luau::AstName name);
+std::optional<Luau::AstName> findTypeReferenceName(
+    Luau::Position pos, Luau::AstArray<Luau::AstGenericType> generics, Luau::AstArray<Luau::AstGenericTypePack> genericPacks);
+std::optional<std::pair<Luau::AstLocal*, Luau::AstExpr*>> findClosestAncestorModuleImport(
+    const Luau::SourceModule& source, const Luau::AstName name, const Luau::Position pos);
 
 std::optional<Luau::Location> getLocation(Luau::TypeId type);
 
@@ -68,6 +81,8 @@ bool isGetService(const Luau::AstExpr* expr);
 bool isRequire(const Luau::AstExpr* expr);
 bool isMethod(const Luau::FunctionType* ftv);
 bool isOverloadedMethod(Luau::TypeId ty);
+bool isSameTable(Luau::TypeId a, Luau::TypeId b);
+bool isTypeReference(Luau::AstName name, Luau::AstArray<Luau::AstGenericType> generics, Luau::AstArray<Luau::AstGenericTypePack> genericPacks);
 
 struct FindImportsVisitor : public Luau::AstVisitor
 {

--- a/src/include/LSP/Workspace.hpp
+++ b/src/include/LSP/Workspace.hpp
@@ -118,6 +118,8 @@ public:
 
     lsp::ReferenceResult references(const lsp::ReferenceParams& params);
     lsp::RenameResult rename(const lsp::RenameParams& params);
+    lsp::PrepareRenameResult prepareRename(const lsp::PrepareRenameParams& params);
+    lsp::DocumentHighlightResult documentHighlight(const lsp::DocumentHighlightParams& params);
     lsp::InlayHintResult inlayHint(const lsp::InlayHintParams& params);
     std::vector<lsp::FoldingRange> foldingRange(const lsp::FoldingRangeParams& params);
 

--- a/src/include/Protocol/LanguageFeatures.hpp
+++ b/src/include/Protocol/LanguageFeatures.hpp
@@ -51,6 +51,39 @@ NLOHMANN_DEFINE_OPTIONAL(RenameParams, textDocument, position, newName)
 
 using RenameResult = std::optional<WorkspaceEdit>;
 
+struct PrepareRenameParams : TextDocumentPositionParams
+{
+};
+
+struct PrepareRenameRangePlaceholderResult
+{
+    Range range;
+    std::string placeholder;
+};
+NLOHMANN_DEFINE_OPTIONAL(PrepareRenameRangePlaceholderResult, range, placeholder)
+
+using PrepareRenameResult = std::optional<PrepareRenameRangePlaceholderResult>;
+
+struct DocumentHighlightParams : TextDocumentPositionParams
+{
+};
+
+enum struct DocumentHighlightKind
+{
+    Text = 1,
+    Read = 2,
+    Write = 3,
+};
+
+struct DocumentHighlight
+{
+    Range range;
+    DocumentHighlightKind kind;
+};
+NLOHMANN_DEFINE_OPTIONAL(DocumentHighlight, range, kind)
+
+using DocumentHighlightResult = std::optional<std::vector<DocumentHighlight>>;
+
 struct DocumentLinkParams
 {
     TextDocumentIdentifier textDocument;

--- a/src/include/Protocol/ServerCapabilities.hpp
+++ b/src/include/Protocol/ServerCapabilities.hpp
@@ -94,6 +94,12 @@ struct CodeActionOptions
 };
 NLOHMANN_DEFINE_OPTIONAL(CodeActionOptions, codeActionKinds, resolveProvider);
 
+struct RenameOptions
+{
+    bool prepareProvider = false;
+};
+NLOHMANN_DEFINE_OPTIONAL(RenameOptions, prepareProvider)
+
 struct ServerCapabilities
 {
     PositionEncodingKind positionEncoding = PositionEncodingKind::UTF16;
@@ -106,6 +112,7 @@ struct ServerCapabilities
     bool typeDefinitionProvider = false;
     bool implementationProvider = false;
     bool referencesProvider = false;
+    bool documentHighlightProvider = false;
     bool documentSymbolProvider = false;
     /**
      * The server provides code actions. The `CodeActionOptions` return type is
@@ -115,7 +122,7 @@ struct ServerCapabilities
     std::optional<CodeActionOptions> codeActionProvider = std::nullopt;
     std::optional<DocumentLinkOptions> documentLinkProvider = std::nullopt;
     bool colorProvider = false;
-    bool renameProvider = false;
+    std::optional<RenameOptions> renameProvider = std::nullopt;
     /**
      * The server provides folding provider support.
      *
@@ -129,16 +136,16 @@ struct ServerCapabilities
      */
     bool workspaceSymbolProvider = false;
     /**
-	 * The server provides call hierarchy support.
-	 *
-	 * @since 3.16.0
-	 */
+     * The server provides call hierarchy support.
+     *
+     * @since 3.16.0
+     */
     bool callHierarchyProvider = false;
     std::optional<SemanticTokensOptions> semanticTokensProvider = std::nullopt;
     std::optional<WorkspaceCapabilities> workspace = std::nullopt;
 };
 NLOHMANN_DEFINE_OPTIONAL(ServerCapabilities, positionEncoding, textDocumentSync, completionProvider, hoverProvider, signatureHelpProvider,
-    declarationProvider, definitionProvider, typeDefinitionProvider, implementationProvider, referencesProvider, documentSymbolProvider,
-    codeActionProvider, documentLinkProvider, colorProvider, renameProvider, foldingRangeProvider, inlayHintProvider, diagnosticProvider, workspaceSymbolProvider,
-    callHierarchyProvider, semanticTokensProvider, workspace);
+    declarationProvider, definitionProvider, typeDefinitionProvider, implementationProvider, referencesProvider, documentHighlightProvider,
+    documentSymbolProvider, codeActionProvider, documentLinkProvider, colorProvider, renameProvider, foldingRangeProvider, inlayHintProvider,
+    diagnosticProvider, workspaceSymbolProvider, callHierarchyProvider, semanticTokensProvider, workspace);
 } // namespace lsp

--- a/src/operations/DocumentHighlight.cpp
+++ b/src/operations/DocumentHighlight.cpp
@@ -1,0 +1,287 @@
+#include "LSP/Workspace.hpp"
+#include "LSP/LanguageServer.hpp"
+
+#include "LSP/LuauExt.hpp"
+
+static lsp::DocumentHighlight createHighlight(const TextDocument& textDocument, Luau::Location location, lsp::DocumentHighlightKind kind)
+{
+    return lsp::DocumentHighlight{{textDocument.convertPosition(location.begin), textDocument.convertPosition(location.end)}, kind};
+}
+
+static std::vector<lsp::DocumentHighlight> findAllPropertyHighlights(
+    const TextDocument& textDocument, Luau::ModulePtr module, const Luau::SourceModule& source, Luau::TypeId ty, Luau::Name property)
+{
+    ty = Luau::follow(ty);
+    auto ttv = Luau::get<Luau::TableType>(ty);
+
+    if (!ttv || ttv->definitionModuleName.empty())
+        return {};
+
+    std::vector<lsp::DocumentHighlight> highlights;
+
+    auto [locations, kinds] = findPropertyReferencesWithKinds(source, property, ty, module->astTypes);
+    highlights.reserve(locations.size());
+
+    for (size_t i = 0; i < locations.size(); ++i)
+    {
+        highlights.emplace_back(createHighlight(textDocument, locations[i], kinds[i]));
+    }
+
+    return highlights;
+}
+
+// Determines whether the name matches a type reference in one of the provided generics
+// If so, we find the usages inside of that node
+static bool handleIfTypeReferenceByName(Luau::AstNode* node, Luau::AstArray<Luau::AstGenericType> generics,
+    Luau::AstArray<Luau::AstGenericTypePack> genericPacks, Luau::AstName name, std::vector<lsp::DocumentHighlight>& highlights,
+    const TextDocument* textDocument)
+{
+    if (!isTypeReference(name, generics, genericPacks))
+        return false;
+
+    auto [locations, kinds] = findTypeParameterUsagesWithKinds(*node, name);
+
+    highlights.reserve(highlights.size() + locations.size());
+
+    for (size_t i = 0; i < locations.size(); ++i)
+    {
+        highlights.push_back(createHighlight(*textDocument, locations[i], kinds[i]));
+    }
+
+    return true;
+}
+
+// Determines whether the name matches a type reference in one of the provided generics
+// If so, we find the usages inside of that node
+static bool handleIfTypeReferenceByPosition(Luau::AstNode* node, Luau::AstArray<Luau::AstGenericType> generics,
+    Luau::AstArray<Luau::AstGenericTypePack> genericPacks, Luau::Position position, std::vector<lsp::DocumentHighlight>& highlights,
+    const TextDocument* textDocument)
+{
+    auto name = findTypeReferenceName(position, generics, genericPacks);
+    if (!name)
+        return false;
+
+    auto [locations, kinds] = findTypeParameterUsagesWithKinds(*node, name.value());
+
+    highlights.reserve(highlights.size() + locations.size());
+
+    for (size_t i = 0; i < locations.size(); ++i)
+    {
+        highlights.push_back(createHighlight(*textDocument, locations[i], kinds[i]));
+    }
+
+    return true;
+}
+
+lsp::DocumentHighlightResult WorkspaceFolder::documentHighlight(const lsp::DocumentHighlightParams& params)
+{
+    auto moduleName = fileResolver.getModuleName(params.textDocument.uri);
+    auto textDocument = fileResolver.getTextDocument(params.textDocument.uri);
+    if (!textDocument)
+        throw JsonRpcException(lsp::ErrorCode::RequestFailed, "No managed text document for " + params.textDocument.uri.toString());
+    auto position = textDocument->convertPosition(params.position);
+
+    // Run the type checker to ensure we are up to date
+    // We check for autocomplete here since autocomplete has stricter types
+    checkStrict(moduleName);
+
+    auto sourceModule = frontend.getSourceModule(moduleName);
+    if (!sourceModule)
+        throw JsonRpcException(lsp::ErrorCode::RequestFailed, "Unable to read source code");
+
+    auto exprOrLocal = findExprOrLocalAtPositionClosed(*sourceModule, position);
+    Luau::Symbol symbol;
+    if (exprOrLocal.getLocal())
+        symbol = exprOrLocal.getLocal();
+    else if (auto expr = exprOrLocal.getExpr())
+    {
+        if (auto local = expr->as<Luau::AstExprLocal>())
+            symbol = local->local;
+        else if (auto global = expr->as<Luau::AstExprGlobal>())
+            symbol = global->name;
+    }
+
+    // Search for usages of a local or global symbol
+    if (symbol)
+    {
+        auto [locations, kinds] = findSymbolReferencesWithKinds(*sourceModule, symbol);
+
+        std::vector<lsp::DocumentHighlight> highlights{}; // TODO: Do I need the `{}`?
+        highlights.reserve(locations.size());
+        for (size_t i = 0; i < locations.size(); ++i)
+        {
+            highlights.emplace_back(createHighlight(*textDocument, locations[i], kinds[i]));
+        }
+
+        return highlights;
+    }
+
+    // Search for a property
+    auto module = getModule(moduleName, /* forAutocomplete: */ true);
+    if (auto expr = exprOrLocal.getExpr())
+    {
+        if (auto indexName = expr->as<Luau::AstExprIndexName>())
+        {
+            auto possibleParentTy = module->astTypes.find(indexName->expr);
+            if (possibleParentTy)
+            {
+                auto parentTy = Luau::follow(*possibleParentTy);
+                return findAllPropertyHighlights(*textDocument, module, *sourceModule, parentTy, indexName->index.value);
+            }
+        }
+        else if (auto constantString = expr->as<Luau::AstExprConstantString>())
+        {
+            // Potentially a property defined inside of a table
+            auto ancestry = Luau::findAstAncestryOfPosition(*sourceModule, position, /* includeTypes = */ false);
+            if (ancestry.size() > 1)
+            {
+                auto parent = ancestry.at(ancestry.size() - 2);
+                if (auto tbl = parent->as<Luau::AstExprTable>())
+                {
+                    auto possibleTableTy = module->astTypes.find(tbl);
+                    if (possibleTableTy)
+                    {
+                        return findAllPropertyHighlights(*textDocument, module, *sourceModule, Luau::follow(*possibleTableTy),
+                            Luau::Name(constantString->value.data, constantString->value.size));
+                    }
+                }
+            }
+        }
+    }
+
+    // Search for a type reference
+    auto node = findNodeOrTypeAtPositionClosed(*sourceModule, position);
+    if (!node)
+        return std::nullopt;
+
+    std::vector<lsp::DocumentHighlight> highlights;
+
+    if (auto typeDefinition = node->as<Luau::AstStatTypeAlias>())
+    {
+        // Check to see whether the position was actually the type parameter: "S" in `type State<S> = ...`
+        if (handleIfTypeReferenceByPosition(
+                typeDefinition, typeDefinition->generics, typeDefinition->genericPacks, position, highlights, textDocument))
+        {
+            return highlights; // TODO: Is this safe or do I need to zero-init highlights?
+        }
+
+        // Include all usages of the type
+        auto references = findTypeReferences(*sourceModule, typeDefinition->name.value, std::nullopt);
+        highlights.reserve(references.size() + 1);
+        for (auto& location : references) // TODO: what's the difference between auto& location and auto location?
+            highlights.emplace_back(createHighlight(*textDocument, location, lsp::DocumentHighlightKind::Read));
+
+        // Include the type definition
+        highlights.emplace_back(createHighlight(*textDocument, typeDefinition->nameLocation, lsp::DocumentHighlightKind::Write));
+
+        return highlights;
+    }
+    else if (auto reference = node->as<Luau::AstTypeReference>())
+    {
+        if (auto prefix = reference->prefix)
+        {
+            auto requireInfo = findClosestAncestorModuleImport(*sourceModule, reference->prefix.value(), reference->prefixLocation->begin);
+            if (!requireInfo)
+                return std::nullopt;
+
+            auto requireSymbol = requireInfo.value().first;
+
+            if (reference->prefixLocation.value().containsClosed(position))
+            {
+                auto [locations, kinds] = findSymbolReferencesWithKinds(*sourceModule, requireSymbol);
+                highlights.reserve(locations.size());
+
+                for (size_t i = 0; i < locations.size(); ++i)
+                {
+                    highlights.emplace_back(createHighlight(*textDocument, locations[i], kinds[i]));
+                }
+            }
+            else
+            {
+                auto references = findTypeReferences(*sourceModule, reference->name.value, reference->prefix.value().value);
+                highlights.reserve(references.size());
+
+                for (auto& location : references)
+                {
+                    highlights.emplace_back(createHighlight(*textDocument, location, lsp::DocumentHighlightKind::Read));
+                }
+            }
+
+            return highlights;
+        }
+        else
+        {
+            // This could potentially be a generic type parameter - so we want to find its references if so.
+            auto ancestry = Luau::findAstAncestryOfPosition(*sourceModule, position, /* includeTypes= */ true);
+            for (auto it = ancestry.rbegin(); it != ancestry.rend(); ++it)
+            {
+                if (auto typeAlias = (*it)->as<Luau::AstStatTypeAlias>())
+                {
+                    if (handleIfTypeReferenceByName(
+                            typeAlias, typeAlias->generics, typeAlias->genericPacks, reference->name, highlights, textDocument))
+                        return highlights;
+                    break;
+                }
+                else if (auto typeFunction = (*it)->as<Luau::AstTypeFunction>())
+                {
+                    if (handleIfTypeReferenceByName(
+                            typeFunction, typeFunction->generics, typeFunction->genericPacks, reference->name, highlights, textDocument))
+                        return highlights;
+                }
+                else if (auto func = (*it)->as<Luau::AstExprFunction>())
+                {
+                    if (handleIfTypeReferenceByName(func, func->generics, func->genericPacks, reference->name, highlights, textDocument))
+                        return highlights;
+                    break;
+                }
+                else if (!(*it)->asType())
+                {
+                    // No longer inside a type, so no point going further
+                    break;
+                }
+            }
+
+            auto references = findTypeReferences(*sourceModule, reference->name.value, std::nullopt);
+            highlights.reserve(references.size() + 1);
+            for (auto& location : references)
+                highlights.emplace_back(createHighlight(*textDocument, location, lsp::DocumentHighlightKind::Read));
+
+            // Find the actual declaration location
+            auto scope = Luau::findScopeAtPosition(*module, position);
+            while (scope)
+            {
+                if (auto location = scope->typeAliasNameLocations.find(reference->name.value); location != scope->typeAliasNameLocations.end())
+                {
+                    highlights.emplace_back(createHighlight(*textDocument, location->second, lsp::DocumentHighlightKind::Write));
+                    break;
+                }
+
+                scope = scope->parent;
+            }
+
+            return highlights;
+        }
+    }
+    else if (auto typeFunction = node->as<Luau::AstTypeFunction>())
+    {
+        if (handleIfTypeReferenceByPosition(typeFunction, typeFunction->generics, typeFunction->genericPacks, position, highlights, textDocument))
+        {
+            return highlights;
+        }
+    }
+    else if (auto func = node->as<Luau::AstExprFunction>())
+    {
+        if (handleIfTypeReferenceByPosition(func, func->generics, func->genericPacks, position, highlights, textDocument))
+        {
+            return highlights;
+        }
+    }
+
+    return std::nullopt;
+}
+
+lsp::DocumentHighlightResult LanguageServer::documentHighlight(const lsp::DocumentHighlightParams& params)
+{
+    auto workspace = findWorkspace(params.textDocument.uri);
+    return workspace->documentHighlight(params);
+}

--- a/src/operations/References.cpp
+++ b/src/operations/References.cpp
@@ -43,7 +43,11 @@ std::vector<Reference> WorkspaceFolder::findAllReferences(Luau::TypeId ty, std::
     ty = Luau::follow(ty);
     auto ttv = Luau::get<Luau::TableType>(ty);
 
-    if (!ttv || ttv->definitionModuleName.empty())
+    // When the definition module name is equal to luauName, `LUAU_ASSERT(!buildQueueItems.empty());` in Frontend.cpp fails, after we call checkStrict
+    // below
+    const char* luauName = "@luau";
+
+    if (!ttv || ttv->definitionModuleName.empty() || ttv->definitionModuleName == luauName)
         return {};
 
     std::vector<Reference> references;

--- a/src/operations/Rename.cpp
+++ b/src/operations/Rename.cpp
@@ -3,7 +3,7 @@
 
 #include "LSP/LuauExt.hpp"
 
-static bool isGlobalBinding(const WorkspaceFolder* workspaceFolder, const lsp::RenameParams& params)
+static bool isGlobalBinding(const WorkspaceFolder* workspaceFolder, const lsp::TextDocumentPositionParams& params)
 {
     auto moduleName = workspaceFolder->fileResolver.getModuleName(params.textDocument.uri);
     auto textDocument = workspaceFolder->fileResolver.getTextDocument(params.textDocument.uri);
@@ -63,4 +63,94 @@ lsp::RenameResult LanguageServer::rename(const lsp::RenameParams& params)
 {
     auto workspace = findWorkspace(params.textDocument.uri);
     return workspace->rename(params);
+}
+
+static lsp::PrepareRenameRangePlaceholderResult createRangePlaceholder(const TextDocument& textDocument, Luau::Location location)
+{
+    lsp::Range range = {textDocument.convertPosition(location.begin), textDocument.convertPosition(location.end)};
+    auto text = textDocument.getText(range);
+    return {range, /* placeholder: */ text};
+}
+
+static std::optional<Luau::Location> findTypeReferenceLocation(
+    Luau::Position position, Luau::AstArray<Luau::AstGenericType> generics, Luau::AstArray<Luau::AstGenericTypePack> genericPacks)
+{
+    for (const auto t : generics)
+        if (t.location.containsClosed(position))
+            return t.location;
+    for (const auto t : genericPacks)
+        if (t.location.containsClosed(position))
+            return t.location;
+    return std::nullopt;
+}
+
+// TODO: Make sure this is correct.
+lsp::PrepareRenameResult WorkspaceFolder::prepareRename(const lsp::PrepareRenameParams& params)
+{
+    if (isGlobalBinding(this, params))
+        throw JsonRpcException(lsp::ErrorCode::RequestFailed, "Cannot rename a global variable");
+
+    auto moduleName = fileResolver.getModuleName(params.textDocument.uri);
+    auto textDocument = fileResolver.getTextDocument(params.textDocument.uri);
+    if (!textDocument)
+        throw JsonRpcException(lsp::ErrorCode::RequestFailed, "No managed text document for " + params.textDocument.uri.toString());
+    auto position = textDocument->convertPosition(params.position);
+
+    // Run the type checker to ensure we are up to date
+    // We check for autocomplete here since autocomplete has stricter types
+    // checkStrict(moduleName);
+
+    auto sourceModule = frontend.getSourceModule(moduleName);
+    if (!sourceModule)
+        throw JsonRpcException(lsp::ErrorCode::RequestFailed, "Unable to read source code");
+
+    auto exprOrLocal = findExprOrLocalAtPositionClosed(*sourceModule, position);
+    if (exprOrLocal.getLocal())
+        return createRangePlaceholder(*textDocument, exprOrLocal.getLocal()->location);
+    else if (auto expr = exprOrLocal.getExpr())
+    {
+        if (auto local = expr->as<Luau::AstExprLocal>())
+            return createRangePlaceholder(*textDocument, local->location);
+        else if (auto global = expr->as<Luau::AstExprGlobal>())
+            return createRangePlaceholder(*textDocument, global->location);
+    }
+
+    auto module = getModule(moduleName, /* forAutocomplete: */ true);
+    if (auto expr = exprOrLocal.getExpr())
+    {
+        if (auto indexName = expr->as<Luau::AstExprIndexName>())
+            return createRangePlaceholder(*textDocument, indexName->indexLocation);
+        else if (auto constantString = expr->as<Luau::AstExprConstantString>())
+        {
+            // Potentially a property defined inside of a table
+            auto ancestry = Luau::findAstAncestryOfPosition(*sourceModule, position, /* includeTypes = */ false);
+            if (ancestry.size() > 1)
+            {
+                auto parent = ancestry.at(ancestry.size() - 2);
+                if (auto tbl = parent->as<Luau::AstExprTable>())
+                    return createRangePlaceholder(*textDocument, constantString->location);
+            }
+        }
+    }
+
+    // Search for a type reference
+    auto node = findNodeOrTypeAtPositionClosed(*sourceModule, position);
+    if (!node)
+        return std::nullopt;
+
+    if (auto typeDefinition = node->as<Luau::AstStatTypeAlias>(); typeDefinition && typeDefinition->nameLocation.containsClosed(position))
+        return createRangePlaceholder(*textDocument, typeDefinition->nameLocation);
+    else if (auto reference = node->as<Luau::AstTypeReference>(); reference && reference->nameLocation.containsClosed(position))
+        return createRangePlaceholder(*textDocument, reference->nameLocation);
+    else if (auto typeFunction = node->as<Luau::AstTypeFunction>())
+        if (auto location = findTypeReferenceLocation(position, typeFunction->generics, typeFunction->genericPacks))
+            return createRangePlaceholder(*textDocument, *location);
+
+    return std::nullopt;
+}
+
+lsp::PrepareRenameResult LanguageServer::prepareRename(const lsp::PrepareRenameParams& params)
+{
+    auto workspace = findWorkspace(params.textDocument.uri);
+    return workspace->prepareRename(params);
 }


### PR DESCRIPTION
Zed requires that language servers support textDocument/prepareRename for symbol renaming to work. Zed also requires textDocument/documentHighlighting for highlighting to work, and this request is also used to mark everything that is about to get renamed when you enter symbol renaming mode. This PR adds support for both these capabilities.

Before, with the current type solver, finding property references didn't recognize assigning to properties, meaning `foo` `tbl.foo = bar` wouldn't be recognized as a reference to the `foo` property inside of `tbl`. This PR changes the logic behind finding property references to instead go through the AST, which also makes it possible to properly determine if symbols should be marked as Read or Write for the documentHighlight request.

Previously, finding references of imported modules in types also didn't work with scopes or shadowing. This PR alters the algorithm so that it stops processing a statement block when the symbol is shadowed by a module import, and when the scope in which the symbol is declared ends, which also is an optimization.

Resolves https://github.com/4teapo/zed-luau/issues/2.