### PR TITLE
Set PluginToolbarButton ClickableWhenViewportHidden to true

### DIFF
--- a/plugin/src/init.server.lua
+++ b/plugin/src/init.server.lua
@@ -15,8 +15,12 @@ local ConnectButton = toolbar:CreateButton(
 	"Luau Language Server"
 ) :: PluginToolbarButton
 
+ConnectButton.ClickableWhenViewportHidden = true
+
 local SettingsButton =
 	toolbar:CreateButton("Settings", "Open Settings", "rbxassetid://13997395868") :: PluginToolbarButton
+
+SettingsButton.ClickableWhenViewportHidden = true
 
 --#region Settings
 


### PR DESCRIPTION
made both PluginToolbarButton ClickableWhenViewportHidden = true

Currently when I'm editing Plugin Settings and want to reconnect I'd have to exit out of the Script which is annoying if I want to try re-connecting

I don't see a reason why ClickableWhenViewportHidden should be kept as false

![image](https://github.com/user-attachments/assets/db630e18-8ad0-4812-ba87-bcc700adcd25)
