### PR TITLE
Fix autocomplete-end inserting keywords inside string literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed autocomplete-end incorrectly inserting `then`/`end` inside a string literal when Enter is pressed with the cursor inside a string used as an `if`/`while` condition ([#1453](https://github.com/JohnnyMorganz/luau-lsp/issues/1453))
+
 ## [1.66.0] - 2026-04-11
 
 ### Changed

--- a/src/operations/Completion.cpp
+++ b/src/operations/Completion.cpp
@@ -26,9 +26,7 @@ static bool isBrokenExpr(Luau::AstExpr* expr)
     return err && err->location.begin != err->location.end;
 }
 
-// True when `parent` is an if/while/for/for-in missing its opening keyword (then/do) AND
-// the cursor is in an error node OR the control expression itself is a real broken expression.
-// In those cases we mustn't auto-insert then/do, because the insertion point would land inside
+// Auto-inserting then/do when the control expression is broken would land the keyword inside
 // what the user intended to be a string literal.
 static bool shouldSuppressKeywordInsertion(Luau::AstNode* parent, bool cursorInError)
 {

--- a/src/operations/Completion.cpp
+++ b/src/operations/Completion.cpp
@@ -46,6 +46,15 @@ void WorkspaceFolder::endAutocompletion(const lsp::CompletionParams& params)
     if (ancestry.size() < 2)
         return;
 
+    // When Enter is pressed inside a string literal (e.g. `if "|"`), the string becomes
+    // broken: the remaining quote lands on the cursor's line as an error statement in the AST.
+    // Capture this *before* stripping error nodes from the ancestry.
+    // When Enter is pressed inside a string literal (e.g. `if "|"`), the string becomes
+    // broken: the remaining quote lands on the cursor's line as an error statement in the AST.
+    // Capture this *before* stripping error nodes from the ancestry.
+    bool cursorIsInErrorNode = (ancestry.back()->is<Luau::AstStatError>() || ancestry.back()->is<Luau::AstExprError>()) &&
+        ancestry.back()->location.begin.line == position.line;
+
     // Remove error nodes from end of ancestry chain
     while (ancestry.size() > 0 && (ancestry.back()->is<Luau::AstStatError>() || ancestry.back()->is<Luau::AstExprError>()))
         ancestry.pop_back();
@@ -69,6 +78,25 @@ void WorkspaceFolder::endAutocompletion(const lsp::CompletionParams& params)
         return;
     if (params.position.line - currentNode->location.begin.line > 1)
         return;
+
+    // If the cursor landed inside an error node, the parent statement is likely missing its
+    // opening keyword (then/do) because the condition contained a broken string literal.
+    // Autocompleting in this situation would insert keywords inside the string.
+    if (cursorIsInErrorNode)
+    {
+        auto* parentNodeForCheck = getParentNode(ancestry);
+        if (parentNodeForCheck)
+        {
+            if (auto* statIf = parentNodeForCheck->as<Luau::AstStatIf>(); statIf && !statIf->thenLocation)
+                return;
+            if (auto* statWhile = parentNodeForCheck->as<Luau::AstStatWhile>(); statWhile && !statWhile->hasDo)
+                return;
+            if (auto* statForIn = parentNodeForCheck->as<Luau::AstStatForIn>(); statForIn && !statForIn->hasDo)
+                return;
+            if (auto* statFor = parentNodeForCheck->as<Luau::AstStatFor>(); statFor && !statFor->hasDo)
+                return;
+        }
+    }
 
     auto unclosedBlock = false;
     for (auto it = ancestry.rbegin(); it != ancestry.rend(); ++it)

--- a/src/operations/Completion.cpp
+++ b/src/operations/Completion.cpp
@@ -15,6 +15,45 @@
 
 LUAU_FASTFLAG(LuauSolverV2)
 
+// Distinguishes a real broken expression (e.g. an unterminated `BrokenString` lexeme spans
+// the offending content) from a synthesized "missing expression" error (zero-width location
+// at a token boundary, produced when the parser expected an expression but found nothing).
+static bool isBrokenExpr(Luau::AstExpr* expr)
+{
+    if (!expr)
+        return false;
+    auto* err = expr->as<Luau::AstExprError>();
+    return err && err->location.begin != err->location.end;
+}
+
+// True when `parent` is an if/while/for/for-in missing its opening keyword (then/do) AND
+// the cursor is in an error node OR the control expression itself is a real broken expression.
+// In those cases we mustn't auto-insert then/do, because the insertion point would land inside
+// what the user intended to be a string literal.
+static bool shouldSuppressKeywordInsertion(Luau::AstNode* parent, bool cursorInError)
+{
+    if (auto* statIf = parent->as<Luau::AstStatIf>(); statIf && !statIf->thenLocation)
+        return cursorInError || isBrokenExpr(statIf->condition);
+    if (auto* statWhile = parent->as<Luau::AstStatWhile>(); statWhile && !statWhile->hasDo)
+        return cursorInError || isBrokenExpr(statWhile->condition);
+    if (auto* statForIn = parent->as<Luau::AstStatForIn>(); statForIn && !statForIn->hasDo)
+    {
+        if (cursorInError)
+            return true;
+        for (auto* v : statForIn->values)
+            if (isBrokenExpr(v))
+                return true;
+        return false;
+    }
+    if (auto* statFor = parent->as<Luau::AstStatFor>(); statFor && !statFor->hasDo)
+    {
+        if (cursorInError)
+            return true;
+        return isBrokenExpr(statFor->from) || isBrokenExpr(statFor->to) || (statFor->step && isBrokenExpr(statFor->step));
+    }
+    return false;
+}
+
 static Luau::AstNode* getParentNode(const std::vector<Luau::AstNode*> ancestry)
 {
     if (ancestry.size() < 2)
@@ -78,20 +117,8 @@ void WorkspaceFolder::endAutocompletion(const lsp::CompletionParams& params)
 
     auto parentNode = getParentNode(ancestry);
 
-    // If the cursor landed inside an error node, the parent statement is likely missing its
-    // opening keyword (then/do) because the condition contained a broken string literal.
-    // Autocompleting in this situation would insert keywords inside the string.
-    if (cursorIsInErrorNode && parentNode)
-    {
-        if (auto* statIf = parentNode->as<Luau::AstStatIf>(); statIf && !statIf->thenLocation)
-            return;
-        if (auto* statWhile = parentNode->as<Luau::AstStatWhile>(); statWhile && !statWhile->hasDo)
-            return;
-        if (auto* statForIn = parentNode->as<Luau::AstStatForIn>(); statForIn && !statForIn->hasDo)
-            return;
-        if (auto* statFor = parentNode->as<Luau::AstStatFor>(); statFor && !statFor->hasDo)
-            return;
-    }
+    if (parentNode && shouldSuppressKeywordInsertion(parentNode, cursorIsInErrorNode))
+        return;
 
     auto unclosedBlock = false;
     for (auto it = ancestry.rbegin(); it != ancestry.rend(); ++it)

--- a/src/operations/Completion.cpp
+++ b/src/operations/Completion.cpp
@@ -49,9 +49,6 @@ void WorkspaceFolder::endAutocompletion(const lsp::CompletionParams& params)
     // When Enter is pressed inside a string literal (e.g. `if "|"`), the string becomes
     // broken: the remaining quote lands on the cursor's line as an error statement in the AST.
     // Capture this *before* stripping error nodes from the ancestry.
-    // When Enter is pressed inside a string literal (e.g. `if "|"`), the string becomes
-    // broken: the remaining quote lands on the cursor's line as an error statement in the AST.
-    // Capture this *before* stripping error nodes from the ancestry.
     bool cursorIsInErrorNode = (ancestry.back()->is<Luau::AstStatError>() || ancestry.back()->is<Luau::AstExprError>()) &&
         ancestry.back()->location.begin.line == position.line;
 
@@ -79,23 +76,21 @@ void WorkspaceFolder::endAutocompletion(const lsp::CompletionParams& params)
     if (params.position.line - currentNode->location.begin.line > 1)
         return;
 
+    auto parentNode = getParentNode(ancestry);
+
     // If the cursor landed inside an error node, the parent statement is likely missing its
     // opening keyword (then/do) because the condition contained a broken string literal.
     // Autocompleting in this situation would insert keywords inside the string.
-    if (cursorIsInErrorNode)
+    if (cursorIsInErrorNode && parentNode)
     {
-        auto* parentNodeForCheck = getParentNode(ancestry);
-        if (parentNodeForCheck)
-        {
-            if (auto* statIf = parentNodeForCheck->as<Luau::AstStatIf>(); statIf && !statIf->thenLocation)
-                return;
-            if (auto* statWhile = parentNodeForCheck->as<Luau::AstStatWhile>(); statWhile && !statWhile->hasDo)
-                return;
-            if (auto* statForIn = parentNodeForCheck->as<Luau::AstStatForIn>(); statForIn && !statForIn->hasDo)
-                return;
-            if (auto* statFor = parentNodeForCheck->as<Luau::AstStatFor>(); statFor && !statFor->hasDo)
-                return;
-        }
+        if (auto* statIf = parentNode->as<Luau::AstStatIf>(); statIf && !statIf->thenLocation)
+            return;
+        if (auto* statWhile = parentNode->as<Luau::AstStatWhile>(); statWhile && !statWhile->hasDo)
+            return;
+        if (auto* statForIn = parentNode->as<Luau::AstStatForIn>(); statForIn && !statForIn->hasDo)
+            return;
+        if (auto* statFor = parentNode->as<Luau::AstStatFor>(); statFor && !statFor->hasDo)
+            return;
     }
 
     auto unclosedBlock = false;
@@ -134,7 +129,6 @@ void WorkspaceFolder::endAutocompletion(const lsp::CompletionParams& params)
 
     // TODO: handle `until` for repeat: `until` can be inserted if `hasEnd` in a repeat block is false
 
-    auto parentNode = getParentNode(ancestry);
     if (parentNode)
     {
         if (auto* statIf = parentNode->as<Luau::AstStatIf>(); statIf && statIf->condition && !statIf->thenLocation)

--- a/tests/Autocomplete.test.cpp
+++ b/tests/Autocomplete.test.cpp
@@ -1754,6 +1754,50 @@ TEST_CASE_FIXTURE(Fixture, "no_autocomplete_end_when_cursor_inside_string_in_whi
     REQUIRE_EQ(client->requestQueue.size(), queueSizeBefore);
 }
 
+TEST_CASE_FIXTURE(Fixture, "no_autocomplete_end_when_cursor_inside_backtick_string_in_if_condition")
+{
+    client->globalConfig.completion.autocompleteEnd = true;
+
+    auto [source, marker] = sourceWithMarker("if `\n|`\n");
+
+    auto uri = newDocument("foo.luau", source);
+
+    lsp::CompletionParams params;
+    params.textDocument = lsp::TextDocumentIdentifier{uri};
+    params.position = marker;
+    params.context = lsp::CompletionContext{};
+    params.context->triggerCharacter = "\n";
+
+    auto queueSizeBefore = client->requestQueue.size();
+    workspace.completion(params, nullptr);
+    REQUIRE_EQ(client->requestQueue.size(), queueSizeBefore);
+}
+
+TEST_CASE_FIXTURE(Fixture, "autocomplete_then_when_cursor_after_string_in_if_condition")
+{
+    client->globalConfig.completion.autocompleteEnd = true;
+
+    auto [source, marker] = sourceWithMarker(R"(
+        if ""
+        |
+    )");
+
+    auto uri = newDocument("foo.luau", source);
+
+    lsp::CompletionParams params;
+    params.textDocument = lsp::TextDocumentIdentifier{uri};
+    params.position = marker;
+    params.context = lsp::CompletionContext{};
+    params.context->triggerCharacter = "\n";
+
+    auto result = workspace.completion(params, nullptr);
+    auto edits = requireEndAutocompletionEdits(client.get(), uri);
+    REQUIRE_EQ(edits.size(), 2);
+    CHECK_EQ(edits[0].newText, " then");
+    CHECK_EQ(edits[1].range, lsp::Range{{marker.line + 1, 0}, {marker.line + 1, 0}});
+    CHECK_EQ(edits[1].newText, "        end\n");
+}
+
 TEST_CASE_FIXTURE(Fixture, "dont_mark_type_as_function_kind_when_autocompleting_in_type_context")
 {
     auto [source, marker] = sourceWithMarker(R"(

--- a/tests/Autocomplete.test.cpp
+++ b/tests/Autocomplete.test.cpp
@@ -1701,8 +1701,6 @@ TEST_CASE_FIXTURE(Fixture, "no_autocomplete_end_when_cursor_inside_double_quoted
 {
     client->globalConfig.completion.autocompleteEnd = true;
 
-    // Simulate pressing Enter while cursor is inside a double-quoted string: if "|"
-    // After Enter the document is split across two lines with cursor at start of line 1
     auto [source, marker] = sourceWithMarker("if \"\n|\"\n");
 
     auto uri = newDocument("foo.luau", source);
@@ -1715,7 +1713,6 @@ TEST_CASE_FIXTURE(Fixture, "no_autocomplete_end_when_cursor_inside_double_quoted
 
     auto queueSizeBefore = client->requestQueue.size();
     workspace.completion(params, nullptr);
-    // No workspace/applyEdit should have been added (no 'then' or 'end' should be inserted)
     REQUIRE_EQ(client->requestQueue.size(), queueSizeBefore);
 }
 
@@ -1723,7 +1720,6 @@ TEST_CASE_FIXTURE(Fixture, "no_autocomplete_end_when_cursor_inside_single_quoted
 {
     client->globalConfig.completion.autocompleteEnd = true;
 
-    // Simulate pressing Enter while cursor is inside a single-quoted string: if '|'
     auto [source, marker] = sourceWithMarker("if '\n|'\n");
 
     auto uri = newDocument("foo.luau", source);
@@ -1743,7 +1739,6 @@ TEST_CASE_FIXTURE(Fixture, "no_autocomplete_end_when_cursor_inside_string_in_whi
 {
     client->globalConfig.completion.autocompleteEnd = true;
 
-    // Simulate pressing Enter while cursor is inside a string in a while condition: while "|" do
     auto [source, marker] = sourceWithMarker("while \"\n|\"\n");
 
     auto uri = newDocument("foo.luau", source);

--- a/tests/Autocomplete.test.cpp
+++ b/tests/Autocomplete.test.cpp
@@ -1773,6 +1773,63 @@ TEST_CASE_FIXTURE(Fixture, "no_autocomplete_end_when_cursor_inside_backtick_stri
     REQUIRE_EQ(client->requestQueue.size(), queueSizeBefore);
 }
 
+TEST_CASE_FIXTURE(Fixture, "no_autocomplete_end_when_cursor_inside_string_in_for_in_condition")
+{
+    client->globalConfig.completion.autocompleteEnd = true;
+
+    auto [source, marker] = sourceWithMarker("for i in \"\n|\"\n");
+
+    auto uri = newDocument("foo.luau", source);
+
+    lsp::CompletionParams params;
+    params.textDocument = lsp::TextDocumentIdentifier{uri};
+    params.position = marker;
+    params.context = lsp::CompletionContext{};
+    params.context->triggerCharacter = "\n";
+
+    auto queueSizeBefore = client->requestQueue.size();
+    workspace.completion(params, nullptr);
+    REQUIRE_EQ(client->requestQueue.size(), queueSizeBefore);
+}
+
+TEST_CASE_FIXTURE(Fixture, "no_autocomplete_end_when_cursor_inside_string_in_complex_if_condition")
+{
+    client->globalConfig.completion.autocompleteEnd = true;
+
+    auto [source, marker] = sourceWithMarker("if x == \"\n|\"\n");
+
+    auto uri = newDocument("foo.luau", source);
+
+    lsp::CompletionParams params;
+    params.textDocument = lsp::TextDocumentIdentifier{uri};
+    params.position = marker;
+    params.context = lsp::CompletionContext{};
+    params.context->triggerCharacter = "\n";
+
+    auto queueSizeBefore = client->requestQueue.size();
+    workspace.completion(params, nullptr);
+    REQUIRE_EQ(client->requestQueue.size(), queueSizeBefore);
+}
+
+TEST_CASE_FIXTURE(Fixture, "no_autocomplete_end_when_cursor_after_unclosed_string_in_if_condition")
+{
+    client->globalConfig.completion.autocompleteEnd = true;
+
+    auto [source, marker] = sourceWithMarker("if \"\n|\n");
+
+    auto uri = newDocument("foo.luau", source);
+
+    lsp::CompletionParams params;
+    params.textDocument = lsp::TextDocumentIdentifier{uri};
+    params.position = marker;
+    params.context = lsp::CompletionContext{};
+    params.context->triggerCharacter = "\n";
+
+    auto queueSizeBefore = client->requestQueue.size();
+    workspace.completion(params, nullptr);
+    REQUIRE_EQ(client->requestQueue.size(), queueSizeBefore);
+}
+
 TEST_CASE_FIXTURE(Fixture, "autocomplete_then_when_cursor_after_string_in_if_condition")
 {
     client->globalConfig.completion.autocompleteEnd = true;

--- a/tests/Autocomplete.test.cpp
+++ b/tests/Autocomplete.test.cpp
@@ -1697,6 +1697,68 @@ TEST_CASE_FIXTURE(Fixture, "autocomplete_do_in_numeric_for_loop_missing_step")
     CHECK_EQ(edits[1].newText, "        end\n");
 }
 
+TEST_CASE_FIXTURE(Fixture, "no_autocomplete_end_when_cursor_inside_double_quoted_string_in_if_condition")
+{
+    client->globalConfig.completion.autocompleteEnd = true;
+
+    // Simulate pressing Enter while cursor is inside a double-quoted string: if "|"
+    // After Enter the document is split across two lines with cursor at start of line 1
+    auto [source, marker] = sourceWithMarker("if \"\n|\"\n");
+
+    auto uri = newDocument("foo.luau", source);
+
+    lsp::CompletionParams params;
+    params.textDocument = lsp::TextDocumentIdentifier{uri};
+    params.position = marker;
+    params.context = lsp::CompletionContext{};
+    params.context->triggerCharacter = "\n";
+
+    auto queueSizeBefore = client->requestQueue.size();
+    workspace.completion(params, nullptr);
+    // No workspace/applyEdit should have been added (no 'then' or 'end' should be inserted)
+    REQUIRE_EQ(client->requestQueue.size(), queueSizeBefore);
+}
+
+TEST_CASE_FIXTURE(Fixture, "no_autocomplete_end_when_cursor_inside_single_quoted_string_in_if_condition")
+{
+    client->globalConfig.completion.autocompleteEnd = true;
+
+    // Simulate pressing Enter while cursor is inside a single-quoted string: if '|'
+    auto [source, marker] = sourceWithMarker("if '\n|'\n");
+
+    auto uri = newDocument("foo.luau", source);
+
+    lsp::CompletionParams params;
+    params.textDocument = lsp::TextDocumentIdentifier{uri};
+    params.position = marker;
+    params.context = lsp::CompletionContext{};
+    params.context->triggerCharacter = "\n";
+
+    auto queueSizeBefore = client->requestQueue.size();
+    workspace.completion(params, nullptr);
+    REQUIRE_EQ(client->requestQueue.size(), queueSizeBefore);
+}
+
+TEST_CASE_FIXTURE(Fixture, "no_autocomplete_end_when_cursor_inside_string_in_while_condition")
+{
+    client->globalConfig.completion.autocompleteEnd = true;
+
+    // Simulate pressing Enter while cursor is inside a string in a while condition: while "|" do
+    auto [source, marker] = sourceWithMarker("while \"\n|\"\n");
+
+    auto uri = newDocument("foo.luau", source);
+
+    lsp::CompletionParams params;
+    params.textDocument = lsp::TextDocumentIdentifier{uri};
+    params.position = marker;
+    params.context = lsp::CompletionContext{};
+    params.context->triggerCharacter = "\n";
+
+    auto queueSizeBefore = client->requestQueue.size();
+    workspace.completion(params, nullptr);
+    REQUIRE_EQ(client->requestQueue.size(), queueSizeBefore);
+}
+
 TEST_CASE_FIXTURE(Fixture, "dont_mark_type_as_function_kind_when_autocompleting_in_type_context")
 {
     auto [source, marker] = sourceWithMarker(R"(


### PR DESCRIPTION
When the cursor was inside a string used as an if/while condition and
Enter was pressed, the autocomplete-end feature incorrectly inserted
`then` and `end` inside the string (e.g. `if "` became `if " then\nend"`).

The fix detects when the cursor lands inside an AST error node (which
happens because pressing Enter inside a string breaks the string token,
leaving the closing quote on the new line as a malformed statement). If
the error node is on the cursor's line AND the ancestor statement is
missing its opening keyword (then/do), we bail out early without
applying any edits.

Fixes #1453