### PR TITLE
Fix default value for 'types.definitionFiles' setting in vscode extension

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -330,7 +330,7 @@
         "luau-lsp.types.definitionFiles": {
           "markdownDescription": "A mapping of package names to paths of definition files to load in to the type checker. Note that definition file syntax is currently unstable and may change at any time",
           "type": "object",
-          "default": [],
+          "default": {},
           "additionalProperties": {
             "type": "string"
           },


### PR DESCRIPTION
Fixes https://github.com/JohnnyMorganz/luau-lsp/issues/1253