### PR TITLE
Set minimum macOS version to 10.15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
     branches:
       - main
 
+env:
+  MACOSX_DEPLOYMENT_TARGET: "10.13"
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
       - main
 
 env:
-  MACOSX_DEPLOYMENT_TARGET: "10.13"
+  MACOSX_DEPLOYMENT_TARGET: "10.15"
 
 jobs:
   build:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: "0 0 * * *" # Runs at 00:00 UTC every day
 
+env:
+  MACOSX_DEPLOYMENT_TARGET: "10.13"
+
 jobs:
   dist:
     strategy:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,7 +6,7 @@ on:
     - cron: "0 0 * * *" # Runs at 00:00 UTC every day
 
 env:
-  MACOSX_DEPLOYMENT_TARGET: "10.13"
+  MACOSX_DEPLOYMENT_TARGET: "10.15"
 
 jobs:
   dist:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags: ["*"]
   workflow_dispatch:
 
+env:
+  MACOSX_DEPLOYMENT_TARGET: "10.13"
+
 jobs:
   create-release:
     name: Create Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 env:
-  MACOSX_DEPLOYMENT_TARGET: "10.13"
+  MACOSX_DEPLOYMENT_TARGET: "10.15"
 
 jobs:
   create-release:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Fixed unintended bump of minimum supported macOS version in 1.39.0 to macOS 14. The language server binary supports a minimum version of macOS 10.15
 - Single-line documentation comments (`---`) now correctly preserve newlines ([#917](https://github.com/JohnnyMorganz/luau-lsp/pull/917)).
 - Fixed stack-use-after-free crash in sourcemap definition magic functions when the new solver is
   enabled ([#928](https://github.com/JohnnyMorganz/luau-lsp/issues/928))


### PR DESCRIPTION
The latest release (1.39.1) caused an unintended bump in the minimum supported macOS version.

Let's make it explicit that we support macOS 10.15 onwards. 10.15 is the minimum version that supports the necessary APIs in use