### PR TITLE
Fix JSON serialization of unordered map keyed by Uri

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed incorrect serialization of maps that are keyed by a Uri, causing commands that apply edits such as Rename to
+  fail
+
 ## [1.44.0] - 2025-04-24
 
 ### Removed

--- a/src/include/LSP/Uri.hpp
+++ b/src/include/LSP/Uri.hpp
@@ -100,3 +100,25 @@ struct UriHash
 
 void from_json(const json& j, Uri& u);
 void to_json(json& j, const Uri& u);
+
+namespace nlohmann
+{
+template<typename T>
+struct adl_serializer<std::unordered_map<Uri, T, UriHash>>
+{
+    static void to_json(json& j, const std::unordered_map<Uri, T, UriHash>& opt)
+    {
+        std::unordered_map<std::string, T> stringifiedKeys;
+        for (const auto& [k, v] : opt)
+            stringifiedKeys[k.toString()] = v;
+        j = stringifiedKeys;
+    }
+
+    static void from_json(const json& j, std::unordered_map<Uri, T, UriHash>& opt)
+    {
+        std::unordered_map<std::string, T> result = j;
+        for (const auto& [k, v] : result)
+            opt[Uri::parse(k)] = v;
+    }
+};
+} // namespace nlohmann

--- a/tests/Rename.test.cpp
+++ b/tests/Rename.test.cpp
@@ -428,4 +428,24 @@ TEST_CASE_FIXTURE(Fixture, "dont_rename_cross_module_usages_of_a_returned_table"
     CHECK_EQ(result->changes.begin()->second.size(), 2);
 }
 
+TEST_CASE_FIXTURE(Fixture, "response_json_is_valid_structure")
+{
+    auto uri = newDocument("tbl.luau", R"(
+        local value = 1
+    )");
+
+    lsp::RenameParams params;
+    params.textDocument = lsp::TextDocumentIdentifier{uri};
+    params.position = lsp::Position{1, 15}; // 'value' definition
+    params.newName = "value2";
+
+    auto result = workspace.rename(params);
+    REQUIRE(result);
+    REQUIRE_EQ(result->changes.size(), 1);
+
+    json response = result;
+    CHECK_EQ(response.dump(), R"({"changes":{")" + uri.toString() +
+                                  R"(":[{"newText":"value2","range":{"end":{"character":19,"line":1},"start":{"character":14,"line":1}}}]}})");
+}
+
 TEST_SUITE_END();


### PR DESCRIPTION
It turns out that if a key is not `std::string`, or not implicitly convertible to a string, then nlohmann will serialize the final `unordered_map` as an array of pairs: https://github.com/nlohmann/json/issues/2132

This caused the result of Rename and other workspace edits to be malformed when sent to VSCode, causing those commands to fail