### PR TITLE
Fix editor guide

### DIFF
--- a/editors/README.md
+++ b/editors/README.md
@@ -30,7 +30,7 @@ The `name` should be a unique reference to the definitions file.
 This can be done multiple times:
 
 ```sh
-$ luau-lsp lsp --definition:@roblox=/path/to/globalTypes.d.luau
+$ luau-lsp lsp --definitions:@roblox=/path/to/globalTypes.d.luau
 ```
 
 > NOTE: Definitions file syntax is unstable and undocumented. It may change at any time


### PR DESCRIPTION
I have spent like an hour figuring out that its `--definitions` and not `--definition`. Yes, it's literally a single letter push but if I can save even one person an hour of searching through protocol specifications and forums, then this push has fulfilled its' purpose.