### PR TITLE
Fix loading type definitions that rely on mutation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a regression in 1.30.0 breaking type definitions files that rely on mutations like `Enum.Foo`
+([#658](https://github.com/JohnnyMorganz/luau-lsp/issues/658))
+
 ## [1.32.3] - 2024-08-10
 
 ### Fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,7 @@ target_sources(Luau.LanguageServer.Test PRIVATE
         tests/LanguageServer.test.cpp
         tests/InlayHints.test.cpp
         tests/JsonTomlSyntaxParser.test.cpp
+        tests/Definitions.test.cpp
 )
 
 # TODO: Set Luau.Analysis at O2 to speed up debugging

--- a/src/LanguageServer.cpp
+++ b/src/LanguageServer.cpp
@@ -570,12 +570,10 @@ void LanguageServer::onInitialized([[maybe_unused]] const lsp::InitializedParams
     // causing us to fall back to the global configuration. Sending the request for configuration
     // first means we receive the user config before processing the first LSP events
     client->sendTrace("initializing null workspace");
-    nullWorkspace->initialize();
     nullWorkspace->setupWithConfiguration(client->globalConfig);
     for (auto& folder : workspaceFolders)
     {
         client->sendTrace("initializing workspace: " + folder->rootUri.toString());
-        folder->initialize();
         // Client does not support retrieving configuration information, so we just setup the workspaces with the default, global, configuration
         if (!requestedConfiguration)
             folder->setupWithConfiguration(client->globalConfig);

--- a/src/Workspace.cpp
+++ b/src/Workspace.cpp
@@ -278,7 +278,7 @@ void WorkspaceFolder::indexFiles(const ClientConfiguration& config)
     client->sendTrace("workspace: indexing all files COMPLETED");
 }
 
-void WorkspaceFolder::initialize()
+void WorkspaceFolder::registerTypes()
 {
     client->sendTrace("workspace initialization: registering Luau globals");
     Luau::registerBuiltinGlobals(frontend, frontend.globals, /* typeCheckForAutocomplete = */ false);
@@ -304,7 +304,8 @@ void WorkspaceFolder::initialize()
 
         // Parse definitions file metadata
         client->sendTrace("workspace initialization: parsing definitions file metadata");
-        if (auto metadata = types::parseDefinitionsFileMetadata(*definitionsContents))
+        auto metadata = types::parseDefinitionsFileMetadata(*definitionsContents);
+        if (!definitionsFileMetadata)
             definitionsFileMetadata = metadata;
         client->sendTrace("workspace initialization: parsing definitions file metadata COMPLETED", json(definitionsFileMetadata).dump());
 
@@ -312,6 +313,10 @@ void WorkspaceFolder::initialize()
         auto result = types::registerDefinitions(frontend, frontend.globals, *definitionsContents, /* typeCheckForAutocomplete = */ false);
         types::registerDefinitions(frontend, frontend.globalsForAutocomplete, *definitionsContents, /* typeCheckForAutocomplete = */ true);
         client->sendTrace("workspace initialization: registering types definition COMPLETED");
+
+        client->sendTrace("workspace: applying platform mutations on definitions");
+        platform->mutateRegisteredDefinitions(frontend.globals, metadata);
+        platform->mutateRegisteredDefinitions(frontend.globalsForAutocomplete, metadata);
 
         auto uri = Uri::file(resolvedFilePath);
 
@@ -357,10 +362,7 @@ void WorkspaceFolder::setupWithConfiguration(const ClientConfiguration& configur
         platform = LSPPlatform::getPlatform(configuration, &fileResolver, this);
         fileResolver.platform = platform.get();
 
-        client->sendTrace("workspace: applying platform mutations on definitions");
-
-        platform->mutateRegisteredDefinitions(frontend.globals, definitionsFileMetadata);
-        platform->mutateRegisteredDefinitions(frontend.globalsForAutocomplete, definitionsFileMetadata);
+        registerTypes();
     }
 
     client->sendTrace("workspace: apply platform-specific configuration");

--- a/src/include/LSP/Workspace.hpp
+++ b/src/include/LSP/Workspace.hpp
@@ -52,9 +52,6 @@ public:
         fileResolver.rootUri = uri;
     }
 
-    // Initialises the workspace folder
-    void initialize();
-
     // Sets up the workspace folder after receiving configuration information
     void setupWithConfiguration(const ClientConfiguration& configuration);
 
@@ -87,6 +84,7 @@ public:
     const Luau::ModulePtr getModule(const Luau::ModuleName& moduleName, bool forAutocomplete = false) const;
 
 private:
+    void registerTypes();
     void endAutocompletion(const lsp::CompletionParams& params);
     void suggestImports(const Luau::ModuleName& moduleName, const Luau::Position& position, const ClientConfiguration& config,
         const TextDocument& textDocument, std::vector<lsp::CompletionItem>& result, bool completingTypeReferencePrefix = true);

--- a/tests/Definitions.test.cpp
+++ b/tests/Definitions.test.cpp
@@ -1,0 +1,45 @@
+#include "doctest.h"
+#include "Fixture.h"
+#include "Platform/RobloxPlatform.hpp"
+
+using namespace Luau::LanguageServer;
+
+TEST_SUITE_BEGIN("Definitions");
+
+TEST_CASE("use_platform_metadata_from_first_registered_definitions_file")
+{
+    auto client = std::make_shared<Client>(Client{});
+    auto workspace = WorkspaceFolder(client, "$TEST_WORKSPACE", Uri(), std::nullopt);
+
+    client->definitionsFiles.emplace_back("./tests/testdata/standard_definitions.d.luau");
+    client->definitionsFiles.emplace_back("./tests/testdata/extra_definitions_relying_on_mutations.d.luau");
+
+    workspace.setupWithConfiguration(defaultTestClientConfiguration());
+
+    REQUIRE(workspace.definitionsFileMetadata);
+
+    RobloxDefinitionsFileMetadata metadata = workspace.definitionsFileMetadata.value();
+    REQUIRE(!metadata.SERVICES.empty());
+    REQUIRE(!metadata.CREATABLE_INSTANCES.empty());
+}
+
+TEST_CASE("handles_definitions_files_relying_on_mutations")
+{
+    auto client = std::make_shared<Client>(Client{});
+    auto workspace = WorkspaceFolder(client, "$TEST_WORKSPACE", Uri(), std::nullopt);
+
+    client->definitionsFiles.emplace_back("./tests/testdata/standard_definitions.d.luau");
+    client->definitionsFiles.emplace_back("./tests/testdata/extra_definitions_relying_on_mutations.d.luau");
+
+    workspace.setupWithConfiguration(defaultTestClientConfiguration());
+
+    auto document = newDocument(workspace, "foo.luau", R"(
+        local x: ExtraDataRelyingOnMutations
+        local y = x.RigType
+    )");
+
+    auto result = workspace.frontend.check("foo.luau");
+    REQUIRE(result.errors.empty());
+}
+
+TEST_SUITE_END();

--- a/tests/Fixture.cpp
+++ b/tests/Fixture.cpp
@@ -11,17 +11,31 @@
 
 static const char* mainModuleName = "MainModule";
 
+namespace Luau::LanguageServer
+{
+ClientConfiguration defaultTestClientConfiguration()
+{
+    ClientConfiguration config;
+    config.sourcemap.enabled = false;
+    config.index.enabled = false;
+    return config;
+}
+
+Uri newDocument(WorkspaceFolder& workspace, const std::string& name, const std::string& source)
+{
+    Uri uri("file", "", name);
+    workspace.openTextDocument(uri, {{uri, "luau", 0, source}});
+    return uri;
+}
+} // namespace Luau::LanguageServer
+
 Fixture::Fixture()
     : client(std::make_shared<Client>(Client{}))
     , workspace(client, "$TEST_WORKSPACE", Uri(), std::nullopt)
 {
     workspace.fileResolver.defaultConfig.mode = Luau::Mode::Strict;
     client->definitionsFiles.push_back("./tests/testdata/standard_definitions.d.luau");
-
-    ClientConfiguration config;
-    config.sourcemap.enabled = false;
-    config.index.enabled = false;
-    workspace.setupWithConfiguration(config);
+    workspace.setupWithConfiguration(Luau::LanguageServer::defaultTestClientConfiguration());
 
     Luau::setPrintLine([](auto s) {});
 }
@@ -38,9 +52,7 @@ Luau::ModuleName fromString(std::string_view name)
 
 Uri Fixture::newDocument(const std::string& name, const std::string& source)
 {
-    Uri uri("file", "", name);
-    workspace.openTextDocument(uri, {{uri, "luau", 0, source}});
-    return uri;
+    return Luau::LanguageServer::newDocument(workspace, name, source);
 }
 
 Luau::AstStatBlock* Fixture::parse(const std::string& source, const Luau::ParseOptions& parseOptions)

--- a/tests/Fixture.cpp
+++ b/tests/Fixture.cpp
@@ -18,8 +18,6 @@ Fixture::Fixture()
     workspace.fileResolver.defaultConfig.mode = Luau::Mode::Strict;
     client->definitionsFiles.push_back("./tests/testdata/standard_definitions.d.luau");
 
-    workspace.initialize();
-
     ClientConfiguration config;
     config.sourcemap.enabled = false;
     config.index.enabled = false;

--- a/tests/Fixture.h
+++ b/tests/Fixture.h
@@ -21,6 +21,13 @@
 
 #include <optional>
 
+// TODO: the rest should be part of this namespace...
+namespace Luau::LanguageServer
+{
+ClientConfiguration defaultTestClientConfiguration();
+Uri newDocument(WorkspaceFolder& workspace, const std::string& name, const std::string& source);
+} // namespace Luau::LanguageServer
+
 struct Fixture
 {
     std::unique_ptr<Luau::SourceModule> sourceModule;

--- a/tests/testdata/extra_definitions_relying_on_mutations.d.luau
+++ b/tests/testdata/extra_definitions_relying_on_mutations.d.luau
@@ -1,0 +1,4 @@
+--#METADATA#{"CREATABLE_INSTANCES":[], "SERVICES": []}
+export type ExtraDataRelyingOnMutations = {
+    RigType: Enum.HumanoidRigType
+}


### PR DESCRIPTION
Fixes #658 

Changes:

- Previously, the workspace-global definitions file metadata (`definitionsMetadata`) was set to the metadata of the last definitions file that contained metadata. Now, it is set to the first one. I think this makes sense as it prevents the platform metadata from getting overridden.
- Since the language server does not do anything useful before the platform is available, `WorkspaceFolder::initialize` (which only performed type registration) was moved to `setupWithConfiguration` and renamed to `registerTypes`.
- The platform mutation function is now run after every definition file is registered. The platform can disambiguate which definitions file is which by checking what types are available (how it was done before) or with the metadata provided in the file.

This should more or less match the behavior from before 1.30.0. I tested with pilot.d.lua and it seems to work.