### PR TITLE
Sync to upstream Luau 0.645

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- Sync to upstream Luau 0.645
+
 ### Fixed
 
 - Fixed a regression in 1.30.0 breaking type definitions files that rely on mutations like `Enum.Foo`


### PR DESCRIPTION
This PR syncs the upstream Luau version to 0.645. I confirmed locally that everything builds without issue, so no additional changes needed beyond upgrading the Luau commit.