### PR TITLE
Enable fragment autocomplete by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Sync to upstream Luau 0.712
+- Fragment autocomplete is now enabled by default ([#1268](https://github.com/JohnnyMorganz/luau-lsp/issues/1268))
 
 ## [1.63.0] - 2026-03-01
 

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -628,13 +628,10 @@
           "scope": "resource"
         },
         "luau-lsp.completion.enableFragmentAutocomplete": {
-          "markdownDescription": "Enables the experimental fragment autocomplete system for performance improvements",
+          "markdownDescription": "Enables the fragment autocomplete system for performance improvements",
           "type": "boolean",
-          "default": false,
-          "scope": "resource",
-          "tags": [
-            "preview"
-          ]
+          "default": true,
+          "scope": "resource"
         },
         "luau-lsp.signatureHelp.enabled": {
           "markdownDescription": "Enable signature help",

--- a/src/include/LSP/ClientConfiguration.hpp
+++ b/src/include/LSP/ClientConfiguration.hpp
@@ -185,8 +185,8 @@ struct ClientCompletionConfiguration
     bool showAnonymousAutofilledFunction = true;
     /// Whether to show deprecated items in autocomplete suggestions
     bool showDeprecatedItems = true;
-    /// Enables the experimental fragment autocomplete system for performance improvements
-    bool enableFragmentAutocomplete = false;
+    /// Enables the fragment autocomplete system for performance improvements
+    bool enableFragmentAutocomplete = true;
 };
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(ClientCompletionConfiguration, enabled, autocompleteEnd, suggestImports, imports, addParentheses,


### PR DESCRIPTION
Fragment autocomplete FFlags have been removed from upstream Luau,
so it is now safe to enable this as the default. 

Closes #1268