### PR TITLE
Create workflows to publish Companion plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,7 @@ jobs:
           lune setup
           echo '{ "luau-lsp.require.directoryAliases": {"@lune/": "~/.lune/.typedefs/0.8.9/"} }' > settings.json
           rojo sourcemap test.project.json --output test-sourcemap.json
-          ../build/luau-lsp analyze --sourcemap=test-sourcemap.json --definitions=../scripts/globalTypes.d.luau --settings=settings.json --fflag:LuauFixIndexerSubtypingOrdering=True cloud
+          ../build/luau-lsp analyze --sourcemap=test-sourcemap.json --definitions=../scripts/globalTypes.d.luau --settings=settings.json --flag:LuauFixIndexerSubtypingOrdering=True cloud
         working-directory: plugin
 
       - name: Build Plugin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,11 +144,11 @@ jobs:
       - uses: ok-nick/setup-aftman@v0.4.2
 
       - name: Run selene
-        run: selene src
+        run: selene src cloud
         working-directory: plugin
 
       - name: Run stylua
-        run: stylua --check src
+        run: stylua --check src cloud
         working-directory: plugin
 
       - name: Generate sourcemap
@@ -161,8 +161,16 @@ jobs:
           cmake ..
           cmake --build . --target Luau.LanguageServer.CLI -j 3
 
-      - name: Run Luau Analyze
+      - name: Run Luau Analyze (Plugin Source)
         run: ../build/luau-lsp analyze --sourcemap=sourcemap.json --definitions=../scripts/globalTypes.d.luau src
+        working-directory: plugin
+
+      - name: Run Luau Analyze (Cloud Scripts)
+        run: |
+          lune setup
+          echo '{ "luau-lsp.require.directoryAliases": {"@lune/": "~/.lune/.typedefs/0.8.9/"} }' > settings.json
+          rojo sourcemap test.project.json --output test-sourcemap.json
+          ../build/luau-lsp analyze --sourcemap=test-sourcemap.json --definitions=../scripts/globalTypes.d.luau --settings=settings.json --fflag:LuauFixIndexerSubtypingOrdering=True cloud
         working-directory: plugin
 
       - name: Build Plugin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,14 @@ jobs:
           asset_name: Luau.rbxm
           asset_content_type: application/octet-stream
 
+      - name: Publish Plugin to Roblox
+        env:
+          ROBLOX_API_KEY: ${{ secrets.ROBLOX_API_KEY }}
+        working-directory: plugin
+        run: |
+          rojo build test.project.json --output plugin_place.rbxl
+          lune run cloud/execute_task.luau plugin_place.rbxl cloud/publishing_task.luau
+
   dist:
     needs: ["create-release"]
     strategy:

--- a/.github/workflows/upload-companion-plugin.yml
+++ b/.github/workflows/upload-companion-plugin.yml
@@ -1,0 +1,29 @@
+name: Upload Companion Plugin (Manual)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  upload-plugin:
+    name: Upload Roblox Studio Plugin
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ok-nick/setup-aftman@v0.4.2
+
+      - name: Build Plugin
+        run: rojo build plugin --output Luau.rbxm
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: Luau.rbxm
+          path: Luau.rbxm
+
+      - name: Publish Plugin to Roblox
+        env:
+          ROBLOX_API_KEY: ${{ secrets.ROBLOX_API_KEY }}
+        working-directory: plugin
+        run: |
+          rojo build test.project.json --output plugin_place.rbxl
+          lune run cloud/execute_task.luau plugin_place.rbxl cloud/publishing_task.luau

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ cmake-build-debug-visual-studio/
 cmake-build-release-visual-studio/
 cmake-build-relwithdebinfo-visual-studio/
 CMakeFiles
+sourcemap.json
 
 # Prerequisites
 *.d

--- a/.stylua.toml
+++ b/.stylua.toml
@@ -1,0 +1,4 @@
+syntax = "Luau"
+
+[sort_requires]
+enabled = true

