### PR TITLE
Implement chained alias support

### DIFF
--- a/src/platform/LSPPlatform.cpp
+++ b/src/platform/LSPPlatform.cpp
@@ -53,7 +53,8 @@ Uri resolveAliasLocation(const Luau::Config::AliasInfo& aliasInfo)
     return Uri::file(aliasInfo.configLocation).resolvePath(resolvePath(aliasInfo.value));
 }
 
-std::optional<Uri> resolveAlias(const std::string& path, const Luau::Config& config, const Uri& from)
+static std::optional<Uri> resolveAliasImpl(
+    const std::string& path, const Luau::Config& config, const Uri& from, std::unordered_set<std::string>& seen)
 {
     if (path.size() < 1 || path[0] != '@')
         return std::nullopt;
@@ -84,25 +85,53 @@ std::optional<Uri> resolveAlias(const std::string& path, const Luau::Config& con
             return ('A' <= c && c <= 'Z') ? (c + ('a' - 'A')) : c;
         });
 
-    Uri resolvedUri;
-    if (auto aliasInfo = config.aliases.find(potentialAlias))
-        resolvedUri = resolveAliasLocation(*aliasInfo);
-    else if (potentialAlias == "self")
-        resolvedUri = from;
-    else
-        // TODO: report error: "@" + potentialAlias + " is not a valid alias"
-        return std::nullopt;
-
     auto remainder = path.substr(potentialAlias.size() + 1);
 
     // If remainder begins with a '/' character, we need to trim it off before it gets mistaken for an
     // absolute path
     remainder.erase(0, remainder.find_first_not_of("/\\"));
 
+    if (potentialAlias == "self")
+    {
+        if (remainder.empty())
+            return from;
+        return from.resolvePath(remainder);
+    }
+
+    auto aliasInfo = config.aliases.find(potentialAlias);
+    if (!aliasInfo)
+    {
+        // TODO: report error: "@" + potentialAlias + " is not a valid alias"
+        return std::nullopt;
+    }
+
+    // If the alias value itself starts with '@', it is a chained alias.
+    if (!aliasInfo->value.empty() && aliasInfo->value[0] == '@')
+    {
+        // TODO: report error: detected alias cycle (@alias1 -> @alias2 -> @alias1)
+        if (seen.count(potentialAlias))
+            return std::nullopt;
+        seen.insert(potentialAlias);
+
+        std::string chainedPath = aliasInfo->value;
+        if (!remainder.empty())
+            chainedPath += "/" + remainder;
+
+        return resolveAliasImpl(chainedPath, config, from, seen);
+    }
+
+    Uri resolvedUri = resolveAliasLocation(*aliasInfo);
+
     if (remainder.empty())
         return resolvedUri;
     else
         return resolvedUri.resolvePath(remainder);
+}
+
+std::optional<Uri> resolveAlias(const std::string& path, const Luau::Config& config, const Uri& from)
+{
+    std::unordered_set<std::string> seen;
+    return resolveAliasImpl(path, config, from, seen);
 }
 
 std::optional<Luau::ModuleInfo> LSPPlatform::resolveStringRequire(

--- a/tests/WorkspaceFileResolver.test.cpp
+++ b/tests/WorkspaceFileResolver.test.cpp
@@ -223,6 +223,100 @@ TEST_CASE_FIXTURE(Fixture, "resolve_alias_supports_self_alias")
     CHECK_EQ(resolveAlias("@self/foo", workspace.fileResolver.defaultConfig, basePath), basePath.resolvePath("foo"));
 }
 
