### PR TITLE
Add useConst setting for auto-import declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Added `luau-lsp.completion.imports.useConst` setting to use `const` instead of `local` for auto-imported declarations ([#1423](https://github.com/JohnnyMorganz/luau-lsp/issues/1423))
+
 ### Fixed
 
 - String requires (including `@game` aliases and relative requires between DataModel siblings with non-mirrored filesystem layouts) now resolve correctly when using `luau-lsp analyze` with a sourcemap ([#1473](https://github.com/JohnnyMorganz/luau-lsp/issues/1473))

--- a/src/include/LSP/ClientConfiguration.hpp
+++ b/src/include/LSP/ClientConfiguration.hpp
@@ -157,9 +157,11 @@ struct ClientCompletionImportsConfiguration
     bool separateGroupsWithLine = false;
     /// Files that match these globs will not be shown during auto-import
     std::vector<std::string> ignoreGlobs{"**/_Index/**"};
+    /// Whether to use `const` instead of `local` for auto-imported declarations
+    bool useConst = false;
 };
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(ClientCompletionImportsConfiguration, enabled, suggestServices, includedServices, excludedServices,
-    suggestRequires, requireStyle, stringRequires, separateGroupsWithLine, ignoreGlobs);
+    suggestRequires, requireStyle, stringRequires, separateGroupsWithLine, ignoreGlobs, useConst);
 
 struct ClientCompletionConfiguration
 {

--- a/src/include/Platform/AutoImports.hpp
+++ b/src/include/Platform/AutoImports.hpp
@@ -48,7 +48,8 @@ public:
 };
 
 std::string makeValidVariableName(std::string name);
-lsp::TextEdit createRequireTextEdit(const std::string& name, const std::string& path, size_t lineNumber, bool prependNewline = false);
+lsp::TextEdit createRequireTextEdit(
+    const std::string& name, const std::string& path, size_t lineNumber, bool prependNewline = false, bool useConst = false);
 lsp::CompletionItem createSuggestRequire(const std::string& name, const std::vector<lsp::TextEdit>& textEdits, const char* sortText,
     const std::string& path, const std::string& requirePath);
 size_t computeMinimumLineNumberForRequire(const FindImportsVisitor& importsVisitor, size_t hotCommentsLineNumber);

--- a/src/include/Platform/AutoImports.hpp
+++ b/src/include/Platform/AutoImports.hpp
@@ -48,6 +48,10 @@ public:
 };
 
 std::string makeValidVariableName(std::string name);
+inline const char* declarationKeyword(bool useConst)
+{
+    return useConst ? "const " : "local ";
+}
 lsp::TextEdit createRequireTextEdit(
     const std::string& name, const std::string& path, size_t lineNumber, bool prependNewline = false, bool useConst = false);
 lsp::CompletionItem createSuggestRequire(const std::string& name, const std::vector<lsp::TextEdit>& textEdits, const char* sortText,

--- a/src/include/Platform/InstanceRequireAutoImporter.hpp
+++ b/src/include/Platform/InstanceRequireAutoImporter.hpp
@@ -91,7 +91,7 @@ struct InstanceRequireResult
 };
 
 /// Create a text edit for inserting a Roblox service import (e.g., `local Players = game:GetService("Players")`)
-lsp::TextEdit createServiceTextEdit(const std::string& name, size_t lineNumber, bool appendNewline = false);
+lsp::TextEdit createServiceTextEdit(const std::string& name, size_t lineNumber, bool appendNewline = false, bool useConst = false);
 /// Optimise an absolute require path by removing the "game/" prefix (e.g., "game/ReplicatedStorage/Foo" -> "ReplicatedStorage/Foo")
 std::string optimiseAbsoluteRequire(const std::string& path);
 

--- a/src/platform/AutoImports.cpp
+++ b/src/platform/AutoImports.cpp
@@ -77,10 +77,10 @@ std::string makeValidVariableName(std::string name)
     return name;
 }
 
