### PR TITLE
Fix aliases not used for string require auto-imports on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `init.luau` files](https://rfcs.luau.org/abstract-module-paths-and-init-dot-luau.html) for file resolution and string
   require autocomplete ([#1023](https://github.com/JohnnyMorganz/luau-lsp/issues/1023))
 
+### Fixed
+
+- Fixed string-require auto imports not using aliases correctly on Windows ([#1025](https://github.com/JohnnyMorganz/luau-lsp/issues/1025))
+
 ## [1.44.1] - 2025-04-24
 
 ### Fixed

--- a/src/Uri.cpp
+++ b/src/Uri.cpp
@@ -449,6 +449,18 @@ std::string Uri::lexicallyRelative(const Uri& base) const
     return relative_path;
 }
 
+bool Uri::isAncestorOf(const Uri& other) const
+{
+    if (scheme != other.scheme || authority != other.authority)
+        return false;
+
+#if defined(_WIN32) || defined(__APPLE__)
+    return Luau::startsWith(toLower(other.path), toLower(path));
+#else
+    return Luau::startsWith(other.path, path);
+#endif
+}
+
 size_t UriHash::operator()(const Uri& uri) const
 {
     size_t hashValue = std::hash<std::string>()(uri.scheme);

--- a/src/include/LSP/Uri.hpp
+++ b/src/include/LSP/Uri.hpp
@@ -89,8 +89,12 @@ public:
 
     // Returns the parent path of this URI, if it exists
     std::optional<Uri> parent() const;
+
     // Returns a string path that is lexically relative to the other URI, similar to std::filesystem::path.lexically_relative()
     std::string lexicallyRelative(const Uri& base) const;
+
+    // Returns whether the current Uri is an ancestor of the other URI
+    bool isAncestorOf(const Uri& other) const;
 };
 
 struct UriHash

--- a/src/platform/StringRequireAutoImporter.cpp
+++ b/src/platform/StringRequireAutoImporter.cpp
@@ -20,18 +20,17 @@ std::optional<std::string> computeBestAliasedPath(const Uri& to, const AliasMap&
 {
     std::optional<std::string> bestAliasedPath = std::nullopt;
 
-    auto toComponents = Luau::split(to.path, '/');
-
     for (const auto& [aliasName, aliasInfo] : availableAliases)
     {
-        auto aliasLocation = resolveAliasLocation(aliasInfo).generic_string();
-        if (!Luau::startsWith(to.path, aliasLocation))
+        auto aliasLocation = Uri::file(resolveAliasLocation(aliasInfo));
+
+        if (!aliasLocation.isAncestorOf(to))
             continue;
 
-        auto remainder = removePrefix(to.path, aliasLocation);
+        auto remainder = to.lexicallyRelative(aliasLocation);
         auto aliasedPath = "@" + aliasInfo.originalCase;
-        if (!remainder.empty() && remainder != "/")
-            aliasedPath += remainder;
+        if (!remainder.empty() && remainder != ".")
+            aliasedPath += "/" + remainder;
 
         if (!bestAliasedPath || aliasedPath.size() < bestAliasedPath->size())
             bestAliasedPath = aliasedPath;
@@ -107,4 +106,4 @@ void suggestStringRequires(const StringRequireAutoImporterContext& ctx, std::vec
         items.emplace_back(createSuggestRequire(name, textEdits, sortText, moduleName, require));
     }
 }
-}
+} // namespace Luau::LanguageServer::AutoImports


### PR DESCRIPTION
The code that checks whether the full file path starts with the aliased value is incorrect on windows:
- `uri.path` contains a leading `/` (`/c:/Users/Development/...`)
- the drive letter can be of different case (`c:/` vs `C:/`)

We fix this by using Uris directly: we introduce a new `Uri::isAncestorOf(other)` method, and use `Uri::lexicallyRelative` for resolving the remainder path to add to the alias.

Fixes #1025 