### PR TITLE
Add CFrame.fromRotationBetweenVectors

### DIFF
--- a/scripts/DataTypes.json
+++ b/scripts/DataTypes.json
@@ -3692,6 +3692,27 @@
                 },
                 {
                     "MemberType": "Function",
+                    "Name": "FuzzyEq",
+                    "Parameters": [
+                        {
+                            "Name": "other",
+                            "Type": {
+                                "Name": "CFrame"
+                            }
+                        },
+                        {
+                            "Name": "epsilon",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "bool"
+                    }
+                },
+                {
+                    "MemberType": "Function",
                     "Name": "components",
                     "Deprecated": true,
                     "Parameters": [],

--- a/scripts/DataTypes.json
+++ b/scripts/DataTypes.json
@@ -1107,6 +1107,27 @@
                 },
                 {
                     "MemberType": "Function",
+                    "Name": "fromRotationBetweenVectors",
+                    "Parameters": [
+                        {
+                            "Name": "from",
+                            "Type": {
+                                "Name": "Vector3"
+                            }
+                        },
+                        {
+                            "Name": "to",
+                            "Type": {
+                                "Name": "Vector3"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "CFrame"
+                    }
+                },
+                {
+                    "MemberType": "Function",
                     "Name": "new",
                     "Parameters": [],
                     "ReturnType": {


### PR DESCRIPTION
Closes #800 and #768

this PR adds `fromRotationBetweenVectors` and `FuzzyEq` to CFrame datatype