### PR TITLE
fix: enable automatic imports server side

### DIFF
--- a/src/include/LSP/ClientConfiguration.hpp
+++ b/src/include/LSP/ClientConfiguration.hpp
@@ -141,7 +141,7 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(ClientCompletionImportsStringReq
 struct ClientCompletionImportsConfiguration
 {
     /// Whether we should suggest automatic imports in completions
-    bool enabled = false;
+    bool enabled = true;
     /// Whether services should be suggested in auto-import
     bool suggestServices = true;
     /// When non-empty, only show the services listed when auto-importing


### PR DESCRIPTION
9c8d58ea2156d608dbe496c675d327f2f26acb9e enabled auto-imports by default, but it's client side and other clients like neovim don't send the whole settings schema so it was still disabled by default 