### PR TITLE
Redefine RaycastResult to have generic type (with BasePart default)

### DIFF
--- a/scripts/dumpRobloxTypes.py
+++ b/scripts/dumpRobloxTypes.py
@@ -441,14 +441,6 @@ export type RBXScriptSignal<T... = ...any> = {
     Once: (self: RBXScriptSignal<T...>, callback: (T...) -> ()) -> RBXScriptConnection,
 }
 
-export type RaycastResult<T = BasePart> = {
-    Instance: T,
-    Position: Vector3,
-    Normal: Vector3,
-    Material: EnumMaterial,
-    Distance: number,
-}
-
 type HttpRequestOptions = {
     Url: string,
     Method: "GET" | "HEAD" | "POST" | "PUT" | "DELETE" | "CONNECT" | "OPTIONS" | "TRACE" | "PATCH" | nil,
@@ -477,6 +469,14 @@ type HumanoidDescriptionAccessory = {
 # More hardcoded types, but go at the end of the file
 # Useful if they rely on previously defined types
 END_BASE = """
+export type RaycastResult<T = BasePart> = {
+    Instance: T,
+    Position: Vector3,
+    Normal: Vector3,
+    Material: EnumMaterial,
+    Distance: number,
+}
+
 declare class GlobalSettings extends GenericSettings
     Lua: LuaSettings
     Game: GameSettings


### PR DESCRIPTION
This is a correctly redone attempt to do what I attempted last year. I've tested it in my own environment and can confirm it works as intended.

The only side effect I've observed is that it breaks type refinement for `typeof(RaycastResult)`, but I reckon this might be acceptable since a similar change was made to `RBXScriptSignal`, and even Roblox Studio defines the type as a dictionary. In an ideal world, class declarations would support generics... but this'll have to do for now.