-lsp::TextEdit createRequireTextEdit(const std::string& name, const std::string& path, size_t lineNumber, bool prependNewline)
+lsp::TextEdit createRequireTextEdit(const std::string& name, const std::string& path, size_t lineNumber, bool prependNewline, bool useConst)
 {
     auto range = lsp::Range{{lineNumber, 0}, {lineNumber, 0}};
-    auto importText = "local " + name + " = require(" + path + ")\n";
+    auto importText = (useConst ? "const " : "local ") + name + " = require(" + path + ")\n";
     if (prependNewline)
         importText = "\n" + importText;
     return {range, importText};

--- a/src/platform/AutoImports.cpp
+++ b/src/platform/AutoImports.cpp
@@ -80,7 +80,7 @@ std::string makeValidVariableName(std::string name)
 lsp::TextEdit createRequireTextEdit(const std::string& name, const std::string& path, size_t lineNumber, bool prependNewline, bool useConst)
 {
     auto range = lsp::Range{{lineNumber, 0}, {lineNumber, 0}};
-    auto importText = (useConst ? "const " : "local ") + name + " = require(" + path + ")\n";
+    auto importText = std::string(declarationKeyword(useConst)) + name + " = require(" + path + ")\n";
     if (prependNewline)
         importText = "\n" + importText;
     return {range, importText};

--- a/src/platform/StringRequireAutoImporter.cpp
+++ b/src/platform/StringRequireAutoImporter.cpp
@@ -146,7 +146,7 @@ std::vector<StringRequireResult> computeAllStringRequires(const StringRequireAut
             name,
             moduleName,
             require,
-            createRequireTextEdit(name, '"' + require + '"', lineNumber, prependNewline),
+            createRequireTextEdit(name, '"' + require + '"', lineNumber, prependNewline, ctx.config->useConst),
             sortText,
         });
     };

--- a/src/platform/roblox/InstanceRequireAutoImporter.cpp
+++ b/src/platform/roblox/InstanceRequireAutoImporter.cpp
@@ -6,10 +6,10 @@
 namespace Luau::LanguageServer::AutoImports
 {
 
-lsp::TextEdit createServiceTextEdit(const std::string& name, size_t lineNumber, bool appendNewline)
+lsp::TextEdit createServiceTextEdit(const std::string& name, size_t lineNumber, bool appendNewline, bool useConst)
 {
     auto range = lsp::Range{{lineNumber, 0}, {lineNumber, 0}};
-    auto importText = "local " + name + " = game:GetService(\"" + name + "\")\n";
+    auto importText = (useConst ? "const " : "local ") + name + " = game:GetService(\"" + name + "\")\n";
     if (appendNewline)
         importText += "\n";
     return {range, importText};
@@ -83,7 +83,7 @@ std::vector<InstanceRequireResult> computeAllInstanceRequires(const InstanceRequ
                 // so we use `.value_or(serviceLineNumber)` to ensure it equals 0 and a newline is added
                 if (ctx.config->separateGroupsWithLine && ctx.importsVisitor->firstRequireLine.value_or(serviceLineNumber) - serviceLineNumber == 0)
                     appendNewline = true;
-                serviceEdit = {service, createServiceTextEdit(service, serviceLineNumber, appendNewline)};
+                serviceEdit = {service, createServiceTextEdit(service, serviceLineNumber, appendNewline, ctx.config->useConst)};
             }
         }
 
@@ -95,7 +95,7 @@ std::vector<InstanceRequireResult> computeAllInstanceRequires(const InstanceRequ
             path,
             require,
             serviceEdit,
-            createRequireTextEdit(name, require, lineNumber, prependNewline),
+            createRequireTextEdit(name, require, lineNumber, prependNewline, ctx.config->useConst),
             isRelative ? SortText::AutoImports : SortText::AutoImportsAbsolute,
         });
     }

