### PR TITLE
Fix @game requires not resolving in luau-lsp analyze

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- `@game` requires now resolve correctly when using `luau-lsp analyze` ([#1473](https://github.com/JohnnyMorganz/luau-lsp/issues/1473))
+- String requires (including `@game` aliases and relative requires between DataModel siblings with non-mirrored filesystem layouts) now resolve correctly when using `luau-lsp analyze` with a sourcemap ([#1473](https://github.com/JohnnyMorganz/luau-lsp/issues/1473))
 
 ## [1.66.1] - 2026-04-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `@game` requires now resolve correctly when using `luau-lsp analyze` ([#1473](https://github.com/JohnnyMorganz/luau-lsp/issues/1473))
+
 ## [1.66.1] - 2026-04-27
 
 ### Changed

--- a/src/AnalyzeCli.cpp
+++ b/src/AnalyzeCli.cpp
@@ -17,12 +17,6 @@
 LUAU_FASTFLAG(DebugLuauTimeTracing)
 LUAU_FASTFLAG(LuauSolverV2)
 
-enum class ReportFormat
-{
-    Default,
-    Luacheck,
-    Gnu,
-};
 
 static void report(ReportFormat format, const char* name, const Luau::Location& loc, const char* type, const char* message)
 {
@@ -84,9 +78,9 @@ static void reportWarning(ReportFormat format, const char* name, const Luau::Lin
     report(format, name, warning.location, Luau::LintWarning::getName(warning.code), warning.text.c_str());
 }
 
-static bool analyzeFile(WorkspaceFolder& workspace, const std::string& path, ReportFormat format, bool annotate)
+bool analyzeFile(WorkspaceFolder& workspace, const std::string& path, ReportFormat format, bool annotate)
 {
-    Luau::ModuleName name = path;
+    Luau::ModuleName name = workspace.fileResolver.getModuleName(Uri::file(path));
 
     // Use checkStrict when annotating to retain type graphs needed by attachTypeData
     Luau::CheckResult cr = annotate ? workspace.checkStrict(name, /* cancellationToken= */ nullptr, /* forAutocomplete= */ false)

--- a/src/include/Analyze/AnalyzeCli.hpp
+++ b/src/include/Analyze/AnalyzeCli.hpp
@@ -12,6 +12,13 @@ class WorkspaceFolder;
 
 std::unordered_map<std::string, std::string> processDefinitionsFilePaths(const argparse::ArgumentParser& program);
 
+enum class ReportFormat
+{
+    Default,
+    Luacheck,
+    Gnu,
+};
+
 struct FilePathInformation
 {
     Uri uri;
@@ -20,6 +27,7 @@ struct FilePathInformation
 
 FilePathInformation getFilePath(const WorkspaceFileResolver* fileResolver, const std::string& moduleName);
 
+bool analyzeFile(WorkspaceFolder& workspace, const std::string& path, ReportFormat format, bool annotate);
 std::vector<std::string> getFilesToAnalyze(const std::vector<std::string>& paths, WorkspaceFolder* workspace = nullptr);
 void applySettings(const std::string& settingsContents, CliClient& client);
 int startAnalyze(const argparse::ArgumentParser& program);

--- a/tests/AnalyzeCli.test.cpp
+++ b/tests/AnalyzeCli.test.cpp
@@ -304,4 +304,104 @@ end
     CHECK(annotated.find("number") != std::string::npos);
 }
 
+TEST_CASE("analyze_resolves_game_requires_with_sourcemap")
+{
+    // Regression test for https://github.com/JohnnyMorganz/luau-lsp/issues/1473
+    // analyzeFile used to pass the raw filesystem path as the module name, which bypassed
+    // RobloxPlatform's sourcemap-aware require resolution. @game requires and relative
+    // requires between DataModel siblings with non-mirrored filesystem layouts produced
+    // UnknownRequire errors.
+    TempDir t("analyze_game_requires");
+
+    // ServerModule is at src/server/ServerModule.luau but mapped to
+    // game/ServerScriptService/ServerModule. Util is at packages/util/Util.luau but
+    // mapped to game/ReplicatedStorage/Util. Completely different filesystem locations.
+    t.write_child("sourcemap.json", R"({
+        "name": "Game",
+        "className": "DataModel",
+        "children": [
+            {
+                "name": "ReplicatedStorage",
+                "className": "ReplicatedStorage",
+                "children": [
+                    {
+                        "name": "Util",
+                        "className": "ModuleScript",
+                        "filePaths": ["packages/util/Util.luau"]
+                    }
+                ]
+            },
+            {
+                "name": "ServerScriptService",
+                "className": "ServerScriptService",
+                "children": [
+                    {
+                        "name": "ServerModule",
+                        "className": "ModuleScript",
+                        "filePaths": ["src/server/ServerModule.luau"]
+                    }
+                ]
+            }
+        ]
+    })");
+    t.write_child("packages/util/Util.luau", "return { value = 42 }");
+    t.write_child("src/server/ServerModule.luau", "local _ = require('@game/ReplicatedStorage/Util')");
+
+    CliClient client;
+    initCliClient(client);
+    client.globalConfig.platform.type = LSPPlatformConfig::Roblox;
+    client.globalConfig.sourcemap.enabled = true;
+    client.globalConfig.sourcemap.sourcemapFile = t.path() + "/sourcemap.json";
+
+    WorkspaceFolder workspace(&client, "CLI", Uri::file(t.path()), std::nullopt);
+    setupCliWorkspace(client, workspace);
+
+    auto serverModulePath = Uri::file(t.path() + "/src/server/ServerModule.luau").fsPath();
+    CHECK(analyzeFile(workspace, serverModulePath, ReportFormat::Default, false));
+}
+
+TEST_CASE("analyze_resolves_non_mirrored_relative_requires_with_sourcemap")
+{
+    // Variant of the above: relative require between DataModel siblings whose
+    // filesystem paths are non-mirrored (packages/core/ vs packages/combat/).
+    TempDir t("analyze_non_mirrored_relative");
+
+    t.write_child("sourcemap.json", R"({
+        "name": "Game",
+        "className": "DataModel",
+        "children": [
+            {
+                "name": "ReplicatedStorage",
+                "className": "ReplicatedStorage",
+                "children": [
+                    {
+                        "name": "ModuleA",
+                        "className": "ModuleScript",
+                        "filePaths": ["packages/core/ModuleA.luau"]
+                    },
+                    {
+                        "name": "ModuleB",
+                        "className": "ModuleScript",
+                        "filePaths": ["packages/combat/ModuleB.luau"]
+                    }
+                ]
+            }
+        ]
+    })");
+    t.write_child("packages/core/ModuleA.luau", "local _ = require('./ModuleB')");
+    t.write_child("packages/combat/ModuleB.luau", "return {}");
+
+    CliClient client;
+    initCliClient(client);
+    client.globalConfig.platform.type = LSPPlatformConfig::Roblox;
+    client.globalConfig.sourcemap.enabled = true;
+    client.globalConfig.sourcemap.sourcemapFile = t.path() + "/sourcemap.json";
+
+    WorkspaceFolder workspace(&client, "CLI", Uri::file(t.path()), std::nullopt);
+    setupCliWorkspace(client, workspace);
+
+    auto moduleAPath = Uri::file(t.path() + "/packages/core/ModuleA.luau").fsPath();
+    CHECK(analyzeFile(workspace, moduleAPath, ReportFormat::Default, false));
+}
+
 TEST_SUITE_END();

--- a/tests/AnalyzeCli.test.cpp
+++ b/tests/AnalyzeCli.test.cpp
@@ -45,6 +45,14 @@ static void setupCliWorkspace(CliClient& client, WorkspaceFolder& workspace)
     workspace.isReady = true;
 }
 
+static void initRobloxCliClient(CliClient& client)
+{
+    initCliClient(client);
+    client.globalConfig.platform.type = LSPPlatformConfig::Roblox;
+    client.globalConfig.sourcemap.enabled = true;
+    client.globalConfig.sourcemap.sourcemapFile = "sourcemap.json";
+}
+
 TEST_CASE("getFilesToAnalyze")
 {
     TempDir t("analyze_cli_get_files_to_analyze");
@@ -262,11 +270,7 @@ TEST_CASE("sourcemap_loaded_through_workspace_configuration")
     t.write_child("src/Module.luau", "return {}");
 
     CliClient client;
-    initCliClient(client);
-    client.globalConfig.platform.type = LSPPlatformConfig::Roblox;
-    client.globalConfig.sourcemap.enabled = true;
-    client.globalConfig.sourcemap.sourcemapFile = "sourcemap.json";
-
+    initRobloxCliClient(client);
     WorkspaceFolder workspace(&client, "CLI", Uri::file(t.path()), std::nullopt);
     setupCliWorkspace(client, workspace);
 
@@ -307,15 +311,10 @@ end
 TEST_CASE("analyze_resolves_game_requires_with_sourcemap")
 {
     // Regression test for https://github.com/JohnnyMorganz/luau-lsp/issues/1473
-    // analyzeFile used to pass the raw filesystem path as the module name, which bypassed
-    // RobloxPlatform's sourcemap-aware require resolution. @game requires and relative
-    // requires between DataModel siblings with non-mirrored filesystem layouts produced
-    // UnknownRequire errors.
     TempDir t("analyze_game_requires");
 
-    // ServerModule is at src/server/ServerModule.luau but mapped to
-    // game/ServerScriptService/ServerModule. Util is at packages/util/Util.luau but
-    // mapped to game/ReplicatedStorage/Util. Completely different filesystem locations.
+    // ServerModule and Util are at completely different filesystem locations but are
+    // DataModel siblings — only the sourcemap knows they are related.
     t.write_child("sourcemap.json", R"({
         "name": "Game",
         "className": "DataModel",
@@ -348,11 +347,7 @@ TEST_CASE("analyze_resolves_game_requires_with_sourcemap")
     t.write_child("src/server/ServerModule.luau", "local _ = require('@game/ReplicatedStorage/Util')");
 
     CliClient client;
-    initCliClient(client);
-    client.globalConfig.platform.type = LSPPlatformConfig::Roblox;
-    client.globalConfig.sourcemap.enabled = true;
-    client.globalConfig.sourcemap.sourcemapFile = t.path() + "/sourcemap.json";
-
+    initRobloxCliClient(client);
     WorkspaceFolder workspace(&client, "CLI", Uri::file(t.path()), std::nullopt);
     setupCliWorkspace(client, workspace);
 
@@ -392,11 +387,7 @@ TEST_CASE("analyze_resolves_non_mirrored_relative_requires_with_sourcemap")
     t.write_child("packages/combat/ModuleB.luau", "return {}");
 
     CliClient client;
-    initCliClient(client);
-    client.globalConfig.platform.type = LSPPlatformConfig::Roblox;
-    client.globalConfig.sourcemap.enabled = true;
-    client.globalConfig.sourcemap.sourcemapFile = t.path() + "/sourcemap.json";
-
+    initRobloxCliClient(client);
     WorkspaceFolder workspace(&client, "CLI", Uri::file(t.path()), std::nullopt);
     setupCliWorkspace(client, workspace);
 


### PR DESCRIPTION
analyzeFile was using the raw filesystem path as the Luau module name
(`Luau::ModuleName name = path`), which bypassed WorkspaceFileResolver's
virtual path system. RobloxPlatform only handles @game aliases and
sourcemap-aware relative requires when the module name is a virtual path
(e.g. "game/ReplicatedStorage/Module"). Real-path module names caused
UnknownRequire errors for any cross-service require.

Fix: convert the path to its module name via
`workspace.fileResolver.getModuleName(Uri::file(path))` before passing
it to the frontend. Files in the sourcemap receive their virtual path;
files outside the sourcemap fall back to the raw path unchanged.

To make analyzeFile directly testable, it is now non-static and declared
in AnalyzeCli.hpp (together with ReportFormat, which moved there from the
.cpp file). Two new integration tests cover the fixed scenarios:
- @game alias require across non-mirrored filesystem paths
- Relative require between DataModel siblings with non-mirrored paths

**Why instance-based requires (`require(game.X.Y)`, `require(script.Parent.X)`) were not affected:**
`game` in `resolveModule` unconditionally returns `ModuleInfo{"game"}` without consulting `context->name` at all, so the chain resolves correctly regardless of whether the calling module's name is a virtual path or a raw filesystem path. `script` has a defence-in-depth fallback: if `context->name` is not a virtual path, `resolveModule` calls `resolveToVirtualPath` to look the real path up in the sourcemap and return the correct virtual path. Once `script` yields a virtual path, all subsequent `.Parent` and child traversals in the chain operate on virtual paths and resolve correctly. String requires had no equivalent fallback — `resolveStringRequire` gates on `isVirtualPath(context->name)` at line 119 and delegates to plain filesystem resolution when the calling module's name is a raw path, which has no concept of `@game` aliases or non-mirrored DataModel siblings.

Fixes #1473