### PR TITLE
Rename Studio Plugin setting from plugin to studioPlugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- Renamed Studio Plugin settings from `luau-lsp.plugin.*` to `luau-lsp.studioPlugin.*` to avoid confusion with the source transform plugins (`luau-lsp.plugins.*`). The old `luau-lsp.plugin.*` settings are deprecated but still supported for backwards compatibility.
+
 ### Fixed
 
 - When a plugin is hot-reloaded, all source nodes (not just managed text documents) are now marked dirty so non-managed files are re-analysed with the updated plugin transformations

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -648,23 +648,47 @@
           "default": true,
           "scope": "resource"
         },
-        "luau-lsp.plugin.enabled": {
+        "luau-lsp.studioPlugin.enabled": {
           "markdownDescription": "Use Roblox Studio Plugin to provide DataModel information",
           "type": "boolean",
           "default": false,
           "scope": "window"
         },
-        "luau-lsp.plugin.port": {
+        "luau-lsp.studioPlugin.port": {
           "markdownDescription": "Port number to connect to the Studio Plugin",
           "type": "number",
           "default": 3667,
           "scope": "window"
         },
-        "luau-lsp.plugin.maximumRequestBodySize": {
+        "luau-lsp.studioPlugin.maximumRequestBodySize": {
           "markdownDescription": "The maximum request body size accepted from the plugin, in a string representation parse-able by the [bytes](https://www.npmjs.com/package/bytes) library",
           "type": "string",
           "default": "3mb",
           "scope": "window"
+        },
+        "luau-lsp.plugin.enabled": {
+          "markdownDescription": "Use Roblox Studio Plugin to provide DataModel information",
+          "type": "boolean",
+          "default": false,
+          "scope": "window",
+          "markdownDeprecationMessage": "**Deprecated**: Use `luau-lsp.studioPlugin.enabled` instead.",
+          "deprecationMessage": "Deprecated: Use luau-lsp.studioPlugin.enabled instead."
+        },
+        "luau-lsp.plugin.port": {
+          "markdownDescription": "Port number to connect to the Studio Plugin",
+          "type": "number",
+          "default": 3667,
+          "scope": "window",
+          "markdownDeprecationMessage": "**Deprecated**: Use `luau-lsp.studioPlugin.port` instead.",
+          "deprecationMessage": "Deprecated: Use luau-lsp.studioPlugin.port instead."
+        },
+        "luau-lsp.plugin.maximumRequestBodySize": {
+          "markdownDescription": "The maximum request body size accepted from the plugin, in a string representation parse-able by the [bytes](https://www.npmjs.com/package/bytes) library",
+          "type": "string",
+          "default": "3mb",
+          "scope": "window",
+          "markdownDeprecationMessage": "**Deprecated**: Use `luau-lsp.studioPlugin.maximumRequestBodySize` instead.",
+          "deprecationMessage": "Deprecated: Use luau-lsp.studioPlugin.maximumRequestBodySize instead."
         },
         "luau-lsp.require.fileAliases": {
           "markdownDescription": "A mapping of custom require string aliases to file paths",

--- a/editors/code/src/roblox.ts
+++ b/editors/code/src/roblox.ts
@@ -11,17 +11,21 @@ import * as utils from "./utils";
 
 let pluginServer: Server | undefined = undefined;
 
-// Reads a studio plugin setting from the new "studioPlugin" key, falling back to the
-// old "plugin" key for backwards compatibility with existing user configurations.
 const getStudioPluginValue = <T>(key: string, defaultValue: T): T => {
-  const newConfig = vscode.workspace.getConfiguration("luau-lsp.studioPlugin");
-  const newInspect = newConfig.inspect<T>(key);
+  const newInspect = vscode.workspace
+    .getConfiguration("luau-lsp.studioPlugin")
+    .inspect<T>(key);
   if (
     newInspect?.globalValue !== undefined ||
     newInspect?.workspaceValue !== undefined ||
     newInspect?.workspaceFolderValue !== undefined
   ) {
-    return newConfig.get<T>(key) ?? defaultValue;
+    return (
+      newInspect.workspaceFolderValue ??
+      newInspect.workspaceValue ??
+      newInspect.globalValue ??
+      defaultValue
+    );
   }
   return vscode.workspace.getConfiguration("luau-lsp.plugin").get<T>(key) ?? defaultValue;
 };

--- a/editors/code/src/roblox.ts
+++ b/editors/code/src/roblox.ts
@@ -27,7 +27,10 @@ const getStudioPluginValue = <T>(key: string, defaultValue: T): T => {
       defaultValue
     );
   }
-  return vscode.workspace.getConfiguration("luau-lsp.plugin").get<T>(key) ?? defaultValue;
+  return (
+    vscode.workspace.getConfiguration("luau-lsp.plugin").get<T>(key) ??
+    defaultValue
+  );
 };
 
 const API_DOCS = "https://luau-lsp.pages.dev/api-docs/en-us.json";

--- a/editors/code/src/roblox.ts
+++ b/editors/code/src/roblox.ts
@@ -11,6 +11,21 @@ import * as utils from "./utils";
 
 let pluginServer: Server | undefined = undefined;
 
+// Reads a studio plugin setting from the new "studioPlugin" key, falling back to the
+// old "plugin" key for backwards compatibility with existing user configurations.
+const getStudioPluginValue = <T>(key: string, defaultValue: T): T => {
+  const newConfig = vscode.workspace.getConfiguration("luau-lsp.studioPlugin");
+  const newInspect = newConfig.inspect<T>(key);
+  if (
+    newInspect?.globalValue !== undefined ||
+    newInspect?.workspaceValue !== undefined ||
+    newInspect?.workspaceFolderValue !== undefined
+  ) {
+    return newConfig.get<T>(key) ?? defaultValue;
+  }
+  return vscode.workspace.getConfiguration("luau-lsp.plugin").get<T>(key) ?? defaultValue;
+};
+
 const API_DOCS = "https://luau-lsp.pages.dev/api-docs/en-us.json";
 const LUAU_API_DOCS = "https://luau-lsp.pages.dev/api-docs/luau-en-us.json";
 const STUDIO_PLUGIN_URL =
@@ -19,7 +34,7 @@ const STUDIO_PLUGIN_URL =
 const setupStudioPlugin = async (client: LanguageClient | undefined) => {
   // Enable the plugin server
   await vscode.workspace
-    .getConfiguration("luau-lsp.plugin")
+    .getConfiguration("luau-lsp.studioPlugin")
     .update("enabled", true);
   startPluginServer(client);
   // Open the studio plugin in the browser for the user to install
@@ -79,11 +94,7 @@ const getRojoProjectFile = async (
   if (foundProjectFiles.length === 0) {
     // If the plugin is not enabled, provide a one-click setup button
     let options: string[] = [];
-    if (
-      !vscode.workspace
-        .getConfiguration("luau-lsp.plugin")
-        .get<boolean>("enabled")
-    ) {
+    if (!getStudioPluginValue("enabled", false)) {
       options.push("Setup Plugin");
     }
     options.push("Configure Settings");
@@ -277,11 +288,7 @@ const startSourcemapGeneration = async (
           ) {
             output +=
               "Rojo not found. Configure your Rojo path in settings, or use the Studio Plugin for DataModel info instead";
-            if (
-              !vscode.workspace
-                .getConfiguration("luau-lsp.plugin")
-                .get<boolean>("enabled")
-            ) {
+            if (!getStudioPluginValue("enabled", false)) {
               options.push("Setup Plugin");
             }
             options.push("Configure Settings");
@@ -375,9 +382,7 @@ const startPluginServer = async (client: LanguageClient | undefined) => {
   const app = express();
   app.use(
     express.json({
-      limit: vscode.workspace
-        .getConfiguration("luau-lsp.plugin")
-        .get("maximumRequestBodySize", "3mb"),
+      limit: getStudioPluginValue("maximumRequestBodySize", "3mb"),
     }),
   );
 
@@ -425,14 +430,14 @@ const startPluginServer = async (client: LanguageClient | undefined) => {
         .status(413)
         .send(
           `Result is too large. Limit: ${bytesFormat(err.limit)}, Received: ${bytesFormat(err.received)}.\n` +
-            `Increase your available limits by updating the 'luau-lsp.plugin.maximumRequestBodySize' property in VSCode, or by reducing the include list in the Studio Plugin settings`,
+            `Increase your available limits by updating the 'luau-lsp.studioPlugin.maximumRequestBodySize' property in VSCode, or by reducing the include list in the Studio Plugin settings`,
         );
     }
   };
 
   app.use(errorHandler);
 
-  const port = vscode.workspace.getConfiguration("luau-lsp.plugin").get("port");
+  const port = getStudioPluginValue("port", 3667);
   pluginServer = app
     .listen(port, () => {
       vscode.window.showInformationMessage(
@@ -454,7 +459,7 @@ const startPluginServer = async (client: LanguageClient | undefined) => {
             } else if (value === "Change Port Configuration") {
               vscode.commands.executeCommand(
                 "workbench.action.openWorkspaceSettings",
-                "luau-lsp.plugin.port",
+                "luau-lsp.studioPlugin.port",
               );
             }
           });
@@ -524,12 +529,11 @@ export const onActivate = async (
             }
           }
         }
-      } else if (e.affectsConfiguration("luau-lsp.plugin")) {
-        if (
-          vscode.workspace
-            .getConfiguration("luau-lsp.plugin")
-            .get<boolean>("enabled")
-        ) {
+      } else if (
+        e.affectsConfiguration("luau-lsp.studioPlugin") ||
+        e.affectsConfiguration("luau-lsp.plugin")
+      ) {
+        if (getStudioPluginValue("enabled", false)) {
           stopPluginServer(true);
           startPluginServer(platformContext.client);
         } else {
@@ -581,9 +585,7 @@ export const postLanguageServerStart = async (
   platformContext: PlatformContext,
   _: vscode.ExtensionContext,
 ) => {
-  if (
-    vscode.workspace.getConfiguration("luau-lsp.plugin").get<boolean>("enabled")
-  ) {
+  if (getStudioPluginValue("enabled", false)) {
     startPluginServer(platformContext.client);
   }
 };


### PR DESCRIPTION
Renames `luau-lsp.plugin.*` settings to `luau-lsp.studioPlugin.*` to
avoid confusion with the source transform plugins (`luau-lsp.plugins.*`).
The old `luau-lsp.plugin.*` settings are marked as deprecated in the schema
but remain functional via backwards-compatibility fallback logic in the
extension.