### PR TITLE
Add missing C++ exception header

### DIFF
--- a/src/Thread.cpp
+++ b/src/Thread.cpp
@@ -1,5 +1,6 @@
 #ifndef _WIN32
 #include "Thread.hpp"
+#include <exception>
 
 static pthread_t NULL_THREAD = pthread_t();
 


### PR DESCRIPTION
If <exception> is not included, the build errors due to std::terminate not being defined.