### PR TITLE
Fix for CFrame.fromEulerAngles constructor

### DIFF
--- a/scripts/DataTypes.json
+++ b/scripts/DataTypes.json
@@ -917,7 +917,8 @@
                             "Type": {
                                 "Category": "Enum",
                                 "Name": "RotationOrder"
-                            }
+                            },
+                            "Default": "nil"
                         }
                     ],
                     "ReturnType": {

--- a/scripts/globalTypes.d.luau
+++ b/scripts/globalTypes.d.luau
@@ -15544,7 +15544,7 @@ declare UDim2: {
 declare CFrame: {
 	identity: CFrame,
 	fromEulerAnglesYXZ: ((rx: number, ry: number, rz: number) -> CFrame),
-	fromEulerAngles: ((rx: number, ry: number, rz: number, order: EnumRotationOrder) -> CFrame),
+	fromEulerAngles: ((rx: number, ry: number, rz: number, order: EnumRotationOrder?) -> CFrame),
 	Angles: ((rx: number, ry: number, rz: number) -> CFrame),
 	fromMatrix: ((pos: Vector3, vX: Vector3, vY: Vector3, vZ: Vector3?) -> CFrame),
 	fromAxisAngle: ((v: Vector3, r: number) -> CFrame),


### PR DESCRIPTION
Fixed the "order" variable in CFrame.fromEulerAngles being incorrectly marked as required by the typechecker