--- a/aftman.toml
+++ b/aftman.toml
@@ -6,4 +6,4 @@
 rojo = "rojo-rbx/rojo@7.4.0-rc3"
 selene = "Kampfkarren/selene@0.26.1"
 stylua = "JohnnyMorganz/stylua@0.19.1"
-# rojo = "rojo-rbx/rojo@6.2.0"
+lune = "lune-org/lune@0.8.9"

--- a/plugin/cloud/execute_task.luau
+++ b/plugin/cloud/execute_task.luau
@@ -1,0 +1,148 @@
+--!strict
+--[=[
+	Lune script to execute Luau tasks using OpenCloud within a Roblox engine.
+	This script can execute any task within the environment, such as publishing the plugin.
+
+	Steps for usage:
+		1) `rojo build test.project.json --output plugin_place.rbxl`
+		2) `ROBLOX_API_KEY=xxxx lune run publish_plugin.luau plugin_place.rbxl <cloud_task_file>`
+
+	test.project.json will build a full place file with the plugin stored in ReplicatedStorage
+	at game.ReplicatedStorage.Plugin. The cloud task file can then reference this Instance for
+	necessary tasks
+
+	For publishing, see `publishing_task.luau` which will publish the plugin to Roblox
+]=]
+
+local fs = require("@lune/fs")
+local net = require("@lune/net")
+local process = require("@lune/process")
+local task = require("@lune/task")
+
+local ROBLOX_API_KEY = assert(process.env.ROBLOX_API_KEY, "Missing ENV variable: ROBLOX_API_KEY")
+local UNIVERSE_ID = 6894392979
+local PLACE_ID = 77855406782464
+
+assert(#process.args == 2, "Usage: lune run publish_plugin.luau PLACE_FILE CLOUD_TASK_FILE")
+local PLACE_FILE = process.args[1]
+local CLOUD_TASK_FILE = process.args[2]
+
+print(`Attempting to execute {CLOUD_TASK_FILE}`)
+
+local SCRIPT_CONTENTS = fs.readFile(CLOUD_TASK_FILE)
+
+print("=== SCRIPT CONTENTS ===")
+print(SCRIPT_CONTENTS)
+print("=== END ===")
+
+type LuauTask = {
+	path: string,
+	createTime: string,
+	updateTime: string,
+	user: string,
+	state: "STATE_UNSPECIFIED" | "QUEUED" | "PROCESSING" | "CANCELLED" | "COMPLETE" | "FAILED",
+	script: string,
+}
+
+local function uploadPlaceFile(universeId: number, placeId: number, placeFile: string): number
+	print("Uploading place file...")
+	local response = net.request({
+		method = "POST",
+		url = `https://apis.roblox.com/universes/v1/{universeId}/places/{placeId}/versions?versionType=Saved`,
+		headers = {
+			["Content-Type"] = "application/xml",
+			["Accept"] = "application/json",
+			["X-API-Key"] = ROBLOX_API_KEY,
+		},
+		body = fs.readFile(placeFile),
+	})
+
+	if response.ok then
+		print("Place file upload succeeded", response.body)
+		return net.jsonDecode(response.body)["versionNumber"]
+	else
+		error(`uploadPlaceFile failed: {response.statusCode} - {response.statusMessage}: {response.body}`)
+	end
+end
+
+local function createTask(universeId: number, placeId: number, placeVersion: number, scriptContents: string): LuauTask
+	local response = net.request({
+		method = "POST",
+		url = `https://apis.roblox.com/cloud/v2/universes/{universeId}/places/{placeId}/versions/{placeVersion}/luau-execution-session-tasks`,
+		headers = {
+			["Content-Type"] = "application/json",
+			["X-API-Key"] = ROBLOX_API_KEY,
+		},
+		body = net.jsonEncode({
+			script = scriptContents,
+		}),
+	})
+
+	if not response.ok then
+		error(`Create task request failed: {response.body}`)
+	end
+
+	return net.jsonDecode(response.body)
+end
+
+local function pollForTaskCompletion(taskPath: string)
+	print("Polling for task status...")
+
+	while true do
+		local response = net.request({
+			method = "GET",
+			url = `https://apis.roblox.com/cloud/v2/{taskPath}`,
+			headers = {
+				["X-API-Key"] = ROBLOX_API_KEY,
+			},
+		})
+
+		if not response.ok then
+			error(`Poll task completion failed: {response.body}`)
+		end
+
+		local cloudTask = net.jsonDecode(response.body)
+		if cloudTask.state ~= "PROCESSING" then
+			return cloudTask
+		else
+			print(".")
+			task.wait(3)
+		end
+	end
+end
+
+local function getTaskLogs(taskPath: string)
+	local response = net.request({
+		method = "GET",
+		url = `https://apis.roblox.com/cloud/v2/{taskPath}/logs`,
+		headers = {
+			["X-API-Key"] = ROBLOX_API_KEY,
+		},
+	})
+
+	if not response.ok then
+		error(`Get task logs failed: {response.body}`)
+	end
+
+	return table.concat(net.jsonDecode(response.body).luauExecutionSessionTaskLogs[1].messages, "\n")
+end
+
+local function runLuauTask(universeId: number, placeId: number, placeVersion: number, scriptContents: string)
+	print("Executing Luau task...")
+
+	local cloudTask = createTask(universeId, placeId, placeVersion, scriptContents)
+	cloudTask = pollForTaskCompletion(cloudTask.path)
+	local logs = getTaskLogs(cloudTask.path)
+
+	print(logs)
+	print(cloudTask)
+
+	if cloudTask.state == "COMPLETE" then
+		print("Luau task completed successfully")
+	else
+		error("Luau task failed")
+	end
+end
+
+local placeVersion = uploadPlaceFile(UNIVERSE_ID, PLACE_ID, PLACE_FILE)
+runLuauTask(UNIVERSE_ID, PLACE_ID, placeVersion, SCRIPT_CONTENTS)

--- a/plugin/cloud/publishing_task.luau
+++ b/plugin/cloud/publishing_task.luau
@@ -1,0 +1,15 @@
+--- Script to publish the Luau Language Server companion plugin to Roblox
+
+local AssetService = game:GetService("AssetService")
+
+local ASSET_ID = 10913122509
+local CREATOR_ID = 68136726
+
+print("Executing AssetService:CreateAssetVersionAsync")
+
+local result, number =
+	AssetService:CreateAssetVersionAsync(game.ReplicatedStorage.Plugin, Enum.AssetType.Plugin, ASSET_ID, {
+		CreatorId = CREATOR_ID,
+	})
+
+print(result, number)

--- a/plugin/cloud/publishing_task.luau
+++ b/plugin/cloud/publishing_task.luau
@@ -1,3 +1,4 @@
+--!strict
 --- Script to publish the Luau Language Server companion plugin to Roblox
 
 local AssetService = game:GetService("AssetService")

--- a/plugin/selene.toml
+++ b/plugin/selene.toml
@@ -1,1 +1,1 @@
-std = "roblox"
+std = "luau+roblox"


### PR DESCRIPTION
Right now, the Studio companion plugin must still be manually published to Roblox after updates.

With the introduction of the new AssetService creation APIs (https://devforum.roblox.com/t/beta-lua-asset-creation-for-creator-tooling-with-createassetasync/3294134/18), alongside the OpenCloud APIs to execute Luau in the engine (https://devforum.roblox.com/t/beta-open-cloud-engine-api-for-executing-luau/3172185), we can now automate this flow!

We develop a Lune script to support executing arbitrary cloud tasks in the engine. `test.project.json` builds a barebones place file with the plugin built at `game.ReplicatedStorage.Plugin`.

After building the place file with Rojo, the execute task script will upload it to Roblox, then execute the provided cloud task file.

We also add in a cloud task file that uses the new AssetService APIs to publish the `game.ReplicatedStorage.Plugin` file to Roblox.