### PR TITLE
Enable HTML rendering in language client options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- Enabled HTML support by setting `supportHtml: true` in the language client options. ([#964](https://github.com/JohnnyMorganz/luau-lsp/pull/964))
+- Enabled HTML support by setting `supportHtml: true` in the language client options ([#964](https://github.com/JohnnyMorganz/luau-lsp/pull/964))
 - Documentation comments now attach to type alias definitions ([#956](https://github.com/JohnnyMorganz/luau-lsp/pull/956))
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Enabled HTML support by setting `supportHtml: true` in the language client options. ([#964](https://github.com/JohnnyMorganz/luau-lsp/pull/964))
 - Documentation comments now attach to type alias definitions ([#956](https://github.com/JohnnyMorganz/luau-lsp/pull/956))
 
 ### Changed

--- a/editors/code/src/extension.ts
+++ b/editors/code/src/extension.ts
@@ -249,6 +249,9 @@ const startLanguageServer = async (context: vscode.ExtensionContext) => {
     initializationOptions: {
       fflags,
     },
+    markdown: {
+      supportHtml: true,
+    },
   };
 
   client = new LanguageClient(

--- a/src/DocumentationParser.cpp
+++ b/src/DocumentationParser.cpp
@@ -14,28 +14,6 @@ Luau::FunctionParameterDocumentation parseDocumentationParameter(const json& j)
     return Luau::FunctionParameterDocumentation{name, documentation};
 }
 
-/// Converts an HTML string provided as an input to markdown
-/// TODO: currently, this just strips tags, rather than do anything special
-std::string convertHtmlToMarkdown(const std::string& input)
-{
-    // TODO - Tags to support:
-    // <code></code> - as well as <code class="language-lua">
-    // <pre></pre>
-    // <em></em> / <i></i>
-    // <ul><li></li></ul>
-    // <ol><li></li></ol>
-    // <a href=""></a>
-    // <strong></strong> / <b></b>
-    // <img alt="" src="" />
-    // Also need to unescape HTML characters
-
-
-    // Yes, regex is bad, but I really cannot be bothered right now
-    std::regex strip("<[^>]*>");
-    return std::regex_replace(input, strip, "");
-}
-
-
 void parseDocumentation(
     const std::vector<std::filesystem::path>& documentationFiles, Luau::DocumentationDatabase& database, const std::shared_ptr<Client>& client)
 {
@@ -64,9 +42,6 @@ void parseDocumentation(
                         info.at("learn_more_link").get_to(learnMoreLink);
                     if (info.contains("code_sample"))
                         info.at("code_sample").get_to(codeSample);
-
-                    documentation = convertHtmlToMarkdown(documentation);
-
                     if (info.contains("keys"))
                     {
                         Luau::DenseHashMap<std::string, Luau::DocumentationSymbol> keys{""};


### PR DESCRIPTION
This PR enables HTML support by adding `supportHtml: true` to the language client options and removing the `convertHtmlToMarkdown` function, which previously just removed the HTML tags from documentation.

I assume other language clients also support HTML (perhaps with a similar option that just needs to be toggled on?).