### PR TITLE
Require a name for definitions files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- Definitions files must now provide a name for the file in settings and command line: i.e.
+  `--definitions:@roblox=path/to/globalTypes.d.luau`. This is to support mapping global types back to their original
+  definitions file for documentation features. Please update your LSP settings and command line arguments.
+  Backwards compatibility has been temporarily preserved, with random names generated.
+
 ## [1.38.0] - 2024-12-28
 
 ### Added

--- a/editors/README.md
+++ b/editors/README.md
@@ -25,11 +25,12 @@ $ luau-lsp --help
 
 ## Configuring Definitions and Documentation
 
-You can add in built-in definitions by passing the `--definitions=PATH` argument.
+You can add in built-in definitions by passing the `--definitions:@name=PATH` argument. The `name` should be a unique
+reference to the definitions file.
 This can be done multiple times:
 
 ```sh
-$ luau-lsp lsp --definitions=/path/to/globalTypes.d.luau
+$ luau-lsp lsp --definitions:@roblox=/path/to/globalTypes.d.luau
 ```
 
 > NOTE: Definitions file syntax is unstable and undocumented. It may change at any time

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -269,10 +269,10 @@
           "scope": "resource"
         },
         "luau-lsp.types.definitionFiles": {
-          "markdownDescription": "A list of paths to definition files to load in to the type checker. Note that definition file syntax is currently unstable and may change at any time",
-          "type": "array",
-          "default": [],
-          "items": {
+          "markdownDescription": "A mapping of package names to paths of definition files to load in to the type checker. Note that definition file syntax is currently unstable and may change at any time",
+          "type": "object",
+          "default": {},
+          "additionalProperties": {
             "type": "string"
           },
           "scope": "window"

--- a/editors/code/src/extension.ts
+++ b/editors/code/src/extension.ts
@@ -79,9 +79,18 @@ const startLanguageServer = async (context: vscode.ExtensionContext) => {
   const typesConfig = vscode.workspace.getConfiguration("luau-lsp.types");
 
   // Load extra type definitions
-  const definitionFiles = typesConfig.get<string[]>("definitionFiles");
+  let definitionFiles = typesConfig.get<
+    { [packageName: string]: string } | string[]
+  >("definitionFiles");
+
   if (definitionFiles) {
-    for (let definitionPath of definitionFiles) {
+    if (Array.isArray(definitionFiles)) {
+      definitionFiles = Object.fromEntries(
+        definitionFiles.map((path, index) => ["roblox" + index, path]),
+      );
+    }
+
+    for (let [packageName, definitionPath] of Object.entries(definitionFiles)) {
       definitionPath = utils.resolvePath(definitionPath);
       let uri;
       if (vscode.workspace.workspaceFolders) {
@@ -93,10 +102,10 @@ const startLanguageServer = async (context: vscode.ExtensionContext) => {
         uri = vscode.Uri.file(definitionPath);
       }
       if (await utils.exists(uri)) {
-        addArg(`--definitions=${uri.fsPath}`);
+        addArg(`--definitions:${packageName}=${uri.fsPath}`);
       } else {
         vscode.window.showWarningMessage(
-          `Definitions file at ${definitionPath} does not exist, types will not be provided from this file`,
+          `Definitions file '${packageName}' at ${definitionPath} does not exist, types will not be provided from this file`,
         );
       }
     }

--- a/src/LuauExt.cpp
+++ b/src/LuauExt.cpp
@@ -53,10 +53,10 @@ std::optional<nlohmann::json> parseDefinitionsFileMetadata(const std::string& de
     return std::nullopt;
 }
 
-Luau::LoadDefinitionFileResult registerDefinitions(Luau::Frontend& frontend, Luau::GlobalTypes& globals, const std::string& definitions)
+Luau::LoadDefinitionFileResult registerDefinitions(
+    Luau::Frontend& frontend, Luau::GlobalTypes& globals, const std::string& packageName, const std::string& definitions)
 {
-    // TODO: packageName shouldn't just be "@roblox"
-    return frontend.loadDefinitionFile(globals, globals.globalScope, definitions, "@roblox", /* captureComments = */ false);
+    return frontend.loadDefinitionFile(globals, globals.globalScope, definitions, packageName, /* captureComments = */ false);
 }
 
 using NameOrExpr = std::variant<std::string, Luau::AstExpr*>;

--- a/src/include/Analyze/AnalyzeCli.hpp
+++ b/src/include/Analyze/AnalyzeCli.hpp
@@ -5,4 +5,5 @@
 #include "argparse/argparse.hpp"
 
 std::vector<std::filesystem::path> getFilesToAnalyze(const std::vector<std::string>& paths, const std::vector<std::string>& ignoreGlobPatterns);
+std::unordered_map<std::string, std::filesystem::path> processDefinitionsFilePaths(const argparse::ArgumentParser& program);
 int startAnalyze(const argparse::ArgumentParser& program);

--- a/src/include/LSP/Client.hpp
+++ b/src/include/LSP/Client.hpp
@@ -29,7 +29,7 @@ public:
     lsp::ClientCapabilities capabilities;
     lsp::TraceValue traceMode = lsp::TraceValue::Off;
     /// A registered definitions file passed by the client
-    std::vector<std::filesystem::path> definitionsFiles{};
+    std::unordered_map<std::string, std::filesystem::path> definitionsFiles{};
     /// A registered documentation file passed by the client
     std::vector<std::filesystem::path> documentationFiles{};
     /// Parsed documentation database

--- a/src/include/LSP/ClientConfiguration.hpp
+++ b/src/include/LSP/ClientConfiguration.hpp
@@ -34,10 +34,10 @@ struct ClientTypesConfiguration
     /// Whether Roblox-related definitions should be supported
     /// DEPRECATED: USE `platform.type` INSTEAD
     bool roblox = true;
-    /// Any definition files to load globally
-    std::vector<std::filesystem::path> definitionFiles{};
+    // TODO: commented out due to backwards compatibility. uncomment if needed later once all settings have converted
+    // std::unordered_map<std::string, std::filesystem::path> definitionFiles{};
 };
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(ClientTypesConfiguration, roblox, definitionFiles);
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(ClientTypesConfiguration, roblox); // definitionFiles
 
 enum struct InlayHintsParameterNamesConfig
 {

--- a/src/include/LSP/LuauExt.hpp
+++ b/src/include/LSP/LuauExt.hpp
@@ -18,7 +18,8 @@ bool isMetamethod(const Luau::Name& name);
 
 std::optional<nlohmann::json> parseDefinitionsFileMetadata(const std::string& definitions);
 
-Luau::LoadDefinitionFileResult registerDefinitions(Luau::Frontend& frontend, Luau::GlobalTypes& globals, const std::string& definitions);
+Luau::LoadDefinitionFileResult registerDefinitions(
+    Luau::Frontend& frontend, Luau::GlobalTypes& globals, const std::string& packageName, const std::string& definitions);
 
 using NameOrExpr = std::variant<std::string, Luau::AstExpr*>;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -45,7 +45,7 @@ int startLanguageServer(const argparse::ArgumentParser& program)
     _setmode(_fileno(stdout), _O_BINARY);
 #endif
 
-    auto definitionsFiles = program.get<std::vector<std::filesystem::path>>("--definitions");
+    auto definitionsFiles = processDefinitionsFilePaths(program);
     auto documentationFiles = program.get<std::vector<std::filesystem::path>>("--docs");
     std::optional<std::filesystem::path> baseLuaurc = program.present<std::filesystem::path>("--base-luaurc");
 
@@ -187,8 +187,7 @@ int main(int argc, char** argv)
         .metavar("PATH");
     analyze_command.add_argument("--definitions", "--defs")
         .help("A path to a Luau definitions file to load into the global namespace")
-        .action(file_path_parser)
-        .default_value<std::vector<std::filesystem::path>>({})
+        .default_value<std::vector<std::string>>({})
         .append()
         .metavar("PATH");
     analyze_command.add_argument("--ignore")
@@ -211,8 +210,7 @@ int main(int argc, char** argv)
     lsp_command.add_parents(parent_parser);
     lsp_command.add_argument("--definitions")
         .help("path to a Luau definitions file to load into the global namespace")
-        .action(file_path_parser)
-        .default_value<std::vector<std::filesystem::path>>({})
+        .default_value<std::vector<std::string>>({})
         .append()
         .metavar("PATH");
     lsp_command.add_argument("--docs", "--documentation")

--- a/tests/Definitions.test.cpp
+++ b/tests/Definitions.test.cpp
@@ -11,8 +11,8 @@ TEST_CASE("use_platform_metadata_from_first_registered_definitions_file")
     auto client = std::make_shared<Client>(Client{});
     auto workspace = WorkspaceFolder(client, "$TEST_WORKSPACE", Uri(), std::nullopt);
 
-    client->definitionsFiles.emplace_back("./tests/testdata/standard_definitions.d.luau");
-    client->definitionsFiles.emplace_back("./tests/testdata/extra_definitions_relying_on_mutations.d.luau");
+    client->definitionsFiles.emplace("@roblox", "./tests/testdata/standard_definitions.d.luau");
+    client->definitionsFiles.emplace("@roblox1", "./tests/testdata/extra_definitions_relying_on_mutations.d.luau");
 
     workspace.setupWithConfiguration(defaultTestClientConfiguration());
 
@@ -28,8 +28,8 @@ TEST_CASE("handles_definitions_files_relying_on_mutations")
     auto client = std::make_shared<Client>(Client{});
     auto workspace = WorkspaceFolder(client, "$TEST_WORKSPACE", Uri(), std::nullopt);
 
-    client->definitionsFiles.emplace_back("./tests/testdata/standard_definitions.d.luau");
-    client->definitionsFiles.emplace_back("./tests/testdata/extra_definitions_relying_on_mutations.d.luau");
+    client->definitionsFiles.emplace("@roblox", "./tests/testdata/standard_definitions.d.luau");
+    client->definitionsFiles.emplace("@roblox1", "./tests/testdata/extra_definitions_relying_on_mutations.d.luau");
 
     workspace.setupWithConfiguration(defaultTestClientConfiguration());
 
@@ -40,6 +40,34 @@ TEST_CASE("handles_definitions_files_relying_on_mutations")
 
     auto result = workspace.frontend.check("foo.luau");
     REQUIRE(result.errors.empty());
+}
+
+TEST_CASE("package_name_is_recorded_onto_the_loaded_types")
+{
+    auto client = std::make_shared<Client>(Client{});
+    auto workspace = WorkspaceFolder(client, "$TEST_WORKSPACE", Uri(), std::nullopt);
+
+    client->definitionsFiles.emplace("@example", "./tests/testdata/standard_definitions.d.luau");
+
+    workspace.setupWithConfiguration(defaultTestClientConfiguration());
+
+    auto document = newDocument(workspace, "foo.luau", R"(
+        local x: Instance
+    )");
+
+    auto result = workspace.frontend.check("foo.luau");
+    auto module = workspace.frontend.moduleResolver.getModule("foo.luau");
+    REQUIRE(module);
+
+    auto binding = module->getModuleScope()->linearSearchForBinding("x");
+    REQUIRE(binding);
+
+    auto ty = Luau::follow(binding->typeId);
+    CHECK_EQ(ty->documentationSymbol, "@example/globaltype/Instance");
+
+    auto ctv = Luau::get<Luau::ClassType>(ty);
+    REQUIRE(ctv);
+    CHECK_EQ(ctv->definitionModuleName, "@example");
 }
 
 TEST_SUITE_END();

--- a/tests/Diagnostics.test.cpp
+++ b/tests/Diagnostics.test.cpp
@@ -12,7 +12,7 @@ TEST_CASE_FIXTURE(Fixture, "document_diagnostics_sends_information_for_required_
     client->capabilities.textDocument->diagnostic->relatedDocumentSupport = true;
 
     // Don't show diagnostic for game indexing
-    loadDefinition("declare game: any");
+    loadDefinition("@extra", "declare game: any");
 
     registerDocumentForVirtualPath(newDocument("required.luau", R"(
         --!strict
@@ -36,7 +36,7 @@ TEST_CASE_FIXTURE(Fixture, "document_diagnostics_does_not_send_information_for_r
     client->capabilities.textDocument->diagnostic->relatedDocumentSupport = false;
 
     // Don't show diagnostic for game indexing
-    loadDefinition("declare game: any");
+    loadDefinition("@extra", "declare game: any");
 
     registerDocumentForVirtualPath(newDocument("required.luau", R"(
         --!strict

--- a/tests/Fixture.cpp
+++ b/tests/Fixture.cpp
@@ -36,7 +36,7 @@ Fixture::Fixture()
     , workspace(client, "$TEST_WORKSPACE", Uri::file(std::filesystem::current_path()), std::nullopt)
 {
     workspace.fileResolver.defaultConfig.mode = Luau::Mode::Strict;
-    client->definitionsFiles.push_back("./tests/testdata/standard_definitions.d.luau");
+    client->definitionsFiles.emplace("@roblox", "./tests/testdata/standard_definitions.d.luau");
     workspace.setupWithConfiguration(Luau::LanguageServer::defaultTestClientConfiguration());
 
     Luau::setPrintLine([](auto s) {});
@@ -145,7 +145,7 @@ Luau::TypeId Fixture::requireType(Luau::ModulePtr module, const std::string& nam
     return Luau::follow(*ty);
 }
 
-Luau::LoadDefinitionFileResult Fixture::loadDefinition(const std::string& source, bool forAutocomplete)
+Luau::LoadDefinitionFileResult Fixture::loadDefinition(const std::string& packageName, const std::string& source, bool forAutocomplete)
 {
     RobloxPlatform platform;
 
@@ -153,7 +153,7 @@ Luau::LoadDefinitionFileResult Fixture::loadDefinition(const std::string& source
     auto& globals = forAutocomplete ? workspace.frontend.globalsForAutocomplete : workspace.frontend.globals;
 
     Luau::unfreeze(globals.globalTypes);
-    Luau::LoadDefinitionFileResult result = types::registerDefinitions(workspace.frontend, globals, source);
+    Luau::LoadDefinitionFileResult result = types::registerDefinitions(workspace.frontend, globals, packageName, source);
     platform.mutateRegisteredDefinitions(globals, std::nullopt);
     Luau::freeze(globals.globalTypes);
 

--- a/tests/Fixture.h
+++ b/tests/Fixture.h
@@ -42,7 +42,7 @@ struct Fixture
     void registerDocumentForVirtualPath(const Uri& uri, const Luau::ModuleName& virtualPath);
 
     Luau::AstStatBlock* parse(const std::string& source, const Luau::ParseOptions& parseOptions = {});
-    Luau::LoadDefinitionFileResult loadDefinition(const std::string& source, bool forAutocomplete = false);
+    Luau::LoadDefinitionFileResult loadDefinition(const std::string& packageName, const std::string& source, bool forAutocomplete = false);
     void loadSourcemap(const std::string& source);
     void loadLuaurc(const std::string& source);
     SourceNodePtr getRootSourceNode();


### PR DESCRIPTION
Makes way for supporting intellisense and documentation comment look up for definitions files

Part of #271 

Supersedes #518