--- a/src/platform/roblox/InstanceRequireAutoImporter.cpp
+++ b/src/platform/roblox/InstanceRequireAutoImporter.cpp
@@ -9,7 +9,7 @@ namespace Luau::LanguageServer::AutoImports
 lsp::TextEdit createServiceTextEdit(const std::string& name, size_t lineNumber, bool appendNewline, bool useConst)
 {
     auto range = lsp::Range{{lineNumber, 0}, {lineNumber, 0}};
-    auto importText = (useConst ? "const " : "local ") + name + " = game:GetService(\"" + name + "\")\n";
+    auto importText = std::string(declarationKeyword(useConst)) + name + " = game:GetService(\"" + name + "\")\n";
     if (appendNewline)
         importText += "\n";
     return {range, importText};

--- a/src/platform/roblox/RobloxCodeAction.cpp
+++ b/src/platform/roblox/RobloxCodeAction.cpp
@@ -103,7 +103,7 @@ void RobloxPlatform::handleUnknownSymbolFix(const UnknownSymbolFixContext& ctx, 
             importsVisitor.firstRequireLine.value() - lineNumber == 0)
             appendNewline = true;
 
-        auto serviceEdit = Luau::LanguageServer::AutoImports::createServiceTextEdit(unknownSymbol.name, lineNumber, appendNewline);
+        auto serviceEdit = Luau::LanguageServer::AutoImports::createServiceTextEdit(unknownSymbol.name, lineNumber, appendNewline, config.completion.imports.useConst);
 
         lsp::CodeAction action;
         action.title = "Import service '" + unknownSymbol.name + "'";
@@ -206,7 +206,7 @@ std::vector<lsp::TextEdit> RobloxPlatform::computeAddAllMissingImportsEdits(
                     importsVisitor.firstRequireLine.value() - lineNumber == 0)
                     appendNewline = true;
 
-                serviceEdits.push_back(Luau::LanguageServer::AutoImports::createServiceTextEdit(symbolName, lineNumber, appendNewline));
+                serviceEdits.push_back(Luau::LanguageServer::AutoImports::createServiceTextEdit(symbolName, lineNumber, appendNewline, config.completion.imports.useConst));
                 addedServices.insert(symbolName);
             }
         }

--- a/src/platform/roblox/RobloxCompletion.cpp
+++ b/src/platform/roblox/RobloxCompletion.cpp
@@ -49,9 +49,9 @@ static constexpr const char* COMMON_SERVICE_PROVIDER_PROPERTIES[] = {
     "GetService",
 };
 
-static lsp::CompletionItem createSuggestService(const std::string& service, size_t lineNumber, bool appendNewline = false)
+static lsp::CompletionItem createSuggestService(const std::string& service, size_t lineNumber, bool appendNewline = false, bool useConst = false)
 {
-    auto textEdit = Luau::LanguageServer::AutoImports::createServiceTextEdit(service, lineNumber, appendNewline);
+    auto textEdit = Luau::LanguageServer::AutoImports::createServiceTextEdit(service, lineNumber, appendNewline, useConst);
 
     lsp::CompletionItem item;
     item.label = service;
@@ -271,7 +271,7 @@ void RobloxPlatform::handleSuggestImports(const TextDocument& textDocument, cons
                 importsVisitor.firstRequireLine.value() - lineNumber == 0)
                 appendNewline = true;
 
-            items.emplace_back(createSuggestService(service, lineNumber, appendNewline));
+            items.emplace_back(createSuggestService(service, lineNumber, appendNewline, config.completion.imports.useConst));
         }
     }
 

--- a/tests/AutoImports.test.cpp
+++ b/tests/AutoImports.test.cpp
@@ -5,6 +5,8 @@
 #include "LSP/IostreamHelpers.hpp"
 #include "Platform/StringRequireAutoImporter.hpp"
 
