### PR TITLE
Introduce support for Luau's fragment-based autocomplete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Auto-import require path information is added in `CompletionItem.labelDetails.description` as well as just in
   `CompletionItem.detail`
 - In VSCode, the opening brace `{` character will be automatically closed with a `}` character when completed within an interpolated string. This occurs when the `{` character is typed just before whitespace or a `` ` `` character ([#916](https://github.com/JohnnyMorganz/luau-lsp/issues/916)).
+- Added support for Luau's fragment autocomplete system. This can be enabled by configuring `luau-lsp.completion.enableFragmentAutocomplete` (default: `false`). This incremental system can lead to performance improvements when autocompleting.
 
 ### Changed
 

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -501,6 +501,12 @@
           ],
           "scope": "resource"
         },
+        "luau-lsp.completion.enableFragmentAutocomplete": {
+          "markdownDescription": "Enables the experimental fragment autocomplete system for performance improvements",
+          "type": "boolean",
+          "default": false,
+          "scope": "resource"
+        },
         "luau-lsp.signatureHelp.enabled": {
           "markdownDescription": "Enable signature help",
           "type": "boolean",

--- a/editors/code/src/extension.ts
+++ b/editors/code/src/extension.ts
@@ -162,6 +162,21 @@ const startLanguageServer = async (context: vscode.ExtensionContext) => {
     fflags["LuauNewSolverPrePopulateClasses"] = "true";
   }
 
+  if (
+    vscode.workspace
+      .getConfiguration("luau-lsp.completion")
+      .get<boolean>("enableFragmentAutocomplete")
+  ) {
+    fflags["LuauAllowFragmentParsing"] = "true";
+    fflags["LuauAutocompleteRefactorsForIncrementalAutocomplete"] = "true";
+    fflags["LuauStoreSolverTypeOnModule"] = "true";
+    fflags["LuauSymbolEquality"] = "true";
+    fflags["LexerResumesFromPosition2"] = "true";
+    fflags["LuauReferenceAllocatorInNewSolver"] = "true";
+    fflags["LuauIncrementalAutocompleteBugfixes"] = "true";
+    fflags["LuauBetterReverseDependencyTracking"] = "true";
+  }
+
   // Handle overrides
   const overridenFFlags = fflagsConfig.get<FFlags>("override");
   if (overridenFFlags) {
@@ -278,7 +293,10 @@ export async function activate(context: vscode.ExtensionContext) {
 
   context.subscriptions.push(
     vscode.workspace.onDidChangeConfiguration((e) => {
-      if (e.affectsConfiguration("luau-lsp.fflags")) {
+      if (
+        e.affectsConfiguration("luau-lsp.fflags") ||
+        e.affectsConfiguration("luau-lsp.completion.enableFragmentAutocomplete")
+      ) {
         vscode.window
           .showInformationMessage(
             "Luau FFlags have been changed, reload server for this to take effect.",

--- a/src/include/LSP/ClientConfiguration.hpp
+++ b/src/include/LSP/ClientConfiguration.hpp
@@ -137,10 +137,12 @@ struct ClientCompletionConfiguration
     bool fillCallArguments = true;
     /// Whether to show non-function properties when performing a method call with a colon
     bool showPropertiesOnMethodCall = false;
+    /// Enables the experimental fragment autocomplete system for performance improvements
+    bool enableFragmentAutocomplete = false;
 };
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(ClientCompletionConfiguration, enabled, autocompleteEnd, suggestImports, imports, addParentheses,
-    addTabstopAfterParentheses, fillCallArguments, showPropertiesOnMethodCall);
+    addTabstopAfterParentheses, fillCallArguments, showPropertiesOnMethodCall, enableFragmentAutocomplete);
 
 struct ClientSignatureHelpConfiguration
 {

--- a/src/include/LSP/Workspace.hpp
+++ b/src/include/LSP/Workspace.hpp
@@ -96,7 +96,7 @@ public:
     std::vector<std::string> getComments(const Luau::ModuleName& moduleName, const Luau::Location& node);
     std::optional<std::string> getDocumentationForType(const Luau::TypeId ty);
     std::optional<std::string> getDocumentationForAutocompleteEntry(const std::string& name, const Luau::AutocompleteEntry& entry,
-        const std::vector<Luau::AstNode*>& ancestry, const Luau::ModuleName& moduleName);
+        const std::vector<Luau::AstNode*>& ancestry, const Luau::ModulePtr& localModule);
     std::vector<Reference> findAllTableReferences(const Luau::TypeId ty, std::optional<Luau::Name> property = std::nullopt);
     std::vector<Reference> findAllFunctionReferences(const Luau::TypeId ty);
     std::vector<Reference> findAllTypeReferences(const Luau::ModuleName& moduleName, const Luau::Name& typeName);

--- a/src/operations/Completion.cpp
+++ b/src/operations/Completion.cpp
@@ -435,8 +435,8 @@ std::vector<lsp::CompletionItem> WorkspaceFolder::completion(const lsp::Completi
         else
             frontendOptions.forAutocomplete = true;
 
-        // NOTE: although we don't use fragment result directly, it is important to keep it in scope
-        // otherwise the incremental module may de-allocate leading to a use-after-free when accessing the result ancestry
+        // It is important to keep the fragmentResult in scope for the whole completion step
+        // Otherwise the incremental module may de-allocate leading to a use-after-free when accessing the result ancestry
         fragmentResult = Luau::fragmentAutocomplete(frontend, textDocument->getText(), moduleName, position, frontendOptions,
             [&](const std::string& tag, std::optional<const Luau::ClassType*> ctx,
                 std::optional<std::string> contents) -> std::optional<Luau::AutocompleteEntryMap>

--- a/src/operations/Completion.cpp
+++ b/src/operations/Completion.cpp
@@ -3,6 +3,7 @@
 
 #include "Luau/AstQuery.h"
 #include "Luau/Autocomplete.h"
+#include "Luau/FragmentAutocomplete.h"
 #include "Luau/TxnLog.h"
 #include "Luau/TypeUtils.h"
 #include "Luau/TimeTrace.h"
@@ -424,13 +425,37 @@ std::vector<lsp::CompletionItem> WorkspaceFolder::completion(const lsp::Completi
     checkStrict(moduleName, /* forAutocomplete: */ true);
 
     auto position = textDocument->convertPosition(params.position);
-    auto result = Luau::autocomplete(frontend, moduleName, position,
-        [&](const std::string& tag, std::optional<const Luau::ClassType*> ctx,
-            std::optional<std::string> contents) -> std::optional<Luau::AutocompleteEntryMap>
-        {
-            tags.insert(tag);
-            return platform->completionCallback(tag, ctx, std::move(contents), moduleName);
-        });
+
+    Luau::FragmentAutocompleteResult fragmentResult;
+    Luau::AutocompleteResult result;
+    if (config.completion.enableFragmentAutocomplete)
+    {
+        Luau::FrontendOptions frontendOptions;
+        frontendOptions.retainFullTypeGraphs = true;
+        if (FFlag::LuauSolverV2)
+            frontendOptions.runLintChecks = true;
+        else
+            frontendOptions.forAutocomplete = true;
+
+        // NOTE: although we don't use fragment result directly, it is important to keep it in scope
+        // otherwise the incremental module may de-allocate leading to a use-after-free when accessing the result ancestry
+        fragmentResult = Luau::fragmentAutocomplete(frontend, textDocument->getText(), moduleName, position, frontendOptions,
+            [&](const std::string& tag, std::optional<const Luau::ClassType*> ctx,
+                std::optional<std::string> contents) -> std::optional<Luau::AutocompleteEntryMap>
+            {
+                tags.insert(tag);
+                return platform->completionCallback(tag, ctx, std::move(contents), moduleName);
+            });
+        result = fragmentResult.acResults;
+    }
+    else
+        result = Luau::autocomplete(frontend, moduleName, position,
+            [&](const std::string& tag, std::optional<const Luau::ClassType*> ctx,
+                std::optional<std::string> contents) -> std::optional<Luau::AutocompleteEntryMap>
+            {
+                tags.insert(tag);
+                return platform->completionCallback(tag, ctx, std::move(contents), moduleName);
+            });
 
 
     std::vector<lsp::CompletionItem> items{};


### PR DESCRIPTION
Fragment based autocomplete is an optimisation to the autocomplete system that reuses previous typechecking data for a module and applies patches on top based on the code changes. This allows Luau to update the type representation of a module without having to recheck the whole module from scratch, leading to a performance improvement for autocompletion.

This PR enables fragment autocompletion for luau-lsp. This is currently gated behind the `luau-lsp.completion.enableFragmentAutocomplete` setting.

Closes #825 