### PR TITLE
Support chained aliases in .luaurc config files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Support chained aliases in `.luaurc` (e.g., an alias whose value references another `@alias`)
+
 ## [1.66.0] - 2026-04-11
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- Support chained aliases in `.luaurc` (e.g., an alias whose value references another `@alias`)
+- Support chained aliases in `.luaurc` (e.g., an alias whose value references another `@alias`) ([#1458](https://github.com/JohnnyMorganz/luau-lsp/issues/1458))
 
 ## [1.66.0] - 2026-04-11
 

--- a/src/platform/LSPPlatform.cpp
+++ b/src/platform/LSPPlatform.cpp
@@ -53,8 +53,12 @@ Uri resolveAliasLocation(const Luau::Config::AliasInfo& aliasInfo)
     return Uri::file(aliasInfo.configLocation).resolvePath(resolvePath(aliasInfo.value));
 }
 
-std::optional<Uri> resolveAlias(const std::string& path, const Luau::Config& config, const Uri& from)
+static std::optional<Uri> resolveAliasWithDepth(
+    const std::string& path, const Luau::Config& config, const Uri& from, int depth)
 {
+    if (depth > 16)
+        return std::nullopt;
+
     if (path.size() < 1 || path[0] != '@')
         return std::nullopt;
 
@@ -86,7 +90,20 @@ std::optional<Uri> resolveAlias(const std::string& path, const Luau::Config& con
 
     Uri resolvedUri;
     if (auto aliasInfo = config.aliases.find(potentialAlias))
-        resolvedUri = resolveAliasLocation(*aliasInfo);
+    {
+        // If the alias value itself starts with '@', it's a chained alias - resolve recursively
+        if (!aliasInfo->value.empty() && aliasInfo->value[0] == '@')
+        {
+            auto chainedResolved = resolveAliasWithDepth(aliasInfo->value, config, from, depth + 1);
+            if (!chainedResolved)
+                return std::nullopt;
+            resolvedUri = *chainedResolved;
+        }
+        else
+        {
+            resolvedUri = resolveAliasLocation(*aliasInfo);
+        }
+    }
     else if (potentialAlias == "self")
         resolvedUri = from;
     else
@@ -103,6 +120,11 @@ std::optional<Uri> resolveAlias(const std::string& path, const Luau::Config& con
         return resolvedUri;
     else
         return resolvedUri.resolvePath(remainder);
+}
+
+std::optional<Uri> resolveAlias(const std::string& path, const Luau::Config& config, const Uri& from)
+{
+    return resolveAliasWithDepth(path, config, from, 0);
 }
 
 std::optional<Luau::ModuleInfo> LSPPlatform::resolveStringRequire(

--- a/src/platform/LSPPlatform.cpp
+++ b/src/platform/LSPPlatform.cpp
@@ -53,12 +53,9 @@ Uri resolveAliasLocation(const Luau::Config::AliasInfo& aliasInfo)
     return Uri::file(aliasInfo.configLocation).resolvePath(resolvePath(aliasInfo.value));
 }
 
-static std::optional<Uri> resolveAliasWithDepth(
-    const std::string& path, const Luau::Config& config, const Uri& from, int depth)
+static std::optional<Uri> resolveAliasWithCycleCheck(
+    const std::string& path, const Luau::Config& config, const Uri& from, std::unordered_set<std::string>& visited)
 {
-    if (depth > 16)
-        return std::nullopt;
-
     if (path.size() < 1 || path[0] != '@')
         return std::nullopt;
 
@@ -94,7 +91,11 @@ static std::optional<Uri> resolveAliasWithDepth(
         // If the alias value itself starts with '@', it's a chained alias - resolve recursively
         if (!aliasInfo->value.empty() && aliasInfo->value[0] == '@')
         {
-            auto chainedResolved = resolveAliasWithDepth(aliasInfo->value, config, from, depth + 1);
+            // Detect cycles: if we've already visited this alias, stop
+            if (!visited.insert(potentialAlias).second)
+                return std::nullopt;
+
+            auto chainedResolved = resolveAliasWithCycleCheck(aliasInfo->value, config, from, visited);
             if (!chainedResolved)
                 return std::nullopt;
             resolvedUri = *chainedResolved;
@@ -124,7 +125,8 @@ static std::optional<Uri> resolveAliasWithDepth(
 
 std::optional<Uri> resolveAlias(const std::string& path, const Luau::Config& config, const Uri& from)
 {
-    return resolveAliasWithDepth(path, config, from, 0);
+    std::unordered_set<std::string> visited;
+    return resolveAliasWithCycleCheck(path, config, from, visited);
 }
 
 std::optional<Luau::ModuleInfo> LSPPlatform::resolveStringRequire(

--- a/src/platform/LSPPlatform.cpp
+++ b/src/platform/LSPPlatform.cpp
@@ -7,6 +7,7 @@
 #include "Platform/StringRequireSuggester.hpp"
 #include "Platform/StringRequireAutoImporter.hpp"
 
+#include "Luau/StringUtils.h"
 #include "Luau/TimeTrace.h"
 #include <memory>
 #include <unordered_set>
@@ -88,10 +89,8 @@ static std::optional<Uri> resolveAliasWithCycleCheck(
     Uri resolvedUri;
     if (auto aliasInfo = config.aliases.find(potentialAlias))
     {
-        // If the alias value itself starts with '@', it's a chained alias - resolve recursively
-        if (!aliasInfo->value.empty() && aliasInfo->value[0] == '@')
+        if (Luau::startsWith(aliasInfo->value, "@"))
         {
-            // Detect cycles: if we've already visited this alias, stop
             if (!visited.insert(potentialAlias).second)
                 return std::nullopt;
 

--- a/tests/WorkspaceFileResolver.test.cpp
+++ b/tests/WorkspaceFileResolver.test.cpp
@@ -242,6 +242,37 @@ TEST_CASE_FIXTURE(Fixture, "resolve_alias_supports_chained_aliases")
     CHECK_EQ(resolveAlias("@transform", workspace.fileResolver.defaultConfig, {}), stdBase.resolvePath("commands/transform/types"));
 }
 
+TEST_CASE_FIXTURE(Fixture, "resolve_alias_resolves_chained_alias_with_intermediate_path")
+{
+    loadLuaurc(R"(
+    {
+        "aliases": {
+            "a": "@b/sub",
+            "b": "libs"
+        }
+    }
+    )");
+
+    CHECK_EQ(resolveAlias("@a", workspace.fileResolver.defaultConfig, {}), workspace.fileResolver.rootUri.resolvePath("libs/sub"));
+    CHECK_EQ(resolveAlias("@a/file", workspace.fileResolver.defaultConfig, {}), workspace.fileResolver.rootUri.resolvePath("libs/sub/file"));
+}
+
+TEST_CASE_FIXTURE(Fixture, "resolve_alias_resolves_longer_alias_chain")
+{
+    loadLuaurc(R"(
+    {
+        "aliases": {
+            "a": "@b",
+            "b": "@c",
+            "c": "deep"
+        }
+    }
+    )");
+
+    CHECK_EQ(resolveAlias("@a", workspace.fileResolver.defaultConfig, {}), workspace.fileResolver.rootUri.resolvePath("deep"));
+    CHECK_EQ(resolveAlias("@a/file", workspace.fileResolver.defaultConfig, {}), workspace.fileResolver.rootUri.resolvePath("deep/file"));
+}
+
 TEST_CASE_FIXTURE(Fixture, "resolve_alias_returns_nullopt_on_cyclic_aliases")
 {
     loadLuaurc(R"(
@@ -255,6 +286,40 @@ TEST_CASE_FIXTURE(Fixture, "resolve_alias_returns_nullopt_on_cyclic_aliases")
     )");
 
     CHECK_EQ(resolveAlias("@a", workspace.fileResolver.defaultConfig, {}), std::nullopt);
+}
+
+TEST_CASE_FIXTURE(Fixture, "resolve_alias_returns_nullopt_on_longer_alias_cycle")
+{
+    loadLuaurc(R"(
+    {
+        "aliases": {
+            "a": "@b",
+            "b": "@c",
+            "c": "@a"
+        }
+    }
+    )");
+
+    CHECK_EQ(resolveAlias("@a", workspace.fileResolver.defaultConfig, {}), std::nullopt);
+}
+
+TEST_CASE_FIXTURE(Fixture, "string_require_resolves_chained_alias_end_to_end")
+{
+    auto mainPath = tempDir.touch_child("main.luau");
+    tempDir.touch_child("packages/utils/init.luau");
+    tempDir.write_child(".luaurc", R"({
+        "aliases": {
+            "utils": "@libs/utils",
+            "libs": "./packages"
+        }
+    })");
+
+    Luau::ModuleInfo baseContext{mainPath};
+    auto result = workspace.platform->resolveStringRequire(&baseContext, "@utils", workspace.limits);
+
+    REQUIRE(result.has_value());
+    auto packagesUri = workspace.fileResolver.rootUri.resolvePath("packages");
+    CHECK(packagesUri.isAncestorOf(Uri::file(result->name)));
 }
 
 TEST_CASE_FIXTURE(Fixture, "string_require_resolves_tilde_alias_end_to_end")

--- a/tests/WorkspaceFileResolver.test.cpp
+++ b/tests/WorkspaceFileResolver.test.cpp
@@ -223,6 +223,25 @@ TEST_CASE_FIXTURE(Fixture, "resolve_alias_supports_self_alias")
     CHECK_EQ(resolveAlias("@self/foo", workspace.fileResolver.defaultConfig, basePath), basePath.resolvePath("foo"));
 }
 
+TEST_CASE_FIXTURE(Fixture, "resolve_alias_supports_chained_aliases")
+{
+    loadLuaurc(R"(
+    {
+        "aliases": {
+            "std": "lute/std/libs",
+            "lint": "@std/commands/lint/types",
+            "transform": "@std/commands/transform/types"
+        }
+    }
+    )");
+
+    auto stdBase = workspace.fileResolver.rootUri.resolvePath("lute/std/libs");
+
+    CHECK_EQ(resolveAlias("@lint", workspace.fileResolver.defaultConfig, {}), stdBase.resolvePath("commands/lint/types"));
+    CHECK_EQ(resolveAlias("@lint/foo", workspace.fileResolver.defaultConfig, {}), stdBase.resolvePath("commands/lint/types/foo"));
+    CHECK_EQ(resolveAlias("@transform", workspace.fileResolver.defaultConfig, {}), stdBase.resolvePath("commands/transform/types"));
+}
+
 TEST_CASE_FIXTURE(Fixture, "string_require_resolves_tilde_alias_end_to_end")
 {
     // This test goes through resolveStringRequire (not resolveAlias directly) to catch

--- a/tests/WorkspaceFileResolver.test.cpp
+++ b/tests/WorkspaceFileResolver.test.cpp
@@ -242,6 +242,21 @@ TEST_CASE_FIXTURE(Fixture, "resolve_alias_supports_chained_aliases")
     CHECK_EQ(resolveAlias("@transform", workspace.fileResolver.defaultConfig, {}), stdBase.resolvePath("commands/transform/types"));
 }
 
+TEST_CASE_FIXTURE(Fixture, "resolve_alias_returns_nullopt_on_cyclic_aliases")
+{
+    loadLuaurc(R"(
+    {
+        "aliases": {
+            "a": "@b",
+            "b": "@c",
+            "c": "@a"
+        }
+    }
+    )");
+
+    CHECK_EQ(resolveAlias("@a", workspace.fileResolver.defaultConfig, {}), std::nullopt);
+}
+
 TEST_CASE_FIXTURE(Fixture, "string_require_resolves_tilde_alias_end_to_end")
 {
     // This test goes through resolveStringRequire (not resolveAlias directly) to catch


### PR DESCRIPTION
When an alias value itself starts with `@`, recursively resolve it through the alias chain. Cycle detection (via a visited set) prevents infinite loops from circular alias definitions, matching the behaviour of Luau's own require implementation.

Fixes #1458