+LUAU_FASTFLAG(LuauConst2)
+
 static std::optional<lsp::CompletionItem> getItem(const std::vector<lsp::CompletionItem>& items, const std::string& label)
 {
     for (const auto& item : items)
@@ -1716,6 +1718,108 @@ TEST_CASE_FIXTURE(Fixture, "sourcemap_auto_import_prefers_alias_over_game_path_w
     REQUIRE_EQ(imports.size(), 1);
     REQUIRE_EQ(imports[0].additionalTextEdits.size(), 1);
     CHECK_EQ(imports[0].additionalTextEdits[0].newText, "local ModuleB = require(\"@combat/ModuleB\")\n");
+}
+
+TEST_CASE_FIXTURE(Fixture, "service_auto_imports_use_const_when_configured")
+{
+    client->globalConfig.completion.imports.enabled = true;
+    client->globalConfig.completion.imports.useConst = true;
+    auto [source, marker] = sourceWithMarker(R"(
+        |
+    )");
+
+    auto uri = newDocument("foo.luau", source);
+
+    lsp::CompletionParams params;
+    params.textDocument = lsp::TextDocumentIdentifier{uri};
+    params.position = marker;
+
+    auto result = workspace.completion(params, nullptr);
+
+    auto serviceImport = getItem(result, "ReplicatedStorage");
+    REQUIRE(serviceImport);
+    REQUIRE_EQ(serviceImport->additionalTextEdits.size(), 1);
+    CHECK_EQ(serviceImport->additionalTextEdits[0].newText, "const ReplicatedStorage = game:GetService(\"ReplicatedStorage\")\n");
+}
+
+TEST_CASE_FIXTURE(Fixture, "instance_require_uses_const_when_configured")
+{
+    client->globalConfig.completion.imports.enabled = true;
+    client->globalConfig.completion.imports.useConst = true;
+    loadSourcemap(R"(
+    {
+        "name": "Game",
+        "className": "DataModel",
+        "children": [
+            {
+                "name": "ReplicatedStorage",
+                "className": "ReplicatedStorage",
+                "children": [
+                    {
+                        "name": "Module",
+                        "className": "ModuleScript",
+                        "filePaths": ["module.luau"]
+                    }
+                ]
+            }
+        ]
+    }
+    )");
+
+    auto [source, marker] = sourceWithMarker(R"(
+        |
+    )");
+
+    auto uri = newDocument("source.luau", source);
+
+    lsp::CompletionParams params;
+    params.textDocument = lsp::TextDocumentIdentifier{uri};
+    params.position = marker;
+
+    auto result = workspace.completion(params, nullptr);
+    auto imports = filterAutoImports(result, "Module");
+
+    REQUIRE_EQ(imports.size(), 1);
+    REQUIRE_EQ(imports[0].additionalTextEdits.size(), 2);
+    CHECK_EQ(imports[0].additionalTextEdits[0].newText, "const ReplicatedStorage = game:GetService(\"ReplicatedStorage\")\n");
+    CHECK_EQ(imports[0].additionalTextEdits[1].newText, "const Module = require(ReplicatedStorage.Module)\n");
+}
+
+TEST_CASE_FIXTURE(Fixture, "string_require_uses_const_when_configured")
+{
+    newDocument("foo.luau", "");
+
+    client->globalConfig.completion.imports.useConst = true;
+
+    FindImportsVisitor visitor;
+    auto user = newDocument("user.luau", "");
+    auto ctx = createContext(this, user, &visitor);
+
+    std::vector<lsp::CompletionItem> items;
+    suggestStringRequires(ctx, items);
+
+    REQUIRE_EQ(items.size(), 1);
+    auto fooItem = getItem(items, "foo");
+    REQUIRE(fooItem);
+    CHECK_EQ(fooItem->additionalTextEdits[0].newText, "const foo = require(\"./foo\")\n");
+}
+
+TEST_CASE_FIXTURE(Fixture, "const_require_is_not_duplicated_when_already_imported")
+{
+    ScopedFastFlag sff{FFlag::LuauConst2, true};
+
+    newDocument("library.luau", "");
+
+    FindImportsVisitor visitor;
+    auto user = newDocument("user.luau", R"(
+        const library = require("./library")
+    )");
+    auto ctx = createContext(this, user, &visitor);
+
+    std::vector<lsp::CompletionItem> items;
+    suggestStringRequires(ctx, items);
+
+    CHECK_EQ(items.size(), 0);
 }
 
 TEST_SUITE_END();


### PR DESCRIPTION
Add a new `luau-lsp.completion.imports.useConst` boolean setting that,
when enabled, generates `const` declarations instead of `local` for
auto-imported requires and services.

Fixes #1423