### PR TITLE
Remove weakly_canonical and replace with Luau's normalisePath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     0.24s) ([#749](https://github.com/JohnnyMorganz/luau-lsp/issues/749))
   - These improvements heavily depend on the amount of code you have matching ignore globs. Workspace diagnostics
     improvements depends on the performance of Luau typechecking.
+- Optimised the resolution of relative string requires by remove filesystem
+  calls ([#856](https://github.com/JohnnyMorganz/luau-lsp/issues/856))
 
 ## [1.37.0] - 2024-12-14
 

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -214,3 +214,137 @@ void replaceAll(std::string& str, const std::string& from, const std::string& to
         start_pos += to.length();
     }
 }
+
+bool isAbsolutePath(std::string_view path)
+{
+#ifdef _WIN32
+    // Must either begin with "X:/", "X:\", "/", or "\", where X is a drive letter
+    return (path.size() >= 3 && isalpha(path[0]) && path[1] == ':' && (path[2] == '/' || path[2] == '\\')) ||
+           (path.size() >= 1 && (path[0] == '/' || path[0] == '\\'));
+#else
+    // Must begin with '/'
+    return path.size() >= 1 && path[0] == '/';
+#endif
+}
+
+// Returns the normal/canonical form of a path (e.g. "../subfolder/../module.luau" -> "../module.luau")
+std::string normalizePath(std::string_view path)
+{
+    return resolvePath(path, "");
+}
+
+// Takes a path that is relative to the file at baseFilePath and returns the path explicitly rebased onto baseFilePath.
+// For absolute paths, baseFilePath will be ignored, and this function will resolve the path to a canonical path:
+// (e.g. "/Users/.././Users/johndoe" -> "/Users/johndoe").
+std::string resolvePath(std::string_view path, std::string_view baseFilePath)
+{
+    std::vector<std::string_view> pathComponents;
+    std::vector<std::string_view> baseFilePathComponents;
+
+    // Dependent on whether the final resolved path is absolute or relative
+    // - if relative (when path and baseFilePath are both relative), resolvedPathPrefix remains empty
+    // - if absolute (if either path or baseFilePath are absolute), resolvedPathPrefix is "C:\", "/", etc.
+    std::string resolvedPathPrefix;
+    bool isResolvedPathRelative = false;
+
+    if (isAbsolutePath(path))
+    {
+        // path is absolute, we use path's prefix and ignore baseFilePath
+        size_t afterPrefix = path.find_first_of("\\/") + 1;
+        resolvedPathPrefix = path.substr(0, afterPrefix);
+        pathComponents = splitPath(path.substr(afterPrefix));
+    }
+    else
+    {
+        size_t afterPrefix = baseFilePath.find_first_of("\\/") + 1;
+        baseFilePathComponents = splitPath(baseFilePath.substr(afterPrefix));
+        if (isAbsolutePath(baseFilePath))
+        {
+            // path is relative and baseFilePath is absolute, we use baseFilePath's prefix
+            resolvedPathPrefix = baseFilePath.substr(0, afterPrefix);
+        }
+        else
+        {
+            // path and baseFilePath are both relative, we do not set a prefix (resolved path will be relative)
+            isResolvedPathRelative = true;
+        }
+        pathComponents = splitPath(path);
+    }
+
+    // Remove filename from components
+    if (!baseFilePathComponents.empty())
+        baseFilePathComponents.pop_back();
+
+    // Resolve the path by applying pathComponents to baseFilePathComponents
+    int numPrependedParents = 0;
+    for (std::string_view component : pathComponents)
+    {
+        if (component == "..")
+        {
+            if (baseFilePathComponents.empty())
+            {
+                if (isResolvedPathRelative)
+                    numPrependedParents++; // "../" will later be added to the beginning of the resolved path
+            }
+            else if (baseFilePathComponents.back() != "..")
+            {
+                baseFilePathComponents.pop_back(); // Resolve cases like "folder/subfolder/../../file" to "file"
+            }
+        }
+        else if (component != "." && !component.empty())
+        {
+            baseFilePathComponents.push_back(component);
+        }
+    }
+
+    // Create resolved path prefix for relative paths
+    if (isResolvedPathRelative)
+    {
+        if (numPrependedParents > 0)
+        {
+            resolvedPathPrefix.reserve(numPrependedParents * 3);
+            for (int i = 0; i < numPrependedParents; i++)
+            {
+                resolvedPathPrefix += "../";
+            }
+        }
+        else
+        {
+            resolvedPathPrefix = "./";
+        }
+    }
+
+    // Join baseFilePathComponents to form the resolved path
+    std::string resolvedPath = resolvedPathPrefix;
+    for (auto iter = baseFilePathComponents.begin(); iter != baseFilePathComponents.end(); ++iter)
+    {
+        if (iter != baseFilePathComponents.begin())
+            resolvedPath += "/";
+
+        resolvedPath += *iter;
+    }
+    if (resolvedPath.size() > resolvedPathPrefix.size() && resolvedPath.back() == '/')
+    {
+        // Remove trailing '/' if present
+        resolvedPath.pop_back();
+    }
+    return resolvedPath;
+}
+
+std::vector<std::string_view> splitPath(std::string_view path)
+{
+    std::vector<std::string_view> components;
+
+    size_t pos = 0;
+    size_t nextPos = path.find_first_of("\\/", pos);
+
+    while (nextPos != std::string::npos)
+    {
+        components.push_back(path.substr(pos, nextPos - pos));
+        pos = nextPos + 1;
+        nextPos = path.find_first_of("\\/", pos);
+    }
+    components.push_back(path.substr(pos));
+
+    return components;
+}

--- a/src/Workspace.cpp
+++ b/src/Workspace.cpp
@@ -180,11 +180,11 @@ bool WorkspaceFolder::isIgnoredFileForAutoImports(const std::filesystem::path& p
 bool WorkspaceFolder::isDefinitionFile(const std::filesystem::path& path, const std::optional<ClientConfiguration>& givenConfig)
 {
     auto config = givenConfig ? *givenConfig : client->getConfiguration(rootUri);
-    auto canonicalised = std::filesystem::weakly_canonical(path);
+    auto canonicalised = normalizePath(path.generic_string());
 
     for (auto& file : config.types.definitionFiles)
     {
-        if (std::filesystem::weakly_canonical(resolvePath(file)) == canonicalised)
+        if (normalizePath(resolvePath(file).generic_string()) == canonicalised)
         {
             return true;
         }

--- a/src/include/LSP/Utils.hpp
+++ b/src/include/LSP/Utils.hpp
@@ -46,3 +46,9 @@ inline bool contains(const std::map<K, V>& map, const K& value)
 {
     return map.find(value) != map.end();
 }
+
+// TODO: taken from FileUtils, use that instead?
+bool isAbsolutePath(std::string_view path);
+std::string normalizePath(std::string_view path);
+std::string resolvePath(std::string_view relativePath, std::string_view baseFilePath);
+std::vector<std::string_view> splitPath(std::string_view path);

--- a/src/platform/LSPPlatform.cpp
+++ b/src/platform/LSPPlatform.cpp
@@ -118,7 +118,7 @@ std::optional<Luau::ModuleInfo> LSPPlatform::resolveStringRequire(const Luau::Mo
         return std::nullopt;
 
     std::filesystem::path basePath = contextPath->parent_path();
-    auto filePath = basePath / requiredString;
+    auto filePath = workspaceFolder->rootUri.fsPath() / basePath / requiredString;
 
     auto luauConfig = fileResolver->getConfig(context->name);
     if (auto aliasedPath = resolveAlias(requiredString, luauConfig))
@@ -142,10 +142,10 @@ std::optional<Luau::ModuleInfo> LSPPlatform::resolveStringRequire(const Luau::Mo
         }
     }
 
-    std::error_code ec;
-    filePath = std::filesystem::weakly_canonical(filePath, ec);
+    filePath = normalizePath(filePath.generic_string());
 
     // Handle "init.luau" files in a directory
+    std::error_code ec;
     if (std::filesystem::is_directory(filePath, ec))
     {
         filePath /= "init";

--- a/tests/WorkspaceFileResolver.test.cpp
+++ b/tests/WorkspaceFileResolver.test.cpp
@@ -238,12 +238,8 @@ TEST_CASE_FIXTURE(Fixture, "resolve_alias_supports_tilde_expansion")
 
 TEST_CASE_FIXTURE(Fixture, "string require doesn't add file extension if already exists")
 {
-    WorkspaceFileResolver fileResolver;
-    LSPPlatform platform{&fileResolver};
-    fileResolver.platform = &platform;
-
     Luau::ModuleInfo baseContext{};
-    auto resolved = platform.resolveStringRequire(&baseContext, "Module.luau");
+    auto resolved = workspace.platform->resolveStringRequire(&baseContext, "Module.luau");
 
     REQUIRE(resolved.has_value());
     CHECK(endsWith(resolved->name, "/Module.luau"));
@@ -251,12 +247,8 @@ TEST_CASE_FIXTURE(Fixture, "string require doesn't add file extension if already
 
 TEST_CASE_FIXTURE(Fixture, "string require doesn't replace a non-luau/lua extension")
 {
-    WorkspaceFileResolver fileResolver;
-    LSPPlatform platform{&fileResolver};
-    fileResolver.platform = &platform;
-
     Luau::ModuleInfo baseContext{};
-    auto resolved = platform.resolveStringRequire(&baseContext, "Module.mod");
+    auto resolved = workspace.platform->resolveStringRequire(&baseContext, "Module.mod");
 
     REQUIRE(resolved.has_value());
     CHECK(endsWith(resolved->name, "/Module.mod.lua"));


### PR DESCRIPTION
weakly_canonical performs filesystem calls to check if all components of the path exist, and resolve symlinks. We don't need these features.

We replace with Luau's normalisePath.

Note that weakly_canonical would also make relative file paths absolute by appending them to the current working directory. This cause relative string requires to break. We resolve this by making paths absolute in string requires - we shouldn't be relying on the current directory in the first place