### PR TITLE
Add SecurityCapabilities DataType

### DIFF
--- a/scripts/DataTypes.json
+++ b/scripts/DataTypes.json
@@ -2500,6 +2500,29 @@
                 }
             ],
             "Name": "Path2DControlPoint"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Function",
+                    "Name": "new",
+                    "Parameters": [
+                        {
+                            "Name": "capabilities",
+                            "Type": {
+                                "Variadic": {
+                                    "Category": "Enum",
+                                    "Name": "SecurityCapability"
+                                }
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "SecurityCapabilities"
+                    }
+                }
+            ],
+            "Name": "SecurityCapabilities"
         }
     ],
     "DataTypes": [
@@ -5364,6 +5387,65 @@
                 }
             ],
             "Name": "Path2DControlPoint"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Function",
+                    "Name": "Add",
+                    "Parameters": [
+                        {
+                            "Name": "capabilities",
+                            "Type": {
+                                "Tuple": {
+                                    "Category": "Enum",
+                                    "Name": "SecurityCapability"
+                                }
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "SecurityCapabilities"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "Remove",
+                    "Parameters": [
+                        {
+                            "Name": "capabilities",
+                            "Type": {
+                                "Tuple": {
+                                    "Category": "Enum",
+                                    "Name": "SecurityCapability"
+                                }
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "SecurityCapabilities"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "Contains",
+                    "Parameters": [
+                        {
+                            "Name": "capabilities",
+                            "Type": {
+                                "Tuple": {
+                                    "Category": "Enum",
+                                    "Name": "SecurityCapability"
+                                }
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "SecurityCapabilities"
+                    }
+                }
+            ],
+            "Name": "SecurityCapabilities"
         }
     ]
 }


### PR DESCRIPTION
This pull request adds Roblox's `SecurityCapabilities` datatype to luau-lsp.
Tested in a local branch, resulting type definition file works as intended 🎉