### PR TITLE
Add TextChatService children configurations

### DIFF
--- a/scripts/dumpRobloxTypes.py
+++ b/scripts/dumpRobloxTypes.py
@@ -464,6 +464,12 @@ EXTRA_MEMBERS = {
         "function BindToRenderStep(self, name: string, priority: number, func: ((delta: number) -> ())): ()",
     ],
     "GuiService": ["SelectedObject: GuiObject?"],
+    "TextChatService": [
+        "ChatWindowConfiguration: ChatWindowConfiguration",
+        "ChatInputBarConfiguration: ChatInputBarConfiguration",
+        "BubbleChatConfiguration: BubbleChatConfiguration",
+        "ChannelTabsConfiguration: ChannelTabsConfiguration",
+    ],
     "GlobalDataStore": [
         # GetAsync we received from upstream didn't have a second return value of DataStoreKeyInfo
         "function GetAsync(self, key: string, options: DataStoreGetOptions?): (any, DataStoreKeyInfo)",


### PR DESCRIPTION
Recently I have been working with `TextChatService` and observed that its children instances are not detected by the LSP.
The [`TextChatService` documentation](https://create.roblox.com/docs/reference/engine/classes/TextChatService) says,

> For further customization, TextChatService has the following singleton children:
> 
>     [ChatWindowConfiguration](https://create.roblox.com/docs/reference/engine/classes/ChatWindowConfiguration)
>     [ChatInputBarConfiguration](https://create.roblox.com/docs/reference/engine/classes/ChatInputBarConfiguration)
>     [BubbleChatConfiguration](https://create.roblox.com/docs/reference/engine/classes/BubbleChatConfiguration)
>     [ChannelTabsConfiguration](https://create.roblox.com/docs/reference/engine/classes/ChannelTabsConfiguration)

Each instance is not creatable and locked. It is always there.
I used `EXTRA_MEMBERS` as it seems the above detail is not available in the `API-Dump.json` upstream.