### PR TITLE
PhysicalProperties: Add AcousticAbsorption, fix constructor type union in new solver.

### DIFF
--- a/scripts/DataTypes.json
+++ b/scripts/DataTypes.json
@@ -631,17 +631,42 @@
                             "Type": {
                                 "Name": "number"
                             }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "PhysicalProperties"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "new",
+                    "Parameters": [
+                        {
+                            "Name": "density",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Name": "friction",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Name": "elasticity",
+                            "Type": {
+                                "Name": "number"
+                            }
                         },
                         {
                             "Name": "frictionWeight",
-                            "Default": "nil",
                             "Type": {
                                 "Name": "number"
                             }
                         },
                         {
                             "Name": "elasticityWeight",
-                            "Default": "nil",
                             "Type": {
                                 "Name": "number"
                             }
@@ -669,6 +694,24 @@
                         },
                         {
                             "Name": "elasticity",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Name": "frictionWeight",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Name": "elasticityWeight",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Name": "acousticAbsorption",
                             "Type": {
                                 "Name": "number"
                             }
@@ -3082,6 +3125,13 @@
                 {
                     "MemberType": "Property",
                     "Name": "Friction",
+                    "ValueType": {
+                        "Name": "number"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "AcousticAbsorption",
                     "ValueType": {
                         "Name": "number"
                     }


### PR DESCRIPTION
In the new Luau type solver, `PhysicalProperties.new` is currently broken with the following error:

```
TypeError: Calling function ((Enum.Material) -> PhysicalProperties) & ((number, number, number) ->
PhysicalProperties) & ((number, number, number, number?, number?) -> PhysicalProperties) with
argument pack number, number, number is ambiguous.
```

This pull request fixes the error.

<hr/>

I also added the missing AcousticAbsorption property and constructor.