### PR TITLE
Add FromValue and FromName Methods to Enum

### DIFF
--- a/scripts/dumpRobloxTypes.py
+++ b/scripts/dumpRobloxTypes.py
@@ -366,6 +366,8 @@ type AdReward = any
 
 declare class Enum
     function GetEnumItems(self): { any }
+    function FromValue(self,Number: number): any
+    function FromName(self,Name: string): any
 end
 
 declare class EnumItem


### PR DESCRIPTION
This PR adds FromValue and FromName Methods to Enum.

Return type is `any` since we can't return the actual enum (`Enum.AssetType:FromValue()` returns `Enum.Assettype?` in studio)