### PR TITLE
Remove shared_ptr where possible

### DIFF
--- a/src/AnalyzeCli.cpp
+++ b/src/AnalyzeCli.cpp
@@ -7,7 +7,6 @@
 #include "LSP/ClientConfiguration.hpp"
 #include "Platform/LSPPlatform.hpp"
 #include "Platform/RobloxPlatform.hpp"
-#include "Luau/ModuleResolver.h"
 #include "Luau/BuiltinDefinitions.h"
 #include "Luau/Frontend.h"
 #include "Luau/TypeAttach.h"
@@ -295,7 +294,7 @@ int startAnalyze(const argparse::ArgumentParser& program)
     }
 
     fileResolver.rootUri = Uri::file(*currentWorkingDirectory);
-    fileResolver.client = std::make_shared<CliClient>(client);
+    fileResolver.client = &client;
 
     if (auto platformArg = program.present("--platform"))
     {

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -118,7 +118,7 @@ void Client::sendWorkDoneProgressEnd(const lsp::ProgressToken& token, std::optio
     sendProgress(lsp::ProgressParams{token, workDone});
 }
 
-void Client::sendLogMessage(const lsp::MessageType& type, const std::string& message)
+void Client::sendLogMessage(const lsp::MessageType& type, const std::string& message) const
 {
     json params{
         {"type", type},
@@ -137,7 +137,7 @@ void Client::sendTrace(const std::string& message, const std::optional<std::stri
     sendNotification("$/logTrace", params);
 }
 
-void Client::sendWindowMessage(const lsp::MessageType& type, const std::string& message)
+void Client::sendWindowMessage(const lsp::MessageType& type, const std::string& message) const
 {
     lsp::ShowMessageParams params{type, message};
     sendNotification("window/showMessage", params);

--- a/src/DocumentationParser.cpp
+++ b/src/DocumentationParser.cpp
@@ -15,8 +15,7 @@ Luau::FunctionParameterDocumentation parseDocumentationParameter(const json& j)
     return Luau::FunctionParameterDocumentation{name, documentation};
 }
 
-void parseDocumentation(
-    const std::vector<std::string>& documentationFiles, Luau::DocumentationDatabase& database, const std::shared_ptr<Client>& client)
+void parseDocumentation(const std::vector<std::string>& documentationFiles, Luau::DocumentationDatabase& database, const Client* client)
 {
     if (documentationFiles.empty())
     {

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -24,7 +24,7 @@ std::optional<std::string> getParentPath(const std::string& path)
 
 /// Returns a path at the ancestor point.
 /// i.e., for game/ReplicatedStorage/Module/Child/Foo, and ancestor == Module, returns game/ReplicatedStorage/Module
-std::optional<std::string> getAncestorPath(const std::string& path, const std::string& ancestorName, const SourceNodePtr& rootSourceNode)
+std::optional<std::string> getAncestorPath(const std::string& path, const std::string& ancestorName, const SourceNode* rootSourceNode)
 {
     // We want to remove the child from the path name in case the ancestor has the same name as the child
     auto parentPath = getParentPath(path);

--- a/src/Workspace.cpp
+++ b/src/Workspace.cpp
@@ -32,7 +32,7 @@ void WorkspaceFolder::openTextDocument(const lsp::DocumentUri& uri, const lsp::D
     frontend.markDirty(moduleName);
 }
 
-static bool isWorkspaceDiagnosticsEnabled(const ClientPtr& client, const ClientConfiguration& config)
+static bool isWorkspaceDiagnosticsEnabled(const Client* client, const ClientConfiguration& config)
 {
     return client->workspaceDiagnosticsToken && config.diagnostics.workspace;
 }
@@ -375,7 +375,7 @@ void WorkspaceFolder::indexFiles(const ClientConfiguration& config)
     client->sendTrace("workspace: indexing all files COMPLETED");
 }
 
-static void clearDisabledGlobals(const ClientPtr client, const Luau::GlobalTypes& globalTypes, const std::vector<std::string>& disabledGlobals)
+static void clearDisabledGlobals(const Client* client, const Luau::GlobalTypes& globalTypes, const std::vector<std::string>& disabledGlobals)
 {
     const auto targetScope = globalTypes.globalScope;
     for (const auto& disabledGlobal : disabledGlobals)

--- a/src/include/LSP/Client.hpp
+++ b/src/include/LSP/Client.hpp
@@ -74,9 +74,9 @@ public:
         const lsp::ProgressToken& token, std::optional<std::string> message = std::nullopt, std::optional<uint8_t> percentage = std::nullopt);
     void sendWorkDoneProgressEnd(const lsp::ProgressToken& token, std::optional<std::string> message = std::nullopt);
 
-    void sendLogMessage(const lsp::MessageType& type, const std::string& message);
+    void sendLogMessage(const lsp::MessageType& type, const std::string& message) const;
     void sendTrace(const std::string& message, const std::optional<std::string>& verbose = std::nullopt) const;
-    void sendWindowMessage(const lsp::MessageType& type, const std::string& message);
+    void sendWindowMessage(const lsp::MessageType& type, const std::string& message) const;
 
     void registerCapability(const std::string& registrationId, const std::string& method, const json& registerOptions);
     void unregisterCapability(const std::string& registrationId, const std::string& method);

--- a/src/include/LSP/DocumentationParser.hpp
+++ b/src/include/LSP/DocumentationParser.hpp
@@ -15,8 +15,7 @@ using json = nlohmann::json;
 const std::string kDocumentationBreaker = "\n----------\n";
 
 Luau::FunctionParameterDocumentation parseDocumentationParameter(const json& j);
-void parseDocumentation(
-    const std::vector<std::string>& documentationFiles, Luau::DocumentationDatabase& database, const std::shared_ptr<Client>& client);
+void parseDocumentation(const std::vector<std::string>& documentationFiles, Luau::DocumentationDatabase& database, const Client* client);
 
 /// Returns a markdown string of the provided documentation
 /// If we can't find any documentation for the given symbol, then we return nullopt

--- a/src/include/LSP/Utils.hpp
+++ b/src/include/LSP/Utils.hpp
@@ -8,11 +8,10 @@
 #include <memory>
 #include <algorithm>
 
-// TODO: must duplicate using to avoid cyclical includes
-using SourceNodePtr = std::shared_ptr<struct SourceNode>;
+struct SourceNode;
 
 std::optional<std::string> getParentPath(const std::string& path);
-std::optional<std::string> getAncestorPath(const std::string& path, const std::string& ancestorName, const SourceNodePtr& rootSourceNode);
+std::optional<std::string> getAncestorPath(const std::string& path, const std::string& ancestorName, const SourceNode* rootSourceNode);
 std::string convertToScriptPath(std::string path);
 std::string codeBlock(const std::string& language, const std::string& code);
 std::optional<std::string> getHomeDirectory();

--- a/src/include/LSP/Workspace.hpp
+++ b/src/include/LSP/Workspace.hpp
@@ -27,7 +27,7 @@ struct Reference
 class WorkspaceFolder
 {
 public:
-    std::shared_ptr<Client> client;
+    Client* client;
     std::unique_ptr<LSPPlatform> platform;
     std::string name;
     lsp::DocumentUri rootUri;
@@ -49,7 +49,7 @@ public:
     bool isReady = false;
 
 public:
-    WorkspaceFolder(const std::shared_ptr<Client>& client, std::string name, const lsp::DocumentUri& uri, std::optional<Luau::Config> defaultConfig)
+    WorkspaceFolder(Client* client, std::string name, const lsp::DocumentUri& uri, std::optional<Luau::Config> defaultConfig)
         : client(client)
         , name(std::move(name))
         , rootUri(uri)
@@ -60,7 +60,7 @@ public:
         , frontend(Luau::Frontend(
               &fileResolver, &fileResolver, {/* retainFullTypeGraphs: */ true, /* forAutocomplete: */ false, /* runLintChecks: */ true}))
     {
-        fileResolver.client = std::static_pointer_cast<BaseClient>(client);
+        fileResolver.client = client;
         fileResolver.rootUri = uri;
     }
 

--- a/src/include/LSP/WorkspaceFileResolver.hpp
+++ b/src/include/LSP/WorkspaceFileResolver.hpp
@@ -81,7 +81,7 @@ private:
 
 public:
     Luau::Config defaultConfig;
-    std::shared_ptr<BaseClient> client;
+    BaseClient* client;
     Uri rootUri;
 
     LSPPlatform* platform = nullptr;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -131,16 +131,16 @@ int startLanguageServer(const argparse::ArgumentParser& program)
         transport = std::make_unique<StdioTransport>();
     }
 
-    auto client = std::make_shared<Client>(std::move(transport));
-    client->definitionsFiles = definitionsFiles;
-    client->documentationFiles = documentationFiles;
-    parseDocumentation(documentationFiles, client->documentation, client);
+    Client client{std::move(transport)};
+    client.definitionsFiles = definitionsFiles;
+    client.documentationFiles = documentationFiles;
+    parseDocumentation(documentationFiles, client.documentation, &client);
 
     // Parse LSP Settings
     if (auto settingsPath = program.present<std::string>("--settings"))
     {
         if (std::optional<std::string> contents = Luau::FileUtils::readFile(*settingsPath))
-            client->globalConfig = dottedToClientConfiguration(contents.value());
+            client.globalConfig = dottedToClientConfiguration(contents.value());
         else
         {
             std::cerr << "Failed to read base LSP settings at '" << *settingsPath << "'\n";
@@ -148,7 +148,7 @@ int startLanguageServer(const argparse::ArgumentParser& program)
         }
     }
 
-    LanguageServer server(client, defaultConfig);
+    LanguageServer server(&client, defaultConfig);
 
     // Begin input loop
     server.processInputLoop();

--- a/src/platform/roblox/RobloxLanguageServer.cpp
+++ b/src/platform/roblox/RobloxLanguageServer.cpp
@@ -22,7 +22,7 @@ void RobloxPlatform::onDidChangeWatchedFiles(const lsp::FileEvent& change)
 void RobloxPlatform::setupWithConfiguration(const ClientConfiguration& config)
 {
     LUAU_TIMETRACE_SCOPE("RobloxPlatform::setupWithConfiguration", "LSP");
-    std::shared_ptr<Client>& client = workspaceFolder->client;
+    auto client = workspaceFolder->client;
 
     if (config.sourcemap.enabled)
     {

--- a/src/platform/roblox/RobloxSourceNode.cpp
+++ b/src/platform/roblox/RobloxSourceNode.cpp
@@ -1,14 +1,22 @@
 #include "Platform/RobloxPlatform.hpp"
 #include <queue>
 
-bool SourceNode::isScript()
+SourceNode::SourceNode(std::string name, std::string className, std::vector<std::string> filePaths, std::vector<SourceNode*> children)
+    : name(std::move(name))
+    , className(std::move(className))
+    , filePaths(std::move(filePaths))
+    , children(std::move(children))
+{
+}
+
+bool SourceNode::isScript() const
 {
     return className == "ModuleScript" || className == "Script" || className == "LocalScript";
 }
 
 /// NOTE: Use `WorkspaceFileResolver::getRealPathFromSourceNode()` instead of this function where
 /// possible, as that will ensure it is relative to the correct workspace root.
-std::optional<std::string> SourceNode::getScriptFilePath()
+std::optional<std::string> SourceNode::getScriptFilePath() const
 {
     for (const auto& path : filePaths)
     {
@@ -45,7 +53,7 @@ Luau::SourceCode::Type SourceNode::sourceCodeType() const
     }
 }
 
-std::optional<SourceNodePtr> SourceNode::findChild(const std::string& childName)
+std::optional<SourceNode*> SourceNode::findChild(const std::string& childName) const
 {
     for (const auto& child : children)
         if (child->name == childName)
@@ -53,14 +61,14 @@ std::optional<SourceNodePtr> SourceNode::findChild(const std::string& childName)
     return std::nullopt;
 }
 
-std::optional<SourceNodePtr> SourceNode::findDescendant(const std::string& childName)
+std::optional<const SourceNode*> SourceNode::findDescendant(const std::string& childName) const
 {
     // Peforms a BFS search
-    std::queue<SourceNodePtr> queue{};
+    std::queue<const SourceNode*> queue{};
 
     // TODO: this isn't so great, we shouldn't really be making a new shared ptr here
     // but since we know this will never get returned, we'll leave it alone for now
-    queue.push(std::make_shared<SourceNode>(*this));
+    queue.push(this);
 
     while (!queue.empty())
     {
@@ -77,14 +85,33 @@ std::optional<SourceNodePtr> SourceNode::findDescendant(const std::string& child
     return std::nullopt;
 }
 
-std::optional<SourceNodePtr> SourceNode::findAncestor(const std::string& ancestorName)
+std::optional<const SourceNode*> SourceNode::findAncestor(const std::string& ancestorName) const
 {
     auto current = parent;
-    while (auto currentPtr = current.lock())
+    while (current)
     {
-        if (currentPtr->name == ancestorName)
-            return currentPtr;
-        current = currentPtr->parent;
+        if (current->name == ancestorName)
+            return current;
+        current = current->parent;
     }
     return std::nullopt;
+}
+
+SourceNode* SourceNode::fromJson(const json& j, Luau::TypedAllocator<SourceNode>& allocator)
+{
+    auto name = j.at("name").get<std::string>();
+    auto className = j.at("className").get<std::string>();
+
+    std::vector<std::string> filePaths;
+    if (j.contains("filePaths"))
+        j.at("filePaths").get_to(filePaths);
+
+    std::vector<SourceNode*> children;
+    if (j.contains("children"))
+    {
+        for (auto& child : j.at("children"))
+            children.emplace_back(SourceNode::fromJson(child, allocator));
+    }
+
+    return allocator.allocate(SourceNode(std::move(name), std::move(className), std::move(filePaths), std::move(children)));
 }

--- a/src/platform/roblox/RobloxSourcemap.cpp
+++ b/src/platform/roblox/RobloxSourcemap.cpp
@@ -9,23 +9,21 @@
 
 LUAU_FASTFLAG(LuauSolverV2)
 
-static void mutateSourceNodeWithPluginInfo(SourceNode& sourceNode, const PluginNodePtr& pluginInstance)
+static void mutateSourceNodeWithPluginInfo(SourceNode* sourceNode, const PluginNode* pluginInstance, Luau::TypedAllocator<SourceNode>& allocator)
 {
     // We currently perform purely additive changes where we add in new children
     for (const auto& dmChild : pluginInstance->children)
     {
-        if (auto existingChildNode = sourceNode.findChild(dmChild->name))
+        if (auto existingChildNode = sourceNode->findChild(dmChild->name))
         {
-            mutateSourceNodeWithPluginInfo(*existingChildNode.value(), dmChild);
+            mutateSourceNodeWithPluginInfo(*existingChildNode, dmChild, allocator);
         }
         else
         {
-            SourceNode childNode;
-            childNode.name = dmChild->name;
-            childNode.className = dmChild->className;
-            mutateSourceNodeWithPluginInfo(childNode, dmChild);
+            auto childNode = allocator.allocate(SourceNode(dmChild->name, dmChild->className, {}, {}));
+            mutateSourceNodeWithPluginInfo(childNode, dmChild, allocator);
 
-            sourceNode.children.push_back(std::make_shared<SourceNode>(childNode));
+            sourceNode->children.push_back(childNode);
         }
     }
 }
@@ -54,17 +52,17 @@ static std::optional<Luau::TypeId> getTypeIdForClass(const Luau::ScopePtr& globa
     }
 }
 
-static Luau::TypeId getSourcemapType(const Luau::GlobalTypes& globals, Luau::TypeArena& arena, const SourceNodePtr& node);
+static Luau::TypeId getSourcemapType(const Luau::GlobalTypes& globals, Luau::TypeArena& arena, const SourceNode* node);
 
 struct MagicChildLookup final : Luau::MagicFunction
 {
     const Luau::GlobalTypes& globals;
     Luau::TypeArena& arena;
-    SourceNodePtr node;
+    const SourceNode* node;
     bool supportsRecursiveParameter;
     bool supportsTimeoutParameter;
 
-    MagicChildLookup(const Luau::GlobalTypes& globals, Luau::TypeArena& arena, SourceNodePtr node, bool supportsRecursiveParameter = false,
+    MagicChildLookup(const Luau::GlobalTypes& globals, Luau::TypeArena& arena, const SourceNode* node, bool supportsRecursiveParameter = false,
         bool supportsTimeoutParameter = false)
         : globals(globals)
         , arena(arena)
@@ -140,7 +138,7 @@ bool MagicChildLookup::infer(const Luau::MagicFunctionCallContext& context)
     return false;
 }
 
-static void attachChildLookupFunction(const Luau::GlobalTypes& globals, Luau::TypeArena& arena, const SourceNodePtr& node, Luau::TypeId lookupFuncTy,
+static void attachChildLookupFunction(const Luau::GlobalTypes& globals, Luau::TypeArena& arena, const SourceNode* node, Luau::TypeId lookupFuncTy,
     bool supportsRecursiveParameter = false, bool supportsTimeoutParameter = false)
 {
     Luau::attachMagicFunction(
@@ -150,7 +148,7 @@ static void attachChildLookupFunction(const Luau::GlobalTypes& globals, Luau::Ty
 }
 
 static void injectChildrenLookupFunctions(
-    const Luau::GlobalTypes& globals, Luau::TypeArena& arena, Luau::ExternType* ctv, const Luau::TypeId& ty, const SourceNodePtr& node)
+    const Luau::GlobalTypes& globals, Luau::TypeArena& arena, Luau::ExternType* ctv, const Luau::TypeId& ty, const SourceNode* node)
 {
     if (auto instanceType = getTypeIdForClass(globals.globalScope, "Instance"))
     {
@@ -191,9 +189,9 @@ struct MagicFindFirstAncestor final : Luau::MagicFunction
 {
     const Luau::GlobalTypes& globals;
     Luau::TypeArena& arena;
-    const SourceNodePtr& node;
+    const SourceNode* node;
 
-    MagicFindFirstAncestor(const Luau::GlobalTypes& globals, Luau::TypeArena& arena, const SourceNodePtr& node)
+    MagicFindFirstAncestor(const Luau::GlobalTypes& globals, Luau::TypeArena& arena, const SourceNode* node)
         : globals(globals)
         , arena(arena)
         , node(node)
@@ -243,7 +241,7 @@ bool MagicFindFirstAncestor::infer(const Luau::MagicFunctionCallContext& context
 
 // Retrieves the corresponding Luau type for a Sourcemap node
 // If it does not yet exist, the type is produced
-static Luau::TypeId getSourcemapType(const Luau::GlobalTypes& globals, Luau::TypeArena& arena, const SourceNodePtr& node)
+static Luau::TypeId getSourcemapType(const Luau::GlobalTypes& globals, Luau::TypeArena& arena, const SourceNode* node)
 {
     // Gets the type corresponding to the sourcemap node if it exists
     // Make sure to use the correct ty version (base typeChecker vs autocomplete typeChecker)
@@ -298,12 +296,12 @@ static Luau::TypeId getSourcemapType(const Luau::GlobalTypes& globals, Luau::Typ
             // Get the mutable version of the type var
             if (auto* ctv = Luau::getMutable<Luau::ExternType>(typeId))
             {
-                if (auto parentNode = node->parent.lock())
+                if (node->parent)
                 {
                     if (FFlag::LuauSolverV2)
-                        ctv->props["Parent"] = Luau::Property::rw(getSourcemapType(globals, arena, parentNode), instanceTy->type);
+                        ctv->props["Parent"] = Luau::Property::rw(getSourcemapType(globals, arena, node->parent), instanceTy->type);
                     else
-                        ctv->props["Parent"] = Luau::makeProperty(getSourcemapType(globals, arena, parentNode));
+                        ctv->props["Parent"] = Luau::makeProperty(getSourcemapType(globals, arena, node->parent));
                 }
 
                 // Add children as properties
@@ -339,7 +337,7 @@ static Luau::TypeId getSourcemapType(const Luau::GlobalTypes& globals, Luau::Typ
     return ty;
 }
 
-void addChildrenToCTV(const Luau::GlobalTypes& globals, Luau::TypeArena& arena, const Luau::TypeId& ty, const SourceNodePtr& node)
+void addChildrenToCTV(const Luau::GlobalTypes& globals, Luau::TypeArena& arena, const Luau::TypeId& ty, const SourceNode* node)
 {
     if (auto* ctv = Luau::getMutable<Luau::ExternType>(ty))
     {
@@ -430,7 +428,7 @@ bool RobloxPlatform::updateSourceMap()
     }
 }
 
-void RobloxPlatform::writePathsToMap(const SourceNodePtr& node, const std::string& base)
+void RobloxPlatform::writePathsToMap(SourceNode* node, const std::string& base)
 {
     LUAU_TIMETRACE_SCOPE("RobloxPlatform::writePathsToMap", "LSP");
     node->virtualPath = base;
@@ -451,13 +449,15 @@ void RobloxPlatform::writePathsToMap(const SourceNodePtr& node, const std::strin
 void RobloxPlatform::updateSourceNodeMap(const std::string& sourceMapContents)
 {
     LUAU_TIMETRACE_SCOPE("RobloxPlatform::updateSourceNodeMap", "LSP");
+    rootSourceNode = nullptr;
+    sourceNodeAllocator.clear();
     realPathsToSourceNodes.clear();
     virtualPathsToSourceNodes.clear();
 
     try
     {
         auto j = json::parse(sourceMapContents);
-        rootSourceNode = std::make_shared<SourceNode>(j.get<SourceNode>());
+        rootSourceNode = SourceNode::fromJson(j, sourceNodeAllocator);
 
         // Write paths
         std::string base = rootSourceNode->className == "DataModel" ? "game" : "ProjectRoot";
@@ -465,8 +465,8 @@ void RobloxPlatform::updateSourceNodeMap(const std::string& sourceMapContents)
     }
     catch (const std::exception& e)
     {
-        // TODO: log message?
-        std::cerr << e.what() << '\n';
+        // TODO: log message? NOTE: this function can be called from CLI
+        std::cerr << "Sourcemap parsing failed, sourcemap is not loaded: " << e.what() << '\n';
     }
 }
 
@@ -484,7 +484,7 @@ void RobloxPlatform::handleSourcemapUpdate(Luau::Frontend& frontend, const Luau:
     {
         if (rootSourceNode->className == "DataModel")
         {
-            mutateSourceNodeWithPluginInfo(*rootSourceNode, pluginInfo);
+            mutateSourceNodeWithPluginInfo(rootSourceNode, pluginInfo, sourceNodeAllocator);
         }
         else
         {
@@ -575,26 +575,26 @@ void RobloxPlatform::handleSourcemapUpdate(Luau::Frontend& frontend, const Luau:
     };
 }
 
-std::optional<SourceNodePtr> RobloxPlatform::getSourceNodeFromVirtualPath(const Luau::ModuleName& name) const
+std::optional<const SourceNode*> RobloxPlatform::getSourceNodeFromVirtualPath(const Luau::ModuleName& name) const
 {
     if (auto it = virtualPathsToSourceNodes.find(name); it != virtualPathsToSourceNodes.end())
         return it->second;
     return std::nullopt;
 }
 
-std::optional<SourceNodePtr> RobloxPlatform::getSourceNodeFromRealPath(const Uri& name) const
+std::optional<const SourceNode*> RobloxPlatform::getSourceNodeFromRealPath(const Uri& name) const
 {
     if (auto it = realPathsToSourceNodes.find(name); it != realPathsToSourceNodes.end())
         return it->second;
     return std::nullopt;
 }
 
-Luau::ModuleName RobloxPlatform::getVirtualPathFromSourceNode(const SourceNodePtr& sourceNode)
+Luau::ModuleName RobloxPlatform::getVirtualPathFromSourceNode(const SourceNode* sourceNode)
 {
     return sourceNode->virtualPath;
 }
 
-std::optional<Uri> RobloxPlatform::getRealPathFromSourceNode(const SourceNodePtr& sourceNode) const
+std::optional<Uri> RobloxPlatform::getRealPathFromSourceNode(const SourceNode* sourceNode) const
 {
     // NOTE: this filepath is generated by the sourcemap, which is relative to the cwd where the sourcemap
     // command was run from. Hence, we concatenate it to the end of the workspace path, and normalise the result

--- a/src/platform/roblox/RobloxStudioPlugin.cpp
+++ b/src/platform/roblox/RobloxStudioPlugin.cpp
@@ -3,12 +3,30 @@
 #include "LSP/LanguageServer.hpp"
 #include "LSP/Workspace.hpp"
 
-void RobloxPlatform::onStudioPluginFullChange(const PluginNode& dataModel)
+
+PluginNode* PluginNode::fromJson(const json& j, Luau::TypedAllocator<PluginNode>& allocator)
+{
+    auto name = j.at("Name").get<std::string>();
+    auto className = j.at("ClassName").get<std::string>();
+
+    std::vector<PluginNode*> children;
+    if (j.contains("Children"))
+    {
+        for (auto& child : j.at("Children"))
+        {
+            children.emplace_back(PluginNode::fromJson(child, allocator));
+        }
+    }
+
+    return allocator.allocate(PluginNode{std::move(name), std::move(className), std::move(children)});
+}
+
+void RobloxPlatform::onStudioPluginFullChange(const json& dataModel)
 {
     workspaceFolder->client->sendLogMessage(lsp::MessageType::Info, "received full change from studio plugin");
 
-    // TODO: properly handle multi-workspace setup
-    pluginInfo = std::make_shared<PluginNode>(dataModel);
+    pluginNodeAllocator.clear();
+    pluginInfo = PluginNode::fromJson(dataModel, pluginNodeAllocator);
 
     // Mutate the sourcemap with the new information
     updateSourceMap();
@@ -19,6 +37,7 @@ void RobloxPlatform::onStudioPluginClear()
     workspaceFolder->client->sendLogMessage(lsp::MessageType::Info, "received clear from studio plugin");
 
     // TODO: properly handle multi-workspace setup
+    pluginNodeAllocator.clear();
     pluginInfo = nullptr;
 
     // Mutate the sourcemap with the new information


### PR DESCRIPTION
We (over) use shared_ptr a bit, let's stop using it:
- Client is now a direct pointer. It is guaranteed to last for the scope of the whole program
- SourceNode and PluginNodes are now created using Luau's TypedAllocator. We can access the nodes directly as pointers.