### PR TITLE
Add custom thread implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,7 @@ target_sources(Luau.LanguageServer PRIVATE
         src/IostreamHelpers.cpp
         src/Utils.cpp
         src/Flags.cpp
+        src/Thread.cpp
         src/JsonTomlSyntaxParser.cpp
         src/CliConfigurationParser.cpp
         src/platform/AutoImports.cpp

--- a/src/LanguageServer.cpp
+++ b/src/LanguageServer.cpp
@@ -30,7 +30,7 @@ LanguageServer::LanguageServer(Client* aClient, std::optional<Luau::Config> aDef
     , defaultConfig(std::move(aDefaultConfig))
     , nullWorkspace(std::make_shared<WorkspaceFolder>(client, "$NULL_WORKSPACE", Uri(), defaultConfig))
 {
-    messageProcessorThread = std::thread(
+    messageProcessorThread = Thread(
         [this]
         {
             while (auto message = popMessage())

--- a/src/Thread.cpp
+++ b/src/Thread.cpp
@@ -1,0 +1,80 @@
+#include "Thread.hpp"
+
+#include <functional>
+#include <memory>
+
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <pthread.h>
+#endif
+
+#ifdef _WIN32
+DWORD WINAPI winThreadFuncWrapper(LPVOID lpParam)
+{
+    std::function<void()>* func = static_cast<std::function<void()>*>(lpParam);
+    (*func)();
+    delete func; // Clean up the allocated function object
+    return 0;
+}
+#else
+static pthread_t NULL_THREAD = pthread_t();
+
+static pthread_t thread_get_id(const pthread_t* t)
+{
+    return *t;
+}
+
+static bool thread_isnull(const pthread_t* t)
+{
+    return thread_get_id(t) == nullptr;
+}
+
+void* posixThreadFuncWrapper(void* arg)
+{
+    auto* func = static_cast<std::function<void()>*>(arg);
+    (*func)();
+    delete func; // Clean up the allocated function object
+    return nullptr;
+}
+
+Thread::~Thread()
+{
+    if (!thread_isnull(&m_threadId))
+        std::terminate();
+}
+
+Thread::Thread(Thread&& thread) noexcept
+    : m_threadId(thread.m_threadId)
+{
+    thread.m_threadId = NULL_THREAD;
+}
+
+Thread& Thread::operator=(Thread&& other) noexcept
+{
+    if (!thread_isnull(&m_threadId))
+        std::terminate();
+    m_threadId = other.m_threadId;
+    other.m_threadId = NULL_THREAD;
+    return *this;
+}
+
+bool Thread::joinable() const
+{
+    return !thread_isnull(&m_threadId);
+}
+
+void Thread::join()
+{
+    int ec = EINVAL;
+    if (joinable())
+    {
+        ec = pthread_join(m_threadId, nullptr);
+        if (ec == 0)
+            m_threadId = NULL_THREAD;
+    }
+
+    if (ec)
+        throw std::system_error(ec, std::generic_category(), "thread::join failed");
+}
+#endif

--- a/src/include/LSP/LanguageServer.hpp
+++ b/src/include/LSP/LanguageServer.hpp
@@ -1,5 +1,4 @@
 #include <optional>
-#include <thread>
 #include <queue>
 #include <condition_variable>
 
@@ -11,6 +10,8 @@
 
 #include "LSP/Client.hpp"
 #include "LSP/Workspace.hpp"
+
+#include "Thread.hpp"
 
 using json = nlohmann::json;
 using namespace json_rpc;
@@ -95,6 +96,6 @@ private:
     std::mutex messagesMutex;
     std::condition_variable messagesCv;
     std::queue<json_rpc::JsonRpcMessage> messages;
-    std::thread messageProcessorThread;
+    Thread messageProcessorThread;
     std::unordered_map<id_type, LSPCancellationToken> cancellationTokens;
 };

--- a/src/include/Thread.hpp
+++ b/src/include/Thread.hpp
@@ -1,0 +1,69 @@
+#pragma once
+
+#include <functional>
+
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <pthread.h>
+#endif
+
+constexpr size_t MACOS_CUSTOM_THREAD_STACK_SIZE = 8 * 1024 * 1024; // 8 MB, default is 512KB
+
+void* posixThreadFuncWrapper(void* arg);
+
+class Thread
+{
+protected:
+#ifdef _WIN32
+    HANDLE m_handle;
+    DWORD m_threadId;
+#else
+    pthread_t m_threadId{};
+#endif
+
+public:
+    Thread() = default;
+    Thread(Thread&& other) noexcept;
+    Thread(const Thread&) = delete;
+    Thread& operator=(Thread&& other) noexcept;
+    ~Thread();
+
+    template<typename Callable>
+    explicit Thread(Callable&& func)
+    {
+        // We need to dynamically allocate the std::function object to pass it
+        // across the C-style thread boundary. It will be deleted by the wrapper.
+        auto* func_ptr = new std::function<void()>(func);
+        std::unique_ptr<std::function<void()>> func_owner(func_ptr);
+
+        pthread_attr_t attr;
+        int ret = pthread_attr_init(&attr);
+        if (ret != 0)
+        {
+            throw std::system_error(ret, std::generic_category(), "error initializing pthread attributes");
+        }
+
+#ifdef __APPLE__
+        // Set stack size
+        ret = pthread_attr_setstacksize(&attr, MACOS_CUSTOM_THREAD_STACK_SIZE);
+        if (ret != 0)
+        {
+            pthread_attr_destroy(&attr);
+            throw std::system_error(ret, std::generic_category(), "error setting pthread stack size");
+        }
+#endif
+
+        ret = pthread_create(&m_threadId, &attr, posixThreadFuncWrapper, func_owner.release());
+        pthread_attr_destroy(&attr);
+
+        if (ret != 0)
+        {
+            delete func_ptr; // thread wrapper function won't delete the func
+            throw std::system_error(ret, std::generic_category(), "error creating thread");
+        }
+    }
+
+    [[nodiscard]] bool joinable() const;
+    void join();
+};


### PR DESCRIPTION
The latest release of luau-lsp introduces cancellation support, which requires running requests on a separate thread. This means that typechecking runs on a separate thread, and typechecking can take up a lot of stack space.

In doing so, I have come to learn that the default stack space for thread creation (incl. `std::thread`) on macOS is 512kB (!). According to several resources, there is no way to customize the stack space with the `std::thread` API (but there is a proposal to potentially add this in C++26... https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p2019r6.pdf)

That means, if we want to use threads, it looks like we need to roll our own implementation. This PR implements a simple Thread interface using Windows APIs on windows and pthreads on Linux / macOS. Inspiration taken from the default implementation in libcxx.

Fixes #1159 

