### PR TITLE
Add server path configuration option to the VSCode extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Added configuration `luau-lsp.server.path` (default: `""`) which allows the use of locally installed `luau-lsp` binaries. ([#897](https://github.com/JohnnyMorganz/luau-lsp/pull/897))
+
 ### Changed
 
 - Sync to upstream Luau 0.659

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -151,6 +151,11 @@
           "scope": "window",
           "default": "off"
         },
+        "luau-lsp.server.path": {
+          "markdownDescription": "Path to the Luau LSP server binary. If not provided, uses the binary included in the extension.",
+          "type": "string",
+          "default": ""
+        },
         "luau-lsp.ignoreGlobs": {
           "markdownDescription": "Diagnostics will not be reported for any file matching these globs unless the file is currently open",
           "type": "array",

--- a/editors/code/src/extension.ts
+++ b/editors/code/src/extension.ts
@@ -181,11 +181,27 @@ const startLanguageServer = async (context: vscode.ExtensionContext) => {
     }
   }
 
-  const serverBinPath = vscode.Uri.joinPath(
-    context.extensionUri,
-    "bin",
-    os.platform() === "win32" ? "server.exe" : "server",
-  ).fsPath;
+  const serverBinConfig = vscode.workspace
+    .getConfiguration("luau-lsp.server")
+    .get("path", "");
+
+  const uri = vscode.Uri.file(serverBinConfig);
+  let serverBinPath;
+
+  if (await utils.exists(uri)) {
+    serverBinPath = uri.fsPath;
+  } else {
+    if (serverBinConfig !== "") {
+      vscode.window.showWarningMessage(
+        `Server binary at path \`${serverBinConfig}\` does not exist, falling back to bundled binary`,
+      );
+    }
+    serverBinPath = vscode.Uri.joinPath(
+      context.extensionUri,
+      "bin",
+      os.platform() === "win32" ? "server.exe" : "server",
+    ).fsPath;
+  }
 
   const run: Executable = {
     command: serverBinPath,


### PR DESCRIPTION
This PR adds a configuration value (`luau-lsp.serverPath`) to the VSCode extension that lets you change the path of the Luau LSP server binary. This is useful for platforms like NixOS, where the included binary doesn't work by default. This hasn't been tested yet.