### PR TITLE
feat: add server info to lsp initialize results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Added `ServerInfo` to the `LanguageServer::onInitialize` result.
+
 ## [1.49.1] - 2025-06-09
 
 ### Changed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,11 @@ option(LSP_BUILD_ASAN "Build with ASAN" OFF)
 option(LSP_STATIC_CRT "Link with the static CRT (/MT)" OFF)
 option(LSP_BUILD_WITH_SENTRY "Build with Sentry (crash reporting)" OFF)
 
+set(LSP_VERSION "1.49.1")
+set(LSP_NAME "Luau Language Server")
+add_definitions(-DLSP_VERSION="${LSP_VERSION}")
+add_definitions(-DLSP_NAME="${LSP_NAME}")
+
 if (LSP_STATIC_CRT)
     cmake_policy(SET CMP0091 NEW)
     set(LUAU_STATIC_CRT ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ option(LSP_STATIC_CRT "Link with the static CRT (/MT)" OFF)
 option(LSP_BUILD_WITH_SENTRY "Build with Sentry (crash reporting)" OFF)
 
 set(LSP_VERSION "1.49.1")
-set(LSP_NAME "Luau Language Server")
+set(LSP_NAME "Luau")
 add_definitions(-DLSP_VERSION="${LSP_VERSION}")
 add_definitions(-DLSP_NAME="${LSP_NAME}")
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -8,7 +8,7 @@ import subprocess
 from datetime import datetime
 
 CHANGELOG_FILE = "CHANGELOG.md"
-MAIN_CPP_FILE = "src/main.cpp"
+MAKE_FILE = "CMakeLists.txt"
 PACKAGE_JSON_FILE = "editors/code/package.json"
 PACKAGE_LOCK_JSON_FILE = "editors/code/package-lock.json"
 
@@ -33,21 +33,17 @@ with open(CHANGELOG_FILE, "w") as file:
     file.writelines(new_changelog_lines)
 
 # Update version in main.cpp
-new_main_cpp_lines: list[str] = []
-with open(MAIN_CPP_FILE, "r") as file:
-    lines = file.readlines()
-
-    for line in lines:
-        if line.strip().startswith("#define LSP_VERSION "):
-            new_line = (
-                line[0 : line.find(line.strip())] + f'#define LSP_VERSION "{VERSION}"\n'
-            )
-            new_main_cpp_lines.append(new_line)
+new_make_file_lines: list[str] = []
+with open(MAKE_FILE, "r") as file:
+    for line in file:
+        if line.startswith("set(LSP_VERSION"):
+            new_line = f"set(LSP_VERSION \"{VERSION}\")\n"
+            new_make_file_lines.append(new_line)
         else:
-            new_main_cpp_lines.append(line)
+            new_make_file_lines.append(line)
 
-with open(MAIN_CPP_FILE, "w") as file:
-    file.writelines(new_main_cpp_lines)
+with open(MAKE_FILE, "w") as file:
+    file.writelines(new_make_file_lines)
 
 # Update version in package.json
 package_json_data = None
@@ -72,7 +68,7 @@ subprocess.run(
         "git",
         "add",
         CHANGELOG_FILE,
-        MAIN_CPP_FILE,
+        MAKE_FILE,
         PACKAGE_JSON_FILE,
         PACKAGE_LOCK_JSON_FILE,
     ],

--- a/src/LanguageServer.cpp
+++ b/src/LanguageServer.cpp
@@ -532,10 +532,7 @@ lsp::InitializeResult LanguageServer::onInitialize(const lsp::InitializeParams& 
     isInitialized = true;
     lsp::InitializeResult result;
     result.capabilities = getServerCapabilities();
-    result.serverInfo = lsp::InitializeResult::ServerInfo{
-        .name = LSP_NAME,
-        .version = LSP_VERSION,
-    };
+    result.serverInfo = lsp::InitializeResult::ServerInfo{LSP_NAME, LSP_VERSION};
 
     // Position Encoding
     if (client->capabilities.general && client->capabilities.general->positionEncodings &&

--- a/src/LanguageServer.cpp
+++ b/src/LanguageServer.cpp
@@ -532,6 +532,10 @@ lsp::InitializeResult LanguageServer::onInitialize(const lsp::InitializeParams& 
     isInitialized = true;
     lsp::InitializeResult result;
     result.capabilities = getServerCapabilities();
+    result.serverInfo = lsp::InitializeResult::ServerInfo{
+        .name = LSP_NAME,
+        .version = LSP_VERSION,
+    };
 
     // Position Encoding
     if (client->capabilities.general && client->capabilities.general->positionEncodings &&

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -26,8 +26,6 @@
 #include <sentry.h>
 #endif
 
-#define LSP_VERSION "1.49.1"
-
 static void displayFlags()
 {
     printf("Available flags:\n");


### PR DESCRIPTION
Adds information about LSP to the initialization result, so it can be used by lsp integrations (e.g. JB IDE plugin)