### PR TITLE
Make `Sound.SoundGroup` optional

### DIFF
--- a/scripts/dumpRobloxTypes.py
+++ b/scripts/dumpRobloxTypes.py
@@ -341,6 +341,9 @@ EXTRA_MEMBERS = {
     "ControllerPartSensor": [
         "SensedPart: BasePart?",
     ],
+    "Sound": [
+        "SoundGroup: SoundGroup?",
+    ],
 }
 
 # Hardcoded types

--- a/scripts/globalTypes.LocalUserSecurity.d.luau
+++ b/scripts/globalTypes.LocalUserSecurity.d.luau
@@ -9306,7 +9306,7 @@ declare class Sound extends Instance
 	RollOffMaxDistance: number
 	RollOffMinDistance: number
 	RollOffMode: EnumRollOffMode
-	SoundGroup: SoundGroup
+	SoundGroup: SoundGroup?
 	SoundId: ContentId
 	Stopped: RBXScriptSignal<string>
 	TimeLength: number

--- a/scripts/globalTypes.None.d.luau
+++ b/scripts/globalTypes.None.d.luau
@@ -9252,7 +9252,7 @@ declare class Sound extends Instance
 	RollOffMaxDistance: number
 	RollOffMinDistance: number
 	RollOffMode: EnumRollOffMode
-	SoundGroup: SoundGroup
+	SoundGroup: SoundGroup?
 	SoundId: ContentId
 	Stopped: RBXScriptSignal<string>
 	TimeLength: number

--- a/scripts/globalTypes.PluginSecurity.d.luau
+++ b/scripts/globalTypes.PluginSecurity.d.luau
@@ -9495,7 +9495,7 @@ declare class Sound extends Instance
 	RollOffMaxDistance: number
 	RollOffMinDistance: number
 	RollOffMode: EnumRollOffMode
-	SoundGroup: SoundGroup
+	SoundGroup: SoundGroup?
 	SoundId: ContentId
 	Stopped: RBXScriptSignal<string>
 	TimeLength: number

--- a/scripts/globalTypes.RobloxScriptSecurity.d.luau
+++ b/scripts/globalTypes.RobloxScriptSecurity.d.luau
@@ -10681,7 +10681,7 @@ declare class Sound extends Instance
 	RollOffMaxDistance: number
 	RollOffMinDistance: number
 	RollOffMode: EnumRollOffMode
-	SoundGroup: SoundGroup
+	SoundGroup: SoundGroup?
 	SoundId: ContentId
 	Stopped: RBXScriptSignal<string>
 	TimeLength: number

--- a/scripts/globalTypes.d.lua
+++ b/scripts/globalTypes.d.lua
@@ -10681,7 +10681,7 @@ declare class Sound extends Instance
 	RollOffMaxDistance: number
 	RollOffMinDistance: number
 	RollOffMode: EnumRollOffMode
-	SoundGroup: SoundGroup
+	SoundGroup: SoundGroup?
 	SoundId: ContentId
 	Stopped: RBXScriptSignal<string>
 	TimeLength: number

--- a/scripts/globalTypes.d.luau
+++ b/scripts/globalTypes.d.luau
@@ -10681,7 +10681,7 @@ declare class Sound extends Instance
 	RollOffMaxDistance: number
 	RollOffMinDistance: number
 	RollOffMode: EnumRollOffMode
-	SoundGroup: SoundGroup
+	SoundGroup: SoundGroup?
 	SoundId: ContentId
 	Stopped: RBXScriptSignal<string>
 	TimeLength: number


### PR DESCRIPTION
Not all sounds have a SoundGroup associated with them. I found out this flaw in one of my scripts I ported to Rojo and analysed in strict mode