### PR TITLE
Use @self for init.luau child requires in sourcemap auto imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - String requires (including `@game` aliases and relative requires between DataModel siblings with non-mirrored filesystem layouts) now resolve correctly when using `luau-lsp analyze` with a sourcemap ([#1473](https://github.com/JohnnyMorganz/luau-lsp/issues/1473))
+- Auto-imported string requires from `init.luau` files now correctly use `@self/` paths for child modules when sourcemap-based requires are in use
 
 ### Changed
 

--- a/src/include/Platform/RobloxPlatform.hpp
+++ b/src/include/Platform/RobloxPlatform.hpp
@@ -39,6 +39,7 @@ struct SourceNode
     std::optional<const SourceNode*> findDescendant(const std::string& name) const;
     // O(n) search for ancestor of name
     std::optional<const SourceNode*> findAncestor(const std::string& name) const;
+    bool isAncestorOf(const SourceNode* other) const;
     /// Walk a slash-delimited path (supporting `.`, `..`, and `./` prefixes) from this node.
     /// Returns nullptr if any segment fails to resolve.
     const SourceNode* walkPath(const std::string& path) const;

--- a/src/platform/roblox/RobloxFileResolver.cpp
+++ b/src/platform/roblox/RobloxFileResolver.cpp
@@ -245,6 +245,22 @@ static std::optional<std::pair<std::string, const char*>> computeSourcemapRequir
     if (style == ImportRequireStyle::AlwaysAbsolute)
         return computeAbsolute();
 
+    // If fromNode is a DataModel ancestor of targetNode, use @self/ — the child module
+    // is always in the same service subtree, so a relative path is always appropriate.
+    if (fromNode->isAncestorOf(targetNode))
+    {
+        std::vector<std::string> pathComponents;
+        for (auto m = targetNode; m != fromNode; m = m->parent)
+            pathComponents.push_back(m->name);
+        std::reverse(pathComponents.begin(), pathComponents.end());
+
+        std::string selfPath = "@self";
+        for (const auto& component : pathComponents)
+            selfPath += "/" + component;
+
+        return std::pair{selfPath, SortText::AutoImports};
+    }
+
     // Find lowest common ancestor
     const SourceNode* commonAncestor = nullptr;
     for (auto n = targetNode; n; n = n->parent)

--- a/src/platform/roblox/RobloxSourceNode.cpp
+++ b/src/platform/roblox/RobloxSourceNode.cpp
@@ -113,6 +113,14 @@ std::optional<const SourceNode*> SourceNode::findAncestor(const std::string& anc
     return std::nullopt;
 }
 
+bool SourceNode::isAncestorOf(const SourceNode* other) const
+{
+    for (auto n = other->parent; n; n = n->parent)
+        if (n == this)
+            return true;
+    return false;
+}
+
 const SourceNode* SourceNode::walkPath(const std::string& path) const
 {
     const SourceNode* base = this;

--- a/tests/AutoImports.test.cpp
+++ b/tests/AutoImports.test.cpp
@@ -1720,6 +1720,136 @@ TEST_CASE_FIXTURE(Fixture, "sourcemap_auto_import_prefers_alias_over_game_path_w
     CHECK_EQ(imports[0].additionalTextEdits[0].newText, "local ModuleB = require(\"@combat/ModuleB\")\n");
 }
 
+TEST_CASE_FIXTURE(Fixture, "sourcemap_auto_import_init_luau_uses_self_for_child")
+{
+    client->globalConfig.completion.imports.enabled = true;
+    client->globalConfig.completion.imports.stringRequires.enabled = true;
+    loadSourcemap(R"(
+    {
+        "name": "Game",
+        "className": "DataModel",
+        "children": [
+            {
+                "name": "ReplicatedStorage",
+                "className": "ReplicatedStorage",
+                "children": [
+                    {
+                        "name": "Core",
+                        "className": "ModuleScript",
+                        "filePaths": ["packages/core/init.luau"],
+                        "children": [
+                            {"name": "ChildModule", "className": "ModuleScript", "filePaths": ["packages/core/ChildModule.luau"]}
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+    )");
+
+    auto [source, marker] = sourceWithMarker(R"(|)");
+    auto uri = newDocument("packages/core/init.luau", source);
+
+    lsp::CompletionParams params;
+    params.textDocument = lsp::TextDocumentIdentifier{uri};
+    params.position = marker;
+
+    auto result = workspace.completion(params, nullptr);
+    auto imports = filterAutoImports(result, "ChildModule");
+
+    REQUIRE_EQ(imports.size(), 1);
+    REQUIRE_EQ(imports[0].additionalTextEdits.size(), 1);
+    CHECK_EQ(imports[0].additionalTextEdits[0].newText, "local ChildModule = require(\"@self/ChildModule\")\n");
+}
+
+TEST_CASE_FIXTURE(Fixture, "sourcemap_auto_import_init_luau_uses_self_for_deep_child")
+{
+    client->globalConfig.completion.imports.enabled = true;
+    client->globalConfig.completion.imports.stringRequires.enabled = true;
+    loadSourcemap(R"(
+    {
+        "name": "Game",
+        "className": "DataModel",
+        "children": [
+            {
+                "name": "ReplicatedStorage",
+                "className": "ReplicatedStorage",
+                "children": [
+                    {
+                        "name": "Core",
+                        "className": "ModuleScript",
+                        "filePaths": ["packages/core/init.luau"],
+                        "children": [
+                            {
+                                "name": "Sub",
+                                "className": "Folder",
+                                "children": [
+                                    {"name": "DeepModule", "className": "ModuleScript", "filePaths": ["packages/core/Sub/DeepModule.luau"]}
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+    )");
+
+    auto [source, marker] = sourceWithMarker(R"(|)");
+    auto uri = newDocument("packages/core/init.luau", source);
+
+    lsp::CompletionParams params;
+    params.textDocument = lsp::TextDocumentIdentifier{uri};
+    params.position = marker;
+
+    auto result = workspace.completion(params, nullptr);
+    auto imports = filterAutoImports(result, "DeepModule");
+
+    REQUIRE_EQ(imports.size(), 1);
+    REQUIRE_EQ(imports[0].additionalTextEdits.size(), 1);
+    CHECK_EQ(imports[0].additionalTextEdits[0].newText, "local DeepModule = require(\"@self/Sub/DeepModule\")\n");
+}
+
+TEST_CASE_FIXTURE(Fixture, "sourcemap_auto_import_init_luau_uses_relative_for_sibling")
+{
+    client->globalConfig.completion.imports.enabled = true;
+    client->globalConfig.completion.imports.stringRequires.enabled = true;
+    loadSourcemap(R"(
+    {
+        "name": "Game",
+        "className": "DataModel",
+        "children": [
+            {
+                "name": "ReplicatedStorage",
+                "className": "ReplicatedStorage",
+                "children": [
+                    {
+                        "name": "Core",
+                        "className": "ModuleScript",
+                        "filePaths": ["packages/core/init.luau"]
+                    },
+                    {"name": "Sibling", "className": "ModuleScript", "filePaths": ["packages/sibling/Sibling.luau"]}
+                ]
+            }
+        ]
+    }
+    )");
+
+    auto [source, marker] = sourceWithMarker(R"(|)");
+    auto uri = newDocument("packages/core/init.luau", source);
+
+    lsp::CompletionParams params;
+    params.textDocument = lsp::TextDocumentIdentifier{uri};
+    params.position = marker;
+
+    auto result = workspace.completion(params, nullptr);
+    auto imports = filterAutoImports(result, "Sibling");
+
+    REQUIRE_EQ(imports.size(), 1);
+    REQUIRE_EQ(imports[0].additionalTextEdits.size(), 1);
+    CHECK_EQ(imports[0].additionalTextEdits[0].newText, "local Sibling = require(\"./Sibling\")\n");
+}
+
 TEST_CASE_FIXTURE(Fixture, "service_auto_imports_use_const_when_configured")
 {
     client->globalConfig.completion.imports.enabled = true;


### PR DESCRIPTION
computeSourcemapRequirePath previously generated ./ModuleName/Child paths
when the from file was an init.luau (e.g. Core/init.luau requiring Core/Child).
The idiomatic path for init.luau files is @self/Child, matching the behaviour
of the non-sourcemap computeRequirePath function.