### PR TITLE
Move Content.none to the constructor table

### DIFF
--- a/scripts/DataTypes.json
+++ b/scripts/DataTypes.json
@@ -2111,7 +2111,7 @@
                     "ValueType": {
                         "Name": "Content"
                     }
-                },
+                }
             ],
             "Name": "Content"
         },
@@ -4631,13 +4631,6 @@
         },
         {
             "Members": [
-                {
-                    "MemberType": "Property",
-                    "Name": "none",
-                    "ValueType": {
-                        "Name": "Content"
-                    }
-                },
                 {
                     "MemberType": "Property",
                     "Name": "SourceType",

--- a/scripts/DataTypes.json
+++ b/scripts/DataTypes.json
@@ -2104,7 +2104,14 @@
                     "ReturnType": {
                         "Name": "Content"
                     }
-                }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "none",
+                    "ValueType": {
+                        "Name": "Content"
+                    }
+                },
             ],
             "Name": "Content"
         },


### PR DESCRIPTION
Expands on #817 - `Content.none` is part of the constructor table for this DataType (and not of the type itself)

Example:
```luau
-- valid
imageLabel.ImageContent = Content.none

-- "none is not a valid member of Content"
local c = Content.fromUri("")
print(c.none == Content.none)
```