### PR TITLE
Fix clang-cl compilation, better compilation instructions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,7 +135,11 @@ target_sources(Luau.LanguageServer.Test PRIVATE
 # TODO: Set Luau.Analysis at O2 to speed up debugging
 if (MSVC)
     list(APPEND LUAU_LSP_OPTIONS /W3 /D_CRT_SECURE_NO_WARNINGS)
-    list(APPEND LUAU_LSP_OPTIONS /MP) # Distribute compilation across multiple cores
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+        list(APPEND LUTE_OPTIONS "/EHsc") # The CMake clang-cl target doesn't enable exceptions by default
+    else()
+        list(APPEND LUAU_LSP_OPTIONS /MP) # Distribute compilation across multiple cores; doesn't work with clang-cl
+    endif()
 else ()
     list(APPEND LUAU_LSP_OPTIONS -Wall)
 endif ()

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ An implementation of a language server for the [Luau](https://github.com/Roblox/
 
 Install the extension from the VSCode Marketplace or OpenVSX Registry:
 
-- VSCode Marketplace: https://marketplace.visualstudio.com/items?itemName=JohnnyMorganz.luau-lsp
-- OpenVSX Registry: https://open-vsx.org/extension/JohnnyMorganz/luau-lsp
+- VSCode Marketplace: <https://marketplace.visualstudio.com/items?itemName=JohnnyMorganz.luau-lsp>
+- OpenVSX Registry: <https://open-vsx.org/extension/JohnnyMorganz/luau-lsp>
 
 Alternatively, check out [Getting Started for Language Server Clients](https://github.com/JohnnyMorganz/luau-lsp/blob/main/editors/README.md)
 to setup your own client for a different editor.
@@ -124,7 +124,16 @@ Crash Reporting is only available for Windows and macOS, and is not active for S
 
 ## Build From Source
 
+Submodules are required to build the project. You should use `--recurse-submodules` when you initally clone the project; e.g.
+
 ```sh
+git clone https://github.com/JohnnyMorganz/luau-lsp.git --recurse-submodules
+```
+
+To compile the project, execute the following commands in the project root directory.
+
+```sh
+git submodule update --init --recursive
 mkdir build && cd build
 cmake .. -DCMAKE_BUILD_TYPE=Release
 cmake --build . --target Luau.LanguageServer.CLI --config Release


### PR DESCRIPTION
tin
the exceptions thing is not required for it to compile, but I imagine you want exceptions on? directly taken from my addition to lute
`/MP` does not work on clang-cl :-(

also runs markdownlint on the readme and adds better compilation instructions