### PR TITLE
fix: return value in Roblox platform notification handler

### DIFF
--- a/src/LanguageServer.cpp
+++ b/src/LanguageServer.cpp
@@ -339,13 +339,15 @@ void LanguageServer::onNotification(const std::string& method, std::optional<jso
     }
     else
     {
+        bool handled = false;
         for (auto& workspace : workspaceFolders)
         {
             if (workspace->platform && workspace->platform->handleNotification(method, params))
-                return;
+                handled = true;
         }
 
-        client->sendLogMessage(lsp::MessageType::Warning, "unknown notification method: " + method);
+        if (!handled)
+            client->sendLogMessage(lsp::MessageType::Warning, "unknown notification method: " + method);
     }
 }
 

--- a/src/platform/roblox/RobloxStudioPlugin.cpp
+++ b/src/platform/roblox/RobloxStudioPlugin.cpp
@@ -30,10 +30,12 @@ bool RobloxPlatform::handleNotification(const std::string& method, std::optional
     if (method == "$/plugin/full")
     {
         onStudioPluginFullChange(JSON_REQUIRED_PARAMS(params, "$/plugin/full"));
+        return true;
     }
     else if (method == "$/plugin/clear")
     {
         onStudioPluginClear();
+        return true;
     }
 
     return false;


### PR DESCRIPTION
https://github.com/JohnnyMorganz/luau-lsp/blob/a82ebc1823fa74fa358c8401ff2c7adcf0ea7aa7/src/LanguageServer.cpp#L342-L348
We don't return `true` so we still hit "unknown notification method" even if handled