### PR TITLE
Add end-to-end test for tilde expansion in alias string requires

### DIFF
--- a/tests/WorkspaceFileResolver.test.cpp
+++ b/tests/WorkspaceFileResolver.test.cpp
@@ -223,6 +223,30 @@ TEST_CASE_FIXTURE(Fixture, "resolve_alias_supports_self_alias")
     CHECK_EQ(resolveAlias("@self/foo", workspace.fileResolver.defaultConfig, basePath), basePath.resolvePath("foo"));
 }
 
+TEST_CASE_FIXTURE(Fixture, "string_require_resolves_tilde_alias_end_to_end")
+{
+    // This test goes through resolveStringRequire (not resolveAlias directly) to catch
+    // regressions where tilde expansion is broken in the require resolution path.
+    // The .luaurc is written to disk because require resolution reads configs from disk.
+    auto mainPath = tempDir.touch_child("main.luau");
+    tempDir.write_child(".luaurc", R"({
+        "aliases": {
+            "test": "~/definitions"
+        }
+    })");
+
+    auto home = getHomeDirectory();
+    REQUIRE(home);
+
+    Luau::ModuleInfo baseContext{mainPath};
+    auto result = workspace.platform->resolveStringRequire(&baseContext, "@test/module", workspace.limits);
+
+    REQUIRE(result.has_value());
+    // The ~ should be expanded: the resolved path must be under the home directory
+    auto definitionsUri = Uri::file(Luau::FileUtils::joinPaths(*home, "definitions"));
+    CHECK(definitionsUri.isAncestorOf(Uri::file(result->name)));
+}
+
 TEST_CASE_FIXTURE(Fixture, "string require doesn't add file extension if already exists")
 {
     Luau::ModuleInfo baseContext{workspace.fileResolver.getModuleName(workspace.rootUri)};


### PR DESCRIPTION
The existing resolve_alias_supports_tilde_expansion test only calls
resolveAlias() directly and would not catch regressions in the
resolveStringRequire() code path (e.g. if a new Navigator-based
implementation forgets to expand ~ before checking isAbsolutePath).

The new test writes .luaurc to disk (as require resolution reads configs
from disk) and calls resolveStringRequire() with a @alias pointing to
~/definitions, asserting the resolved path is under the home directory.