+TEST_CASE_FIXTURE(Fixture, "resolve_alias_resolves_chained_alias")
+{
+    loadLuaurc(R"(
+    {
+        "aliases": {
+            "a": "@b",
+            "b": "folder"
+        }
+    }
+    )");
+
+    CHECK_EQ(resolveAlias("@a", workspace.fileResolver.defaultConfig, {}), workspace.fileResolver.rootUri.resolvePath("folder"));
+    CHECK_EQ(resolveAlias("@a/file", workspace.fileResolver.defaultConfig, {}), workspace.fileResolver.rootUri.resolvePath("folder/file"));
+}
+
+TEST_CASE_FIXTURE(Fixture, "resolve_alias_resolves_chained_alias_with_intermediate_path")
+{
+    loadLuaurc(R"(
+    {
+        "aliases": {
+            "a": "@b/sub",
+            "b": "libs"
+        }
+    }
+    )");
+
+    CHECK_EQ(resolveAlias("@a", workspace.fileResolver.defaultConfig, {}), workspace.fileResolver.rootUri.resolvePath("libs/sub"));
+    CHECK_EQ(resolveAlias("@a/file", workspace.fileResolver.defaultConfig, {}), workspace.fileResolver.rootUri.resolvePath("libs/sub/file"));
+}
+
+TEST_CASE_FIXTURE(Fixture, "resolve_alias_resolves_longer_alias_chain")
+{
+    loadLuaurc(R"(
+    {
+        "aliases": {
+            "a": "@b",
+            "b": "@c",
+            "c": "deep"
+        }
+    }
+    )");
+
+    CHECK_EQ(resolveAlias("@a", workspace.fileResolver.defaultConfig, {}), workspace.fileResolver.rootUri.resolvePath("deep"));
+    CHECK_EQ(resolveAlias("@a/file", workspace.fileResolver.defaultConfig, {}), workspace.fileResolver.rootUri.resolvePath("deep/file"));
+}
+
+TEST_CASE_FIXTURE(Fixture, "resolve_alias_returns_nullopt_on_alias_cycle")
+{
+    loadLuaurc(R"(
+    {
+        "aliases": {
+            "a": "@b",
+            "b": "@a"
+        }
+    }
+    )");
+
+    CHECK_EQ(resolveAlias("@a", workspace.fileResolver.defaultConfig, {}), std::nullopt);
+}
+
+TEST_CASE_FIXTURE(Fixture, "resolve_alias_returns_nullopt_on_longer_alias_cycle")
+{
+    loadLuaurc(R"(
+    {
+        "aliases": {
+            "a": "@b",
+            "b": "@c",
+            "c": "@a"
+        }
+    }
+    )");
+
+    CHECK_EQ(resolveAlias("@a", workspace.fileResolver.defaultConfig, {}), std::nullopt);
+}
+
+TEST_CASE_FIXTURE(Fixture, "string_require_resolves_chained_alias_end_to_end")
+{
+    auto mainPath = tempDir.touch_child("main.luau");
+    tempDir.touch_child("packages/utils/init.luau");
+    tempDir.write_child(".luaurc", R"({
+        "aliases": {
+            "utils": "@libs/utils",
+            "libs": "./packages"
+        }
+    })");
+
+    Luau::ModuleInfo baseContext{mainPath};
+    auto result = workspace.platform->resolveStringRequire(&baseContext, "@utils", workspace.limits);
+
+    REQUIRE(result.has_value());
+    auto packagesUri = workspace.fileResolver.rootUri.resolvePath("packages");
+    CHECK(packagesUri.isAncestorOf(Uri::file(result->name)));
+}
+
 TEST_CASE_FIXTURE(Fixture, "string_require_resolves_tilde_alias_end_to_end")
 {
     // This test goes through resolveStringRequire (not resolveAlias directly) to catch


### PR DESCRIPTION
Implements this amendment to the require-by-string aliases RFC: https://github.com/luau-lang/rfcs/pull/145. Aliases in a given configuration can reference each other, and cycles are handled gracefully with a `std::nullopt` result.

I noticed that there's an existing TODO for reporting alias resolution errors, so I left an additional TODO for reporting alias cycle errors. I'm assuming whatever reporting mechanism is used to solve the first problem can easily be used for the second problem as well.