### PR TITLE
fix(cli): add missing newline to log messages 

### DIFF
--- a/src/include/Analyze/CliClient.hpp
+++ b/src/include/Analyze/CliClient.hpp
@@ -30,7 +30,7 @@ struct CliClient : public BaseClient
 
     void sendLogMessage(const lsp::MessageType& type, const std::string& message) const override
     {
-        std::cerr << "[" << getMessageTypeString(type) << "] " << message;
+        std::cerr << "[" << getMessageTypeString(type) << "] " << message << "\n";
     }
 
     // In the CLI, this is only used for config errors right now


### PR DESCRIPTION
Log messages in the analyze CLI were printed without trailing
newlines, causing consecutive messages to run together on the
same line.