### PR TITLE
Re-alias ContentId as string, remove Content alias.

### DIFF
--- a/scripts/dumpRobloxTypes.py
+++ b/scripts/dumpRobloxTypes.py
@@ -349,8 +349,7 @@ EXTRA_MEMBERS = {
 # Hardcoded types
 # These will go before anything else, and are useful to define for other tools
 START_BASE = """
-type Content = string
-type ContentId = any
+type ContentId = string
 type ProtectedString = string
 type BinaryString = string
 type QDir = string


### PR DESCRIPTION
`ContentId` is the new name for what was previously the `Content` type, before the actual Content type was introduced.
I can't auto-complete string methods on ContentId properties at the moment because of the `any` type. It should be `string`.