### PR TITLE
Add context-aware autocomplete for QueryDescendants selectors

### DIFF
--- a/src/LanguageServer.cpp
+++ b/src/LanguageServer.cpp
@@ -94,7 +94,7 @@ lsp::ServerCapabilities LanguageServer::getServerCapabilities()
     textDocumentSyncOptions.save = {/* includeText= */ false};
     capabilities.textDocumentSync = textDocumentSyncOptions;
     // Completion
-    std::vector<std::string> completionTriggerCharacters{".", ":", "'", "\"", "/", "\n"}; // \n is used to trigger end completion
+    std::vector<std::string> completionTriggerCharacters{".", ":", "'", "\"", "/", "\n", "[", ",", "(", ">"}; // \n is used to trigger end completion
     lsp::CompletionOptions::CompletionItem completionItem{/* labelDetailsSupport: */ true};
     capabilities.completionProvider = {completionTriggerCharacters, std::nullopt, /* resolveProvider: */ false, completionItem};
     // Hover Provider

--- a/src/platform/roblox/RobloxLuauExt.cpp
+++ b/src/platform/roblox/RobloxLuauExt.cpp
@@ -715,6 +715,8 @@ void RobloxPlatform::mutateRegisteredDefinitions(Luau::GlobalTypes& globals, std
             attachTagSafe(ctv->props, "IsPropertyModified", "Properties");
             attachTagSafe(ctv->props, "ResetPropertyToDefault", "Properties");
 
+            attachTagSafe(ctv->props, "QueryDescendants", "QuerySelector");
+
             // Go through all the defined classes and if they are a subclass of Instance then give them the
             // same metatable identity as Instance so that equality comparison works.
             // NOTE: This will OVERWRITE any metatables set on these classes!


### PR DESCRIPTION
TODO: We now trigger a lot of completion for common punctuation. Is this a performance concern? Maybe we need to scope it down to just ClassNames.

A lot of roblox specific details are leaking into the generic Completion.cpp, can we improve this? 

## Summary

- Adds context-aware autocomplete inside `Instance:QueryDescendants("...")` selector strings
- Understands CSS-like selector syntax and provides appropriate completions based on cursor position
- Builds on the magic type narrowing added in #1367

## Completion Contexts

| Cursor position | Completions |
|----------------|-------------|
| Empty string or after `>`, `>>`, `,`, space | All Instance subclass names |
| After `:` | Pseudo-classes (`not`, `has`) with snippet parentheses |
| Inside `[...]` | Properties of the preceding class (or Instance if none) |
| After `.` or `#` | None (tags/names have no LSP data available) |

## Implementation Details

- **`RobloxLuauExt.cpp`**: Attaches `"QuerySelector"` tag to `QueryDescendants`
- **`RobloxCompletion.cpp`**: Selector context parser (`detectSelectorContext`, `findPrecedingClassName`) and `"QuerySelector"` handler in `completionCallback`. Extracts shared `getPropertiesOfType()` helper to deduplicate with existing `"Properties"` handler
- **`Completion.cpp`**: Computes string content up to cursor for context detection; token-level `textEdit` replaces only the current token instead of the full string; pseudo-class entries get snippet parentheses and documentation
- **`LanguageServer.cpp`**: Registers `[`, `(`, `,`, `>` as completion trigger characters, suppressed outside QuerySelector context

## Test plan

- [x] 22 test cases covering all selector contexts, mid-identifier completion, textEdit ranges, pseudo-class snippets/documentation, fallback to Instance properties, and no-completion cases
- [x] Full test suite passes (677 tests)
- [x] Tests pass with `--new-solver`

🤖 Generated with [Claude Code](https://claude.com/claude-code)