### PR TITLE
Migrate deprecated API markers from boolean to Tags array in DataTypes.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - String requires (including `@game` aliases and relative requires between DataModel siblings with non-mirrored filesystem layouts) now resolve correctly when using `luau-lsp analyze` with a sourcemap ([#1473](https://github.com/JohnnyMorganz/luau-lsp/issues/1473))
+- Deprecated properties defined in `DataTypes.json` (e.g. `Vector3.magnitude`, `Vector2.y`, `CFrame.p`) are now correctly filtered from autocompletion when `showDeprecatedItems` is disabled, and annotated with `@deprecated` in generated type definitions ([#1477](https://github.com/JohnnyMorganz/luau-lsp/issues/1477))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - String requires (including `@game` aliases and relative requires between DataModel siblings with non-mirrored filesystem layouts) now resolve correctly when using `luau-lsp analyze` with a sourcemap ([#1473](https://github.com/JohnnyMorganz/luau-lsp/issues/1473))
-- Deprecated properties defined in `DataTypes.json` (e.g. `Vector3.magnitude`, `Vector2.y`, `CFrame.p`) are now correctly filtered from autocompletion when `showDeprecatedItems` is disabled, and annotated with `@deprecated` in generated type definitions ([#1477](https://github.com/JohnnyMorganz/luau-lsp/issues/1477))
+- Deprecated properties for Data Types (e.g. `Vector3.magnitude`, `Vector2.y`, `CFrame.p`) are now correctly filtered from autocompletion when `showDeprecatedItems` is disabled, and deprecated functions are annotated with `@deprecated` in generated type definitions ([#1477](https://github.com/JohnnyMorganz/luau-lsp/issues/1477))
 
 ### Changed
 

--- a/scripts/DataTypes.json
+++ b/scripts/DataTypes.json
@@ -369,37 +369,37 @@
                     }
                 },
                 {
-                    "MemberType":"Function",
-                    "Name":"min",
+                    "MemberType": "Function",
+                    "Name": "min",
                     "Parameters": [
                         {
-                        "Name": "other",
-                        "Type":{
-                            "Variadic":{
-                                "Name":"Vector2"
+                            "Name": "other",
+                            "Type": {
+                                "Variadic": {
+                                    "Name": "Vector2"
+                                }
                             }
                         }
-                        }
                     ],
-                    "ReturnType":{
-                        "Name":"Vector2"
+                    "ReturnType": {
+                        "Name": "Vector2"
                     }
                 },
                 {
-                    "MemberType":"Function",
-                    "Name":"max",
+                    "MemberType": "Function",
+                    "Name": "max",
                     "Parameters": [
                         {
-                        "Name": "other",
-                        "Type":{
-                            "Variadic":{
-                                "Name":"Vector2"
+                            "Name": "other",
+                            "Type": {
+                                "Variadic": {
+                                    "Name": "Vector2"
+                                }
                             }
                         }
-                        }
                     ],
-                    "ReturnType":{
-                        "Name":"Vector2"
+                    "ReturnType": {
+                        "Name": "Vector2"
                     }
                 }
             ],
@@ -732,12 +732,12 @@
                     "Parameters": [
                         {
                             "Name": "axes",
-                            "Type":{
-                                "Variadic":{
+                            "Type": {
+                                "Variadic": {
                                     "Category": "Enum",
                                     "Name": "Axis | EnumNormalId"
                                 }
-                        }
+                            }
                         }
                     ],
                     "ReturnType": {
@@ -1402,12 +1402,12 @@
                     "Parameters": [
                         {
                             "Name": "normalIds",
-                            "Type":{
-                                "Variadic":{
+                            "Type": {
+                                "Variadic": {
                                     "Category": "Enum",
                                     "Name": "NormalId"
                                 }
-                        }
+                            }
                         }
                     ],
                     "ReturnType": {
@@ -1422,8 +1422,7 @@
                 {
                     "MemberType": "Function",
                     "Name": "new",
-                    "Parameters": [
-                    ],
+                    "Parameters": [],
                     "ReturnType": {
                         "Name": "Rect"
                     }
@@ -1619,37 +1618,37 @@
                     }
                 },
                 {
-                    "MemberType":"Function",
-                    "Name":"min",
+                    "MemberType": "Function",
+                    "Name": "min",
                     "Parameters": [
                         {
-                        "Name": "other",
-                        "Type":{
-                            "Variadic":{
-                                "Name":"Vector3"
+                            "Name": "other",
+                            "Type": {
+                                "Variadic": {
+                                    "Name": "Vector3"
+                                }
                             }
                         }
-                        }
                     ],
-                    "ReturnType":{
-                        "Name":"Vector3"
+                    "ReturnType": {
+                        "Name": "Vector3"
                     }
                 },
                 {
-                    "MemberType":"Function",
-                    "Name":"max",
+                    "MemberType": "Function",
+                    "Name": "max",
                     "Parameters": [
                         {
-                        "Name": "other",
-                        "Type":{
-                            "Variadic":{
-                                "Name":"Vector3"
+                            "Name": "other",
+                            "Type": {
+                                "Variadic": {
+                                    "Name": "Vector3"
+                                }
                             }
                         }
-                        }
                     ],
-                    "ReturnType":{
-                        "Name":"Vector3"
+                    "ReturnType": {
+                        "Name": "Vector3"
                     }
                 }
             ],
@@ -2072,7 +2071,7 @@
                         {
                             "Name": "value",
                             "Type": {
-                                "Name":  "number"
+                                "Name": "number"
                             }
                         },
                         {
@@ -2173,7 +2172,6 @@
             ],
             "Name": "Content"
         },
-
         {
             "Members": [
                 {
@@ -2394,67 +2392,67 @@
         },
         {
             "Members": [
-                    {
-                        "MemberType": "Function",
-                        "Name": "new",
-                        "Parameters": [
-                            {
-                                "Name": "time",
-                                "Type": {
-                                    "Name": "number"
-                                }
-                            },
-                            {
-                                "Name": "value",
-                                "Type": {
-                                    "Name": "number"
-                                }
-                            },
-                            {
-                                "Name": "Interpolation",
-                                "Type": {
-                                    "Category": "Enum",
-                                    "Name": "KeyInterpolationMode"
-                                }
+                {
+                    "MemberType": "Function",
+                    "Name": "new",
+                    "Parameters": [
+                        {
+                            "Name": "time",
+                            "Type": {
+                                "Name": "number"
                             }
-                        ],
-                        "ReturnType": {
-                            "Name": "FloatCurveKey"
+                        },
+                        {
+                            "Name": "value",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Name": "Interpolation",
+                            "Type": {
+                                "Category": "Enum",
+                                "Name": "KeyInterpolationMode"
+                            }
                         }
+                    ],
+                    "ReturnType": {
+                        "Name": "FloatCurveKey"
                     }
+                }
             ],
             "Name": "FloatCurveKey"
         },
         {
             "Members": [
-                    {
-                        "MemberType": "Function",
-                        "Name": "new",
-                        "Parameters": [
-                            {
-                                "Name": "time",
-                                "Type": {
-                                    "Name": "number"
-                                }
-                            },
-                            {
-                                "Name": "value",
-                                "Type": {
-                                    "Name": "CFrame"
-                                }
-                            },
-                            {
-                                "Name": "Interpolation",
-                                "Type": {
-                                    "Category": "Enum",
-                                    "Name": "KeyInterpolationMode"
-                                }
+                {
+                    "MemberType": "Function",
+                    "Name": "new",
+                    "Parameters": [
+                        {
+                            "Name": "time",
+                            "Type": {
+                                "Name": "number"
                             }
-                        ],
-                        "ReturnType": {
-                            "Name": "RotationCurveKey"
+                        },
+                        {
+                            "Name": "value",
+                            "Type": {
+                                "Name": "CFrame"
+                            }
+                        },
+                        {
+                            "Name": "Interpolation",
+                            "Type": {
+                                "Category": "Enum",
+                                "Name": "KeyInterpolationMode"
+                            }
                         }
+                    ],
+                    "ReturnType": {
+                        "Name": "RotationCurveKey"
                     }
+                }
             ],
             "Name": "RotationCurveKey"
         },
@@ -2671,10 +2669,10 @@
                     }
                 },
                 {
-                    "MemberType":"Property",
-                    "Name":"Label",
-                    "ValueType":{
-                        "Name":"string"
+                    "MemberType": "Property",
+                    "Name": "Label",
+                    "ValueType": {
+                        "Name": "string"
                     }
                 }
             ],
@@ -2811,8 +2809,7 @@
                 {
                     "MemberType": "Function",
                     "Name": "Abs",
-                    "Parameters": [
-                    ],
+                    "Parameters": [],
                     "ReturnType": {
                         "Name": "Vector2"
                     }
@@ -2820,8 +2817,7 @@
                 {
                     "MemberType": "Function",
                     "Name": "Ceil",
-                    "Parameters": [
-                    ],
+                    "Parameters": [],
                     "ReturnType": {
                         "Name": "Vector2"
                     }
@@ -2829,8 +2825,7 @@
                 {
                     "MemberType": "Function",
                     "Name": "Floor",
-                    "Parameters": [
-                    ],
+                    "Parameters": [],
                     "ReturnType": {
                         "Name": "Vector2"
                     }
@@ -2838,8 +2833,7 @@
                 {
                     "MemberType": "Function",
                     "Name": "Sign",
-                    "Parameters": [
-                    ],
+                    "Parameters": [],
                     "ReturnType": {
                         "Name": "Vector2"
                     }
@@ -2849,15 +2843,15 @@
                     "Name": "Angle",
                     "Parameters": [
                         {
-                            "Name":"other",
-                            "Type":{
-                                "Name":"Vector2"
+                            "Name": "other",
+                            "Type": {
+                                "Name": "Vector2"
                             }
                         },
                         {
-                            "Name":"isSigned",
-                            "Type":{
-                                "Name":"bool"
+                            "Name": "isSigned",
+                            "Type": {
+                                "Name": "bool"
                             }
                         }
                     ],
@@ -2902,39 +2896,46 @@
                 {
                     "MemberType": "Property",
                     "Name": "y",
-                    "Deprecated": true,
                     "ValueType": {
                         "Name": "number"
-                    }
+                    },
+                    "Tags": [
+                        "Deprecated"
+                    ]
                 },
                 {
                     "MemberType": "Property",
                     "Name": "x",
-                    "Deprecated": true,
                     "ValueType": {
                         "Name": "number"
-                    }
+                    },
+                    "Tags": [
+                        "Deprecated"
+                    ]
                 },
                 {
                     "MemberType": "Property",
                     "Name": "unit",
-                    "Deprecated": true,
                     "ValueType": {
                         "Name": "Vector2"
-                    }
+                    },
+                    "Tags": [
+                        "Deprecated"
+                    ]
                 },
                 {
                     "MemberType": "Property",
                     "Name": "magnitude",
-                    "Deprecated": true,
                     "ValueType": {
                         "Name": "number"
-                    }
+                    },
+                    "Tags": [
+                        "Deprecated"
+                    ]
                 },
                 {
                     "MemberType": "Function",
                     "Name": "lerp",
-                    "Deprecated": true,
                     "Parameters": [
                         {
                             "Name": "v",
@@ -2951,7 +2952,10 @@
                     ],
                     "ReturnType": {
                         "Name": "Vector2"
-                    }
+                    },
+                    "Tags": [
+                        "Deprecated"
+                    ]
                 }
             ],
             "Name": "Vector2"
@@ -3027,31 +3031,36 @@
                 {
                     "MemberType": "Property",
                     "Name": "r",
-                    "Deprecated": true,
                     "ValueType": {
                         "Name": "number"
-                    }
+                    },
+                    "Tags": [
+                        "Deprecated"
+                    ]
                 },
                 {
                     "MemberType": "Property",
                     "Name": "g",
-                    "Deprecated": true,
                     "ValueType": {
                         "Name": "number"
-                    }
+                    },
+                    "Tags": [
+                        "Deprecated"
+                    ]
                 },
                 {
                     "MemberType": "Property",
                     "Name": "b",
-                    "Deprecated": true,
                     "ValueType": {
                         "Name": "number"
-                    }
+                    },
+                    "Tags": [
+                        "Deprecated"
+                    ]
                 },
                 {
                     "MemberType": "Function",
                     "Name": "lerp",
-                    "Deprecated": true,
                     "Parameters": [
                         {
                             "Name": "color",
@@ -3068,7 +3077,10 @@
                     ],
                     "ReturnType": {
                         "Name": "Color3"
-                    }
+                    },
+                    "Tags": [
+                        "Deprecated"
+                    ]
                 }
             ],
             "Name": "Color3"
@@ -3441,7 +3453,7 @@
                     "Parameters": [
                         {
                             "Name": "order",
-                            "Default":"XYZ",
+                            "Default": "XYZ",
                             "Type": {
                                 "Category": "Enum",
                                 "Name": "RotationOrder"
@@ -3633,31 +3645,36 @@
                 {
                     "MemberType": "Property",
                     "Name": "z",
-                    "Deprecated": true,
                     "ValueType": {
                         "Name": "number"
-                    }
+                    },
+                    "Tags": [
+                        "Deprecated"
+                    ]
                 },
                 {
                     "MemberType": "Property",
                     "Name": "y",
-                    "Deprecated": true,
                     "ValueType": {
                         "Name": "number"
-                    }
+                    },
+                    "Tags": [
+                        "Deprecated"
+                    ]
                 },
                 {
                     "MemberType": "Property",
                     "Name": "x",
-                    "Deprecated": true,
                     "ValueType": {
                         "Name": "number"
-                    }
+                    },
+                    "Tags": [
+                        "Deprecated"
+                    ]
                 },
                 {
                     "MemberType": "Function",
                     "Name": "pointToObjectSpace",
-                    "Deprecated": true,
                     "Parameters": [
                         {
                             "Name": "v3",
@@ -3668,27 +3685,33 @@
                     ],
                     "ReturnType": {
                         "Name": "Vector3"
-                    }
+                    },
+                    "Tags": [
+                        "Deprecated"
+                    ]
                 },
                 {
                     "MemberType": "Property",
                     "Name": "p",
-                    "Deprecated": true,
                     "ValueType": {
                         "Name": "Vector3"
-                    }
+                    },
+                    "Tags": [
+                        "Deprecated"
+                    ]
                 },
                 {
                     "MemberType": "Property",
-                    "Deprecated": true,
                     "Name": "rightVector",
                     "ValueType": {
                         "Name": "Vector3"
-                    }
+                    },
+                    "Tags": [
+                        "Deprecated"
+                    ]
                 },
                 {
                     "MemberType": "Function",
-                    "Deprecated": true,
                     "Name": "vectorToWorldSpace",
                     "Parameters": [
                         {
@@ -3700,12 +3723,14 @@
                     ],
                     "ReturnType": {
                         "Name": "Vector3"
-                    }
+                    },
+                    "Tags": [
+                        "Deprecated"
+                    ]
                 },
                 {
                     "MemberType": "Function",
                     "Name": "toAxisAngle",
-                    "Deprecated": true,
                     "Parameters": [],
                     "TupleReturns": [
                         {
@@ -3714,29 +3739,35 @@
                         {
                             "Name": "number"
                         }
+                    ],
+                    "Tags": [
+                        "Deprecated"
                     ]
                 },
                 {
                     "MemberType": "Function",
                     "Name": "inverse",
-                    "Deprecated": true,
                     "Parameters": [],
                     "ReturnType": {
                         "Name": "CFrame"
-                    }
+                    },
+                    "Tags": [
+                        "Deprecated"
+                    ]
                 },
                 {
                     "MemberType": "Property",
                     "Name": "upVector",
-                    "Deprecated": true,
                     "ValueType": {
                         "Name": "Vector3"
-                    }
+                    },
+                    "Tags": [
+                        "Deprecated"
+                    ]
                 },
                 {
                     "MemberType": "Function",
                     "Name": "lerp",
-                    "Deprecated": true,
                     "Parameters": [
                         {
                             "Name": "goal",
@@ -3753,12 +3784,14 @@
                     ],
                     "ReturnType": {
                         "Name": "CFrame"
-                    }
+                    },
+                    "Tags": [
+                        "Deprecated"
+                    ]
                 },
                 {
                     "MemberType": "Function",
                     "Name": "vectorToObjectSpace",
-                    "Deprecated": true,
                     "Parameters": [
                         {
                             "Name": "v3",
@@ -3769,20 +3802,24 @@
                     ],
                     "ReturnType": {
                         "Name": "Vector3"
-                    }
+                    },
+                    "Tags": [
+                        "Deprecated"
+                    ]
                 },
                 {
                     "MemberType": "Property",
                     "Name": "lookVector",
-                    "Deprecated": true,
                     "ValueType": {
                         "Name": "Vector3"
-                    }
+                    },
+                    "Tags": [
+                        "Deprecated"
+                    ]
                 },
                 {
                     "MemberType": "Function",
                     "Name": "pointToWorldSpace",
-                    "Deprecated": true,
                     "Parameters": [
                         {
                             "Name": "v3",
@@ -3793,12 +3830,14 @@
                     ],
                     "ReturnType": {
                         "Name": "Vector3"
-                    }
+                    },
+                    "Tags": [
+                        "Deprecated"
+                    ]
                 },
                 {
                     "MemberType": "Function",
                     "Name": "toWorldSpace",
-                    "Deprecated": true,
                     "Parameters": [
                         {
                             "Name": "cf",
@@ -3809,12 +3848,14 @@
                     ],
                     "ReturnType": {
                         "Name": "CFrame"
-                    }
+                    },
+                    "Tags": [
+                        "Deprecated"
+                    ]
                 },
                 {
                     "MemberType": "Function",
                     "Name": "toObjectSpace",
-                    "Deprecated": true,
                     "Parameters": [
                         {
                             "Name": "cf",
@@ -3825,12 +3866,14 @@
                     ],
                     "ReturnType": {
                         "Name": "CFrame"
-                    }
+                    },
+                    "Tags": [
+                        "Deprecated"
+                    ]
                 },
                 {
                     "MemberType": "Function",
                     "Name": "toEulerAnglesXYZ",
-                    "Deprecated": true,
                     "Parameters": [],
                     "TupleReturns": [
                         {
@@ -3842,6 +3885,9 @@
                         {
                             "Name": "number"
                         }
+                    ],
+                    "Tags": [
+                        "Deprecated"
                     ]
                 },
                 {
@@ -3869,7 +3915,6 @@
                 {
                     "MemberType": "Function",
                     "Name": "components",
-                    "Deprecated": true,
                     "Parameters": [],
                     "TupleReturns": [
                         {
@@ -3908,6 +3953,9 @@
                         {
                             "Name": "number"
                         }
+                    ],
+                    "Tags": [
+                        "Deprecated"
                     ]
                 }
             ],
@@ -4153,8 +4201,7 @@
                 {
                     "MemberType": "Function",
                     "Name": "Abs",
-                    "Parameters": [
-                    ],
+                    "Parameters": [],
                     "ReturnType": {
                         "Name": "Vector3"
                     }
@@ -4162,8 +4209,7 @@
                 {
                     "MemberType": "Function",
                     "Name": "Ceil",
-                    "Parameters": [
-                    ],
+                    "Parameters": [],
                     "ReturnType": {
                         "Name": "Vector3"
                     }
@@ -4171,8 +4217,7 @@
                 {
                     "MemberType": "Function",
                     "Name": "Floor",
-                    "Parameters": [
-                    ],
+                    "Parameters": [],
                     "ReturnType": {
                         "Name": "Vector3"
                     }
@@ -4180,8 +4225,7 @@
                 {
                     "MemberType": "Function",
                     "Name": "Sign",
-                    "Parameters": [
-                    ],
+                    "Parameters": [],
                     "ReturnType": {
                         "Name": "Vector3"
                     }
@@ -4266,7 +4310,6 @@
                 {
                     "MemberType": "Function",
                     "Name": "lerp",
-                    "Deprecated": true,
                     "Parameters": [
                         {
                             "Name": "goal",
@@ -4283,47 +4326,60 @@
                     ],
                     "ReturnType": {
                         "Name": "Vector3"
-                    }
+                    },
+                    "Tags": [
+                        "Deprecated"
+                    ]
                 },
                 {
                     "MemberType": "Property",
-                    "Deprecated": true,
                     "Name": "z",
                     "ValueType": {
                         "Name": "number"
-                    }
+                    },
+                    "Tags": [
+                        "Deprecated"
+                    ]
                 },
                 {
                     "MemberType": "Property",
-                    "Deprecated": true,
                     "Name": "y",
                     "ValueType": {
                         "Name": "number"
-                    }
+                    },
+                    "Tags": [
+                        "Deprecated"
+                    ]
                 },
                 {
                     "MemberType": "Property",
-                    "Deprecated": true,
                     "Name": "x",
                     "ValueType": {
                         "Name": "number"
-                    }
+                    },
+                    "Tags": [
+                        "Deprecated"
+                    ]
                 },
                 {
                     "MemberType": "Property",
-                    "Deprecated": true,
                     "Name": "unit",
                     "ValueType": {
                         "Name": "Vector3"
-                    }
+                    },
+                    "Tags": [
+                        "Deprecated"
+                    ]
                 },
                 {
                     "MemberType": "Property",
-                    "Deprecated": true,
                     "Name": "magnitude",
                     "ValueType": {
                         "Name": "number"
-                    }
+                    },
+                    "Tags": [
+                        "Deprecated"
+                    ]
                 }
             ],
             "Name": "Vector3"
@@ -4468,19 +4524,23 @@
                 {
                     "MemberType": "Function",
                     "Name": "disconnect",
-                    "Deprecated": true,
                     "Parameters": [],
                     "ReturnType": {
                         "Name": "void"
-                    }
+                    },
+                    "Tags": [
+                        "Deprecated"
+                    ]
                 },
                 {
                     "MemberType": "Property",
                     "Name": "connected",
-                    "Deprecated": true,
                     "ValueType": {
                         "Name": "bool"
-                    }
+                    },
+                    "Tags": [
+                        "Deprecated"
+                    ]
                 }
             ],
             "Name": "RBXScriptConnection"
@@ -4546,16 +4606,17 @@
                 {
                     "MemberType": "Function",
                     "Name": "wait",
-                    "Deprecated": true,
                     "Parameters": [],
                     "ReturnType": {
                         "Name": "Variant"
-                    }
+                    },
+                    "Tags": [
+                        "Deprecated"
+                    ]
                 },
                 {
                     "MemberType": "Function",
                     "Name": "connect",
-                    "Deprecated": true,
                     "Parameters": [
                         {
                             "Name": "callback",
@@ -4566,7 +4627,10 @@
                     ],
                     "ReturnType": {
                         "Name": "RBXScriptConnection"
-                    }
+                    },
+                    "Tags": [
+                        "Deprecated"
+                    ]
                 }
             ],
             "Name": "RBXScriptSignal"
@@ -4733,7 +4797,7 @@
                     "MemberType": "Property",
                     "Name": "SourceType",
                     "ValueType": {
-                       "Category": "Enum",
+                        "Category": "Enum",
                         "Name": "ContentSourceType"
                     }
                 },
@@ -4750,7 +4814,7 @@
                     "ValueType": {
                         "Name": "Object?"
                     }
-                } 
+                }
             ],
             "Name": "Content"
         },
@@ -5510,7 +5574,6 @@
                 {
                     "MemberType": "Property",
                     "Name": "Position",
-                    
                     "ValueType": {
                         "Name": "UDim2"
                     }
@@ -5518,7 +5581,6 @@
                 {
                     "MemberType": "Property",
                     "Name": "LeftTangent",
-                    
                     "ValueType": {
                         "Name": "UDim2"
                     }
@@ -5526,7 +5588,6 @@
                 {
                     "MemberType": "Property",
                     "Name": "RightTangent",
-                    
                     "ValueType": {
                         "Name": "UDim2"
                     }

--- a/scripts/DataTypes.json
+++ b/scripts/DataTypes.json
@@ -369,37 +369,37 @@
                     }
                 },
                 {
-                    "MemberType": "Function",
-                    "Name": "min",
+                    "MemberType":"Function",
+                    "Name":"min",
                     "Parameters": [
                         {
-                            "Name": "other",
-                            "Type": {
-                                "Variadic": {
-                                    "Name": "Vector2"
-                                }
+                        "Name": "other",
+                        "Type":{
+                            "Variadic":{
+                                "Name":"Vector2"
                             }
                         }
+                        }
                     ],
-                    "ReturnType": {
-                        "Name": "Vector2"
+                    "ReturnType":{
+                        "Name":"Vector2"
                     }
                 },
                 {
-                    "MemberType": "Function",
-                    "Name": "max",
+                    "MemberType":"Function",
+                    "Name":"max",
                     "Parameters": [
                         {
-                            "Name": "other",
-                            "Type": {
-                                "Variadic": {
-                                    "Name": "Vector2"
-                                }
+                        "Name": "other",
+                        "Type":{
+                            "Variadic":{
+                                "Name":"Vector2"
                             }
                         }
+                        }
                     ],
-                    "ReturnType": {
-                        "Name": "Vector2"
+                    "ReturnType":{
+                        "Name":"Vector2"
                     }
                 }
             ],
@@ -495,7 +495,7 @@
                 {
                     "MemberType": "Function",
                     "Name": "toHSV",
-                    "Deprecated": true,
+                    "Tags": ["Deprecated"],
                     "Parameters": [
                         {
                             "Name": "color",
@@ -732,12 +732,12 @@
                     "Parameters": [
                         {
                             "Name": "axes",
-                            "Type": {
-                                "Variadic": {
+                            "Type":{
+                                "Variadic":{
                                     "Category": "Enum",
                                     "Name": "Axis | EnumNormalId"
                                 }
-                            }
+                        }
                         }
                     ],
                     "ReturnType": {
@@ -1402,12 +1402,12 @@
                     "Parameters": [
                         {
                             "Name": "normalIds",
-                            "Type": {
-                                "Variadic": {
+                            "Type":{
+                                "Variadic":{
                                     "Category": "Enum",
                                     "Name": "NormalId"
                                 }
-                            }
+                        }
                         }
                     ],
                     "ReturnType": {
@@ -1422,7 +1422,8 @@
                 {
                     "MemberType": "Function",
                     "Name": "new",
-                    "Parameters": [],
+                    "Parameters": [
+                    ],
                     "ReturnType": {
                         "Name": "Rect"
                     }
@@ -1618,37 +1619,37 @@
                     }
                 },
                 {
-                    "MemberType": "Function",
-                    "Name": "min",
+                    "MemberType":"Function",
+                    "Name":"min",
                     "Parameters": [
                         {
-                            "Name": "other",
-                            "Type": {
-                                "Variadic": {
-                                    "Name": "Vector3"
-                                }
+                        "Name": "other",
+                        "Type":{
+                            "Variadic":{
+                                "Name":"Vector3"
                             }
                         }
+                        }
                     ],
-                    "ReturnType": {
-                        "Name": "Vector3"
+                    "ReturnType":{
+                        "Name":"Vector3"
                     }
                 },
                 {
-                    "MemberType": "Function",
-                    "Name": "max",
+                    "MemberType":"Function",
+                    "Name":"max",
                     "Parameters": [
                         {
-                            "Name": "other",
-                            "Type": {
-                                "Variadic": {
-                                    "Name": "Vector3"
-                                }
+                        "Name": "other",
+                        "Type":{
+                            "Variadic":{
+                                "Name":"Vector3"
                             }
                         }
+                        }
                     ],
-                    "ReturnType": {
-                        "Name": "Vector3"
+                    "ReturnType":{
+                        "Name":"Vector3"
                     }
                 }
             ],
@@ -2071,7 +2072,7 @@
                         {
                             "Name": "value",
                             "Type": {
-                                "Name": "number"
+                                "Name":  "number"
                             }
                         },
                         {
@@ -2172,6 +2173,7 @@
             ],
             "Name": "Content"
         },
+
         {
             "Members": [
                 {
@@ -2392,67 +2394,67 @@
         },
         {
             "Members": [
-                {
-                    "MemberType": "Function",
-                    "Name": "new",
-                    "Parameters": [
-                        {
-                            "Name": "time",
-                            "Type": {
-                                "Name": "number"
+                    {
+                        "MemberType": "Function",
+                        "Name": "new",
+                        "Parameters": [
+                            {
+                                "Name": "time",
+                                "Type": {
+                                    "Name": "number"
+                                }
+                            },
+                            {
+                                "Name": "value",
+                                "Type": {
+                                    "Name": "number"
+                                }
+                            },
+                            {
+                                "Name": "Interpolation",
+                                "Type": {
+                                    "Category": "Enum",
+                                    "Name": "KeyInterpolationMode"
+                                }
                             }
-                        },
-                        {
-                            "Name": "value",
-                            "Type": {
-                                "Name": "number"
-                            }
-                        },
-                        {
-                            "Name": "Interpolation",
-                            "Type": {
-                                "Category": "Enum",
-                                "Name": "KeyInterpolationMode"
-                            }
+                        ],
+                        "ReturnType": {
+                            "Name": "FloatCurveKey"
                         }
-                    ],
-                    "ReturnType": {
-                        "Name": "FloatCurveKey"
                     }
-                }
             ],
             "Name": "FloatCurveKey"
         },
         {
             "Members": [
-                {
-                    "MemberType": "Function",
-                    "Name": "new",
-                    "Parameters": [
-                        {
-                            "Name": "time",
-                            "Type": {
-                                "Name": "number"
+                    {
+                        "MemberType": "Function",
+                        "Name": "new",
+                        "Parameters": [
+                            {
+                                "Name": "time",
+                                "Type": {
+                                    "Name": "number"
+                                }
+                            },
+                            {
+                                "Name": "value",
+                                "Type": {
+                                    "Name": "CFrame"
+                                }
+                            },
+                            {
+                                "Name": "Interpolation",
+                                "Type": {
+                                    "Category": "Enum",
+                                    "Name": "KeyInterpolationMode"
+                                }
                             }
-                        },
-                        {
-                            "Name": "value",
-                            "Type": {
-                                "Name": "CFrame"
-                            }
-                        },
-                        {
-                            "Name": "Interpolation",
-                            "Type": {
-                                "Category": "Enum",
-                                "Name": "KeyInterpolationMode"
-                            }
+                        ],
+                        "ReturnType": {
+                            "Name": "RotationCurveKey"
                         }
-                    ],
-                    "ReturnType": {
-                        "Name": "RotationCurveKey"
                     }
-                }
             ],
             "Name": "RotationCurveKey"
         },
@@ -2669,10 +2671,10 @@
                     }
                 },
                 {
-                    "MemberType": "Property",
-                    "Name": "Label",
-                    "ValueType": {
-                        "Name": "string"
+                    "MemberType":"Property",
+                    "Name":"Label",
+                    "ValueType":{
+                        "Name":"string"
                     }
                 }
             ],
@@ -2809,7 +2811,8 @@
                 {
                     "MemberType": "Function",
                     "Name": "Abs",
-                    "Parameters": [],
+                    "Parameters": [
+                    ],
                     "ReturnType": {
                         "Name": "Vector2"
                     }
@@ -2817,7 +2820,8 @@
                 {
                     "MemberType": "Function",
                     "Name": "Ceil",
-                    "Parameters": [],
+                    "Parameters": [
+                    ],
                     "ReturnType": {
                         "Name": "Vector2"
                     }
@@ -2825,7 +2829,8 @@
                 {
                     "MemberType": "Function",
                     "Name": "Floor",
-                    "Parameters": [],
+                    "Parameters": [
+                    ],
                     "ReturnType": {
                         "Name": "Vector2"
                     }
@@ -2833,7 +2838,8 @@
                 {
                     "MemberType": "Function",
                     "Name": "Sign",
-                    "Parameters": [],
+                    "Parameters": [
+                    ],
                     "ReturnType": {
                         "Name": "Vector2"
                     }
@@ -2843,15 +2849,15 @@
                     "Name": "Angle",
                     "Parameters": [
                         {
-                            "Name": "other",
-                            "Type": {
-                                "Name": "Vector2"
+                            "Name":"other",
+                            "Type":{
+                                "Name":"Vector2"
                             }
                         },
                         {
-                            "Name": "isSigned",
-                            "Type": {
-                                "Name": "bool"
+                            "Name":"isSigned",
+                            "Type":{
+                                "Name":"bool"
                             }
                         }
                     ],
@@ -2896,46 +2902,39 @@
                 {
                     "MemberType": "Property",
                     "Name": "y",
+                    "Tags": ["Deprecated"],
                     "ValueType": {
                         "Name": "number"
-                    },
-                    "Tags": [
-                        "Deprecated"
-                    ]
+                    }
                 },
                 {
                     "MemberType": "Property",
                     "Name": "x",
+                    "Tags": ["Deprecated"],
                     "ValueType": {
                         "Name": "number"
-                    },
-                    "Tags": [
-                        "Deprecated"
-                    ]
+                    }
                 },
                 {
                     "MemberType": "Property",
                     "Name": "unit",
+                    "Tags": ["Deprecated"],
                     "ValueType": {
                         "Name": "Vector2"
-                    },
-                    "Tags": [
-                        "Deprecated"
-                    ]
+                    }
                 },
                 {
                     "MemberType": "Property",
                     "Name": "magnitude",
+                    "Tags": ["Deprecated"],
                     "ValueType": {
                         "Name": "number"
-                    },
-                    "Tags": [
-                        "Deprecated"
-                    ]
+                    }
                 },
                 {
                     "MemberType": "Function",
                     "Name": "lerp",
+                    "Tags": ["Deprecated"],
                     "Parameters": [
                         {
                             "Name": "v",
@@ -2952,10 +2951,7 @@
                     ],
                     "ReturnType": {
                         "Name": "Vector2"
-                    },
-                    "Tags": [
-                        "Deprecated"
-                    ]
+                    }
                 }
             ],
             "Name": "Vector2"
@@ -3031,36 +3027,31 @@
                 {
                     "MemberType": "Property",
                     "Name": "r",
+                    "Tags": ["Deprecated"],
                     "ValueType": {
                         "Name": "number"
-                    },
-                    "Tags": [
-                        "Deprecated"
-                    ]
+                    }
                 },
                 {
                     "MemberType": "Property",
                     "Name": "g",
+                    "Tags": ["Deprecated"],
                     "ValueType": {
                         "Name": "number"
-                    },
-                    "Tags": [
-                        "Deprecated"
-                    ]
+                    }
                 },
                 {
                     "MemberType": "Property",
                     "Name": "b",
+                    "Tags": ["Deprecated"],
                     "ValueType": {
                         "Name": "number"
-                    },
-                    "Tags": [
-                        "Deprecated"
-                    ]
+                    }
                 },
                 {
                     "MemberType": "Function",
                     "Name": "lerp",
+                    "Tags": ["Deprecated"],
                     "Parameters": [
                         {
                             "Name": "color",
@@ -3077,10 +3068,7 @@
                     ],
                     "ReturnType": {
                         "Name": "Color3"
-                    },
-                    "Tags": [
-                        "Deprecated"
-                    ]
+                    }
                 }
             ],
             "Name": "Color3"
@@ -3453,7 +3441,7 @@
                     "Parameters": [
                         {
                             "Name": "order",
-                            "Default": "XYZ",
+                            "Default":"XYZ",
                             "Type": {
                                 "Category": "Enum",
                                 "Name": "RotationOrder"
@@ -3645,36 +3633,31 @@
                 {
                     "MemberType": "Property",
                     "Name": "z",
+                    "Tags": ["Deprecated"],
                     "ValueType": {
                         "Name": "number"
-                    },
-                    "Tags": [
-                        "Deprecated"
-                    ]
+                    }
                 },
                 {
                     "MemberType": "Property",
                     "Name": "y",
+                    "Tags": ["Deprecated"],
                     "ValueType": {
                         "Name": "number"
-                    },
-                    "Tags": [
-                        "Deprecated"
-                    ]
+                    }
                 },
                 {
                     "MemberType": "Property",
                     "Name": "x",
+                    "Tags": ["Deprecated"],
                     "ValueType": {
                         "Name": "number"
-                    },
-                    "Tags": [
-                        "Deprecated"
-                    ]
+                    }
                 },
                 {
                     "MemberType": "Function",
                     "Name": "pointToObjectSpace",
+                    "Tags": ["Deprecated"],
                     "Parameters": [
                         {
                             "Name": "v3",
@@ -3685,33 +3668,27 @@
                     ],
                     "ReturnType": {
                         "Name": "Vector3"
-                    },
-                    "Tags": [
-                        "Deprecated"
-                    ]
+                    }
                 },
                 {
                     "MemberType": "Property",
                     "Name": "p",
+                    "Tags": ["Deprecated"],
                     "ValueType": {
                         "Name": "Vector3"
-                    },
-                    "Tags": [
-                        "Deprecated"
-                    ]
+                    }
                 },
                 {
                     "MemberType": "Property",
+                    "Tags": ["Deprecated"],
                     "Name": "rightVector",
                     "ValueType": {
                         "Name": "Vector3"
-                    },
-                    "Tags": [
-                        "Deprecated"
-                    ]
+                    }
                 },
                 {
                     "MemberType": "Function",
+                    "Tags": ["Deprecated"],
                     "Name": "vectorToWorldSpace",
                     "Parameters": [
                         {
@@ -3723,14 +3700,12 @@
                     ],
                     "ReturnType": {
                         "Name": "Vector3"
-                    },
-                    "Tags": [
-                        "Deprecated"
-                    ]
+                    }
                 },
                 {
                     "MemberType": "Function",
                     "Name": "toAxisAngle",
+                    "Tags": ["Deprecated"],
                     "Parameters": [],
                     "TupleReturns": [
                         {
@@ -3739,35 +3714,29 @@
                         {
                             "Name": "number"
                         }
-                    ],
-                    "Tags": [
-                        "Deprecated"
                     ]
                 },
                 {
                     "MemberType": "Function",
                     "Name": "inverse",
+                    "Tags": ["Deprecated"],
                     "Parameters": [],
                     "ReturnType": {
                         "Name": "CFrame"
-                    },
-                    "Tags": [
-                        "Deprecated"
-                    ]
+                    }
                 },
                 {
                     "MemberType": "Property",
                     "Name": "upVector",
+                    "Tags": ["Deprecated"],
                     "ValueType": {
                         "Name": "Vector3"
-                    },
-                    "Tags": [
-                        "Deprecated"
-                    ]
+                    }
                 },
                 {
                     "MemberType": "Function",
                     "Name": "lerp",
+                    "Tags": ["Deprecated"],
                     "Parameters": [
                         {
                             "Name": "goal",
@@ -3784,14 +3753,12 @@
                     ],
                     "ReturnType": {
                         "Name": "CFrame"
-                    },
-                    "Tags": [
-                        "Deprecated"
-                    ]
+                    }
                 },
                 {
                     "MemberType": "Function",
                     "Name": "vectorToObjectSpace",
+                    "Tags": ["Deprecated"],
                     "Parameters": [
                         {
                             "Name": "v3",
@@ -3802,24 +3769,20 @@
                     ],
                     "ReturnType": {
                         "Name": "Vector3"
-                    },
-                    "Tags": [
-                        "Deprecated"
-                    ]
+                    }
                 },
                 {
                     "MemberType": "Property",
                     "Name": "lookVector",
+                    "Tags": ["Deprecated"],
                     "ValueType": {
                         "Name": "Vector3"
-                    },
-                    "Tags": [
-                        "Deprecated"
-                    ]
+                    }
                 },
                 {
                     "MemberType": "Function",
                     "Name": "pointToWorldSpace",
+                    "Tags": ["Deprecated"],
                     "Parameters": [
                         {
                             "Name": "v3",
@@ -3830,14 +3793,12 @@
                     ],
                     "ReturnType": {
                         "Name": "Vector3"
-                    },
-                    "Tags": [
-                        "Deprecated"
-                    ]
+                    }
                 },
                 {
                     "MemberType": "Function",
                     "Name": "toWorldSpace",
+                    "Tags": ["Deprecated"],
                     "Parameters": [
                         {
                             "Name": "cf",
@@ -3848,14 +3809,12 @@
                     ],
                     "ReturnType": {
                         "Name": "CFrame"
-                    },
-                    "Tags": [
-                        "Deprecated"
-                    ]
+                    }
                 },
                 {
                     "MemberType": "Function",
                     "Name": "toObjectSpace",
+                    "Tags": ["Deprecated"],
                     "Parameters": [
                         {
                             "Name": "cf",
@@ -3866,14 +3825,12 @@
                     ],
                     "ReturnType": {
                         "Name": "CFrame"
-                    },
-                    "Tags": [
-                        "Deprecated"
-                    ]
+                    }
                 },
                 {
                     "MemberType": "Function",
                     "Name": "toEulerAnglesXYZ",
+                    "Tags": ["Deprecated"],
                     "Parameters": [],
                     "TupleReturns": [
                         {
@@ -3885,9 +3842,6 @@
                         {
                             "Name": "number"
                         }
-                    ],
-                    "Tags": [
-                        "Deprecated"
                     ]
                 },
                 {
@@ -3915,6 +3869,7 @@
                 {
                     "MemberType": "Function",
                     "Name": "components",
+                    "Tags": ["Deprecated"],
                     "Parameters": [],
                     "TupleReturns": [
                         {
@@ -3953,9 +3908,6 @@
                         {
                             "Name": "number"
                         }
-                    ],
-                    "Tags": [
-                        "Deprecated"
                     ]
                 }
             ],
@@ -4201,7 +4153,8 @@
                 {
                     "MemberType": "Function",
                     "Name": "Abs",
-                    "Parameters": [],
+                    "Parameters": [
+                    ],
                     "ReturnType": {
                         "Name": "Vector3"
                     }
@@ -4209,7 +4162,8 @@
                 {
                     "MemberType": "Function",
                     "Name": "Ceil",
-                    "Parameters": [],
+                    "Parameters": [
+                    ],
                     "ReturnType": {
                         "Name": "Vector3"
                     }
@@ -4217,7 +4171,8 @@
                 {
                     "MemberType": "Function",
                     "Name": "Floor",
-                    "Parameters": [],
+                    "Parameters": [
+                    ],
                     "ReturnType": {
                         "Name": "Vector3"
                     }
@@ -4225,7 +4180,8 @@
                 {
                     "MemberType": "Function",
                     "Name": "Sign",
-                    "Parameters": [],
+                    "Parameters": [
+                    ],
                     "ReturnType": {
                         "Name": "Vector3"
                     }
@@ -4310,6 +4266,7 @@
                 {
                     "MemberType": "Function",
                     "Name": "lerp",
+                    "Tags": ["Deprecated"],
                     "Parameters": [
                         {
                             "Name": "goal",
@@ -4326,60 +4283,47 @@
                     ],
                     "ReturnType": {
                         "Name": "Vector3"
-                    },
-                    "Tags": [
-                        "Deprecated"
-                    ]
+                    }
                 },
                 {
                     "MemberType": "Property",
+                    "Tags": ["Deprecated"],
                     "Name": "z",
                     "ValueType": {
                         "Name": "number"
-                    },
-                    "Tags": [
-                        "Deprecated"
-                    ]
+                    }
                 },
                 {
                     "MemberType": "Property",
+                    "Tags": ["Deprecated"],
                     "Name": "y",
                     "ValueType": {
                         "Name": "number"
-                    },
-                    "Tags": [
-                        "Deprecated"
-                    ]
+                    }
                 },
                 {
                     "MemberType": "Property",
+                    "Tags": ["Deprecated"],
                     "Name": "x",
                     "ValueType": {
                         "Name": "number"
-                    },
-                    "Tags": [
-                        "Deprecated"
-                    ]
+                    }
                 },
                 {
                     "MemberType": "Property",
+                    "Tags": ["Deprecated"],
                     "Name": "unit",
                     "ValueType": {
                         "Name": "Vector3"
-                    },
-                    "Tags": [
-                        "Deprecated"
-                    ]
+                    }
                 },
                 {
                     "MemberType": "Property",
+                    "Tags": ["Deprecated"],
                     "Name": "magnitude",
                     "ValueType": {
                         "Name": "number"
-                    },
-                    "Tags": [
-                        "Deprecated"
-                    ]
+                    }
                 }
             ],
             "Name": "Vector3"
@@ -4524,23 +4468,19 @@
                 {
                     "MemberType": "Function",
                     "Name": "disconnect",
+                    "Tags": ["Deprecated"],
                     "Parameters": [],
                     "ReturnType": {
                         "Name": "void"
-                    },
-                    "Tags": [
-                        "Deprecated"
-                    ]
+                    }
                 },
                 {
                     "MemberType": "Property",
                     "Name": "connected",
+                    "Tags": ["Deprecated"],
                     "ValueType": {
                         "Name": "bool"
-                    },
-                    "Tags": [
-                        "Deprecated"
-                    ]
+                    }
                 }
             ],
             "Name": "RBXScriptConnection"
@@ -4606,17 +4546,16 @@
                 {
                     "MemberType": "Function",
                     "Name": "wait",
+                    "Tags": ["Deprecated"],
                     "Parameters": [],
                     "ReturnType": {
                         "Name": "Variant"
-                    },
-                    "Tags": [
-                        "Deprecated"
-                    ]
+                    }
                 },
                 {
                     "MemberType": "Function",
                     "Name": "connect",
+                    "Tags": ["Deprecated"],
                     "Parameters": [
                         {
                             "Name": "callback",
@@ -4627,10 +4566,7 @@
                     ],
                     "ReturnType": {
                         "Name": "RBXScriptConnection"
-                    },
-                    "Tags": [
-                        "Deprecated"
-                    ]
+                    }
                 }
             ],
             "Name": "RBXScriptSignal"
@@ -4797,7 +4733,7 @@
                     "MemberType": "Property",
                     "Name": "SourceType",
                     "ValueType": {
-                        "Category": "Enum",
+                       "Category": "Enum",
                         "Name": "ContentSourceType"
                     }
                 },
@@ -4814,7 +4750,7 @@
                     "ValueType": {
                         "Name": "Object?"
                     }
-                }
+                } 
             ],
             "Name": "Content"
         },
@@ -5574,6 +5510,7 @@
                 {
                     "MemberType": "Property",
                     "Name": "Position",
+                    
                     "ValueType": {
                         "Name": "UDim2"
                     }
@@ -5581,6 +5518,7 @@
                 {
                     "MemberType": "Property",
                     "Name": "LeftTangent",
+                    
                     "ValueType": {
                         "Name": "UDim2"
                     }
@@ -5588,6 +5526,7 @@
                 {
                     "MemberType": "Property",
                     "Name": "RightTangent",
+                    
                     "ValueType": {
                         "Name": "UDim2"
                     }

--- a/scripts/dumpRobloxTypes.py
+++ b/scripts/dumpRobloxTypes.py
@@ -914,6 +914,9 @@ def resolveDeprecation(member: ApiMember, klass: ApiClass | DataType) -> str:
 
     result = ""
 
+    if member.get("Deprecated") is True and not tags:
+        return "@deprecated\n\t\t"
+
     if tags is not None:
         for tag in tags:
             if tag == "Deprecated":
@@ -973,12 +976,11 @@ def classIgnoredMembers(klassName: str):
 
 
 def filterMember(klassName: str, member: ApiMember):
-    if not INCLUDE_DEPRECATED_MEMBERS and (
-        "Tags" in member and
-        member["Tags"] is not None
-        and "Deprecated" in member["Tags"]
-        and member["MemberType"] != "Function"
-    ):
+    is_deprecated = (
+        member.get("Deprecated") is True
+        or ("Tags" in member and member["Tags"] is not None and "Deprecated" in member["Tags"])
+    )
+    if not INCLUDE_DEPRECATED_MEMBERS and is_deprecated and member["MemberType"] != "Function":
         return False
 
     if ("Tags" in member and

--- a/scripts/dumpRobloxTypes.py
+++ b/scripts/dumpRobloxTypes.py
@@ -914,9 +914,6 @@ def resolveDeprecation(member: ApiMember, klass: ApiClass | DataType) -> str:
 
     result = ""
 
-    if member.get("Deprecated") is True and not tags:
-        return "@deprecated\n\t\t"
-
     if tags is not None:
         for tag in tags:
             if tag == "Deprecated":
@@ -976,11 +973,12 @@ def classIgnoredMembers(klassName: str):
 
 
 def filterMember(klassName: str, member: ApiMember):
-    is_deprecated = (
-        member.get("Deprecated") is True
-        or ("Tags" in member and member["Tags"] is not None and "Deprecated" in member["Tags"])
-    )
-    if not INCLUDE_DEPRECATED_MEMBERS and is_deprecated and member["MemberType"] != "Function":
+    if not INCLUDE_DEPRECATED_MEMBERS and (
+        "Tags" in member and
+        member["Tags"] is not None
+        and "Deprecated" in member["Tags"]
+        and member["MemberType"] != "Function"
+    ):
         return False
 
     if ("Tags" in member and

--- a/scripts/globalTypes.LocalUserSecurity.d.luau
+++ b/scripts/globalTypes.LocalUserSecurity.d.luau
@@ -7513,6 +7513,28 @@ declare class BrickColor
 end
 
 declare class CFrame
+	@deprecated
+		function components(self): (number, number, number, number, number, number, number, number, number, number, number, number)
+	@deprecated
+		function inverse(self): CFrame
+	@deprecated
+		function lerp(self, goal: CFrame, alpha: number): CFrame
+	@deprecated
+		function pointToObjectSpace(self, v3: Vector3): Vector3
+	@deprecated
+		function pointToWorldSpace(self, v3: Vector3): Vector3
+	@deprecated
+		function toAxisAngle(self): (Vector3, number)
+	@deprecated
+		function toEulerAnglesXYZ(self): (number, number, number)
+	@deprecated
+		function toObjectSpace(self, cf: CFrame): CFrame
+	@deprecated
+		function toWorldSpace(self, cf: CFrame): CFrame
+	@deprecated
+		function vectorToObjectSpace(self, v3: Vector3): Vector3
+	@deprecated
+		function vectorToWorldSpace(self, v3: Vector3): Vector3
 	LookVector: Vector3
 	Position: Vector3
 	RightVector: Vector3
@@ -7544,24 +7566,6 @@ declare class CFrame
 	function __mul(self, other: CFrame): CFrame
 	function __mul(self, other: Vector3): Vector3
 	function __sub(self, other: Vector3): CFrame
-	function components(self): (number, number, number, number, number, number, number, number, number, number, number, number)
-	function inverse(self): CFrame
-	function lerp(self, goal: CFrame, alpha: number): CFrame
-	function pointToObjectSpace(self, v3: Vector3): Vector3
-	function pointToWorldSpace(self, v3: Vector3): Vector3
-	function toAxisAngle(self): (Vector3, number)
-	function toEulerAnglesXYZ(self): (number, number, number)
-	function toObjectSpace(self, cf: CFrame): CFrame
-	function toWorldSpace(self, cf: CFrame): CFrame
-	function vectorToObjectSpace(self, v3: Vector3): Vector3
-	function vectorToWorldSpace(self, v3: Vector3): Vector3
-	lookVector: Vector3
-	p: Vector3
-	rightVector: Vector3
-	upVector: Vector3
-	x: number
-	y: number
-	z: number
 end
 
 declare class CatalogSearchParams
@@ -7582,16 +7586,14 @@ declare class CatalogSearchParams
 end
 
 declare class Color3
+	@deprecated
+		function lerp(self, color: Color3, alpha: number): Color3
 	B: number
 	G: number
 	R: number
-	b: number
 	function Lerp(self, color: Color3, alpha: number): Color3
 	function ToHSV(self): (number, number, number)
 	function ToHex(self): string
-	function lerp(self, color: Color3, alpha: number): Color3
-	g: number
-	r: number
 end
 
 declare class ColorSequence
@@ -7710,10 +7712,10 @@ declare class PhysicalProperties
 end
 
 declare class RBXScriptConnection
+	@deprecated
+		function disconnect(self): nil
 	Connected: boolean
-	connected: boolean
 	function Disconnect(self): nil
-	function disconnect(self): nil
 end
 
 
@@ -7817,6 +7819,8 @@ declare class UDim2
 end
 
 declare class Vector2
+	@deprecated
+		function lerp(self, v: Vector2, alpha: number): Vector2
 	Magnitude: number
 	Unit: Vector2
 	X: number
@@ -7838,11 +7842,6 @@ declare class Vector2
 	function __mul(self, other: Vector2 | number): Vector2
 	function __sub(self, other: Vector2): Vector2
 	function __unm(self): Vector2
-	function lerp(self, v: Vector2, alpha: number): Vector2
-	magnitude: number
-	unit: Vector2
-	x: number
-	y: number
 end
 
 declare class Vector2int16
@@ -7856,6 +7855,8 @@ declare class Vector2int16
 end
 
 declare class Vector3
+	@deprecated
+		function lerp(self, goal: Vector3, alpha: number): Vector3
 	Magnitude: number
 	Unit: Vector3
 	X: number
@@ -7878,12 +7879,6 @@ declare class Vector3
 	function __mul(self, other: Vector3 | number): Vector3
 	function __sub(self, other: Vector3): Vector3
 	function __unm(self): Vector3
-	function lerp(self, goal: Vector3, alpha: number): Vector3
-	magnitude: number
-	unit: Vector3
-	x: number
-	y: number
-	z: number
 end
 
 declare class Vector3int16

--- a/scripts/globalTypes.None.d.luau
+++ b/scripts/globalTypes.None.d.luau
@@ -7513,6 +7513,28 @@ declare class BrickColor
 end
 
 declare class CFrame
+	@deprecated
+		function components(self): (number, number, number, number, number, number, number, number, number, number, number, number)
+	@deprecated
+		function inverse(self): CFrame
+	@deprecated
+		function lerp(self, goal: CFrame, alpha: number): CFrame
+	@deprecated
+		function pointToObjectSpace(self, v3: Vector3): Vector3
+	@deprecated
+		function pointToWorldSpace(self, v3: Vector3): Vector3
+	@deprecated
+		function toAxisAngle(self): (Vector3, number)
+	@deprecated
+		function toEulerAnglesXYZ(self): (number, number, number)
+	@deprecated
+		function toObjectSpace(self, cf: CFrame): CFrame
+	@deprecated
+		function toWorldSpace(self, cf: CFrame): CFrame
+	@deprecated
+		function vectorToObjectSpace(self, v3: Vector3): Vector3
+	@deprecated
+		function vectorToWorldSpace(self, v3: Vector3): Vector3
 	LookVector: Vector3
 	Position: Vector3
 	RightVector: Vector3
@@ -7544,24 +7566,6 @@ declare class CFrame
 	function __mul(self, other: CFrame): CFrame
 	function __mul(self, other: Vector3): Vector3
 	function __sub(self, other: Vector3): CFrame
-	function components(self): (number, number, number, number, number, number, number, number, number, number, number, number)
-	function inverse(self): CFrame
-	function lerp(self, goal: CFrame, alpha: number): CFrame
-	function pointToObjectSpace(self, v3: Vector3): Vector3
-	function pointToWorldSpace(self, v3: Vector3): Vector3
-	function toAxisAngle(self): (Vector3, number)
-	function toEulerAnglesXYZ(self): (number, number, number)
-	function toObjectSpace(self, cf: CFrame): CFrame
-	function toWorldSpace(self, cf: CFrame): CFrame
-	function vectorToObjectSpace(self, v3: Vector3): Vector3
-	function vectorToWorldSpace(self, v3: Vector3): Vector3
-	lookVector: Vector3
-	p: Vector3
-	rightVector: Vector3
-	upVector: Vector3
-	x: number
-	y: number
-	z: number
 end
 
 declare class CatalogSearchParams
@@ -7582,16 +7586,14 @@ declare class CatalogSearchParams
 end
 
 declare class Color3
+	@deprecated
+		function lerp(self, color: Color3, alpha: number): Color3
 	B: number
 	G: number
 	R: number
-	b: number
 	function Lerp(self, color: Color3, alpha: number): Color3
 	function ToHSV(self): (number, number, number)
 	function ToHex(self): string
-	function lerp(self, color: Color3, alpha: number): Color3
-	g: number
-	r: number
 end
 
 declare class ColorSequence
@@ -7710,10 +7712,10 @@ declare class PhysicalProperties
 end
 
 declare class RBXScriptConnection
+	@deprecated
+		function disconnect(self): nil
 	Connected: boolean
-	connected: boolean
 	function Disconnect(self): nil
-	function disconnect(self): nil
 end
 
 
@@ -7817,6 +7819,8 @@ declare class UDim2
 end
 
 declare class Vector2
+	@deprecated
+		function lerp(self, v: Vector2, alpha: number): Vector2
 	Magnitude: number
 	Unit: Vector2
 	X: number
@@ -7838,11 +7842,6 @@ declare class Vector2
 	function __mul(self, other: Vector2 | number): Vector2
 	function __sub(self, other: Vector2): Vector2
 	function __unm(self): Vector2
-	function lerp(self, v: Vector2, alpha: number): Vector2
-	magnitude: number
-	unit: Vector2
-	x: number
-	y: number
 end
 
 declare class Vector2int16
@@ -7856,6 +7855,8 @@ declare class Vector2int16
 end
 
 declare class Vector3
+	@deprecated
+		function lerp(self, goal: Vector3, alpha: number): Vector3
 	Magnitude: number
 	Unit: Vector3
 	X: number
@@ -7878,12 +7879,6 @@ declare class Vector3
 	function __mul(self, other: Vector3 | number): Vector3
 	function __sub(self, other: Vector3): Vector3
 	function __unm(self): Vector3
-	function lerp(self, goal: Vector3, alpha: number): Vector3
-	magnitude: number
-	unit: Vector3
-	x: number
-	y: number
-	z: number
 end
 
 declare class Vector3int16

--- a/scripts/globalTypes.PluginSecurity.d.luau
+++ b/scripts/globalTypes.PluginSecurity.d.luau
@@ -7513,6 +7513,28 @@ declare class BrickColor
 end
 
 declare class CFrame
+	@deprecated
+		function components(self): (number, number, number, number, number, number, number, number, number, number, number, number)
+	@deprecated
+		function inverse(self): CFrame
+	@deprecated
+		function lerp(self, goal: CFrame, alpha: number): CFrame
+	@deprecated
+		function pointToObjectSpace(self, v3: Vector3): Vector3
+	@deprecated
+		function pointToWorldSpace(self, v3: Vector3): Vector3
+	@deprecated
+		function toAxisAngle(self): (Vector3, number)
+	@deprecated
+		function toEulerAnglesXYZ(self): (number, number, number)
+	@deprecated
+		function toObjectSpace(self, cf: CFrame): CFrame
+	@deprecated
+		function toWorldSpace(self, cf: CFrame): CFrame
+	@deprecated
+		function vectorToObjectSpace(self, v3: Vector3): Vector3
+	@deprecated
+		function vectorToWorldSpace(self, v3: Vector3): Vector3
 	LookVector: Vector3
 	Position: Vector3
 	RightVector: Vector3
@@ -7544,24 +7566,6 @@ declare class CFrame
 	function __mul(self, other: CFrame): CFrame
 	function __mul(self, other: Vector3): Vector3
 	function __sub(self, other: Vector3): CFrame
-	function components(self): (number, number, number, number, number, number, number, number, number, number, number, number)
-	function inverse(self): CFrame
-	function lerp(self, goal: CFrame, alpha: number): CFrame
-	function pointToObjectSpace(self, v3: Vector3): Vector3
-	function pointToWorldSpace(self, v3: Vector3): Vector3
-	function toAxisAngle(self): (Vector3, number)
-	function toEulerAnglesXYZ(self): (number, number, number)
-	function toObjectSpace(self, cf: CFrame): CFrame
-	function toWorldSpace(self, cf: CFrame): CFrame
-	function vectorToObjectSpace(self, v3: Vector3): Vector3
-	function vectorToWorldSpace(self, v3: Vector3): Vector3
-	lookVector: Vector3
-	p: Vector3
-	rightVector: Vector3
-	upVector: Vector3
-	x: number
-	y: number
-	z: number
 end
 
 declare class CatalogSearchParams
@@ -7582,16 +7586,14 @@ declare class CatalogSearchParams
 end
 
 declare class Color3
+	@deprecated
+		function lerp(self, color: Color3, alpha: number): Color3
 	B: number
 	G: number
 	R: number
-	b: number
 	function Lerp(self, color: Color3, alpha: number): Color3
 	function ToHSV(self): (number, number, number)
 	function ToHex(self): string
-	function lerp(self, color: Color3, alpha: number): Color3
-	g: number
-	r: number
 end
 
 declare class ColorSequence
@@ -7710,10 +7712,10 @@ declare class PhysicalProperties
 end
 
 declare class RBXScriptConnection
+	@deprecated
+		function disconnect(self): nil
 	Connected: boolean
-	connected: boolean
 	function Disconnect(self): nil
-	function disconnect(self): nil
 end
 
 
@@ -7817,6 +7819,8 @@ declare class UDim2
 end
 
 declare class Vector2
+	@deprecated
+		function lerp(self, v: Vector2, alpha: number): Vector2
 	Magnitude: number
 	Unit: Vector2
 	X: number
@@ -7838,11 +7842,6 @@ declare class Vector2
 	function __mul(self, other: Vector2 | number): Vector2
 	function __sub(self, other: Vector2): Vector2
 	function __unm(self): Vector2
-	function lerp(self, v: Vector2, alpha: number): Vector2
-	magnitude: number
-	unit: Vector2
-	x: number
-	y: number
 end
 
 declare class Vector2int16
@@ -7856,6 +7855,8 @@ declare class Vector2int16
 end
 
 declare class Vector3
+	@deprecated
+		function lerp(self, goal: Vector3, alpha: number): Vector3
 	Magnitude: number
 	Unit: Vector3
 	X: number
@@ -7878,12 +7879,6 @@ declare class Vector3
 	function __mul(self, other: Vector3 | number): Vector3
 	function __sub(self, other: Vector3): Vector3
 	function __unm(self): Vector3
-	function lerp(self, goal: Vector3, alpha: number): Vector3
-	magnitude: number
-	unit: Vector3
-	x: number
-	y: number
-	z: number
 end
 
 declare class Vector3int16

--- a/scripts/globalTypes.RobloxScriptSecurity.d.luau
+++ b/scripts/globalTypes.RobloxScriptSecurity.d.luau
@@ -7513,6 +7513,28 @@ declare class BrickColor
 end
 
 declare class CFrame
+	@deprecated
+		function components(self): (number, number, number, number, number, number, number, number, number, number, number, number)
+	@deprecated
+		function inverse(self): CFrame
+	@deprecated
+		function lerp(self, goal: CFrame, alpha: number): CFrame
+	@deprecated
+		function pointToObjectSpace(self, v3: Vector3): Vector3
+	@deprecated
+		function pointToWorldSpace(self, v3: Vector3): Vector3
+	@deprecated
+		function toAxisAngle(self): (Vector3, number)
+	@deprecated
+		function toEulerAnglesXYZ(self): (number, number, number)
+	@deprecated
+		function toObjectSpace(self, cf: CFrame): CFrame
+	@deprecated
+		function toWorldSpace(self, cf: CFrame): CFrame
+	@deprecated
+		function vectorToObjectSpace(self, v3: Vector3): Vector3
+	@deprecated
+		function vectorToWorldSpace(self, v3: Vector3): Vector3
 	LookVector: Vector3
 	Position: Vector3
 	RightVector: Vector3
@@ -7544,24 +7566,6 @@ declare class CFrame
 	function __mul(self, other: CFrame): CFrame
 	function __mul(self, other: Vector3): Vector3
 	function __sub(self, other: Vector3): CFrame
-	function components(self): (number, number, number, number, number, number, number, number, number, number, number, number)
-	function inverse(self): CFrame
-	function lerp(self, goal: CFrame, alpha: number): CFrame
-	function pointToObjectSpace(self, v3: Vector3): Vector3
-	function pointToWorldSpace(self, v3: Vector3): Vector3
-	function toAxisAngle(self): (Vector3, number)
-	function toEulerAnglesXYZ(self): (number, number, number)
-	function toObjectSpace(self, cf: CFrame): CFrame
-	function toWorldSpace(self, cf: CFrame): CFrame
-	function vectorToObjectSpace(self, v3: Vector3): Vector3
-	function vectorToWorldSpace(self, v3: Vector3): Vector3
-	lookVector: Vector3
-	p: Vector3
-	rightVector: Vector3
-	upVector: Vector3
-	x: number
-	y: number
-	z: number
 end
 
 declare class CatalogSearchParams
@@ -7582,16 +7586,14 @@ declare class CatalogSearchParams
 end
 
 declare class Color3
+	@deprecated
+		function lerp(self, color: Color3, alpha: number): Color3
 	B: number
 	G: number
 	R: number
-	b: number
 	function Lerp(self, color: Color3, alpha: number): Color3
 	function ToHSV(self): (number, number, number)
 	function ToHex(self): string
-	function lerp(self, color: Color3, alpha: number): Color3
-	g: number
-	r: number
 end
 
 declare class ColorSequence
@@ -7710,10 +7712,10 @@ declare class PhysicalProperties
 end
 
 declare class RBXScriptConnection
+	@deprecated
+		function disconnect(self): nil
 	Connected: boolean
-	connected: boolean
 	function Disconnect(self): nil
-	function disconnect(self): nil
 end
 
 
@@ -7817,6 +7819,8 @@ declare class UDim2
 end
 
 declare class Vector2
+	@deprecated
+		function lerp(self, v: Vector2, alpha: number): Vector2
 	Magnitude: number
 	Unit: Vector2
 	X: number
@@ -7838,11 +7842,6 @@ declare class Vector2
 	function __mul(self, other: Vector2 | number): Vector2
 	function __sub(self, other: Vector2): Vector2
 	function __unm(self): Vector2
-	function lerp(self, v: Vector2, alpha: number): Vector2
-	magnitude: number
-	unit: Vector2
-	x: number
-	y: number
 end
 
 declare class Vector2int16
@@ -7856,6 +7855,8 @@ declare class Vector2int16
 end
 
 declare class Vector3
+	@deprecated
+		function lerp(self, goal: Vector3, alpha: number): Vector3
 	Magnitude: number
 	Unit: Vector3
 	X: number
@@ -7878,12 +7879,6 @@ declare class Vector3
 	function __mul(self, other: Vector3 | number): Vector3
 	function __sub(self, other: Vector3): Vector3
 	function __unm(self): Vector3
-	function lerp(self, goal: Vector3, alpha: number): Vector3
-	magnitude: number
-	unit: Vector3
-	x: number
-	y: number
-	z: number
 end
 
 declare class Vector3int16

--- a/scripts/globalTypes.d.luau
+++ b/scripts/globalTypes.d.luau
@@ -7513,6 +7513,28 @@ declare class BrickColor
 end
 
 declare class CFrame
+	@deprecated
+		function components(self): (number, number, number, number, number, number, number, number, number, number, number, number)
+	@deprecated
+		function inverse(self): CFrame
+	@deprecated
+		function lerp(self, goal: CFrame, alpha: number): CFrame
+	@deprecated
+		function pointToObjectSpace(self, v3: Vector3): Vector3
+	@deprecated
+		function pointToWorldSpace(self, v3: Vector3): Vector3
+	@deprecated
+		function toAxisAngle(self): (Vector3, number)
+	@deprecated
+		function toEulerAnglesXYZ(self): (number, number, number)
+	@deprecated
+		function toObjectSpace(self, cf: CFrame): CFrame
+	@deprecated
+		function toWorldSpace(self, cf: CFrame): CFrame
+	@deprecated
+		function vectorToObjectSpace(self, v3: Vector3): Vector3
+	@deprecated
+		function vectorToWorldSpace(self, v3: Vector3): Vector3
 	LookVector: Vector3
 	Position: Vector3
 	RightVector: Vector3
@@ -7544,24 +7566,6 @@ declare class CFrame
 	function __mul(self, other: CFrame): CFrame
 	function __mul(self, other: Vector3): Vector3
 	function __sub(self, other: Vector3): CFrame
-	function components(self): (number, number, number, number, number, number, number, number, number, number, number, number)
-	function inverse(self): CFrame
-	function lerp(self, goal: CFrame, alpha: number): CFrame
-	function pointToObjectSpace(self, v3: Vector3): Vector3
-	function pointToWorldSpace(self, v3: Vector3): Vector3
-	function toAxisAngle(self): (Vector3, number)
-	function toEulerAnglesXYZ(self): (number, number, number)
-	function toObjectSpace(self, cf: CFrame): CFrame
-	function toWorldSpace(self, cf: CFrame): CFrame
-	function vectorToObjectSpace(self, v3: Vector3): Vector3
-	function vectorToWorldSpace(self, v3: Vector3): Vector3
-	lookVector: Vector3
-	p: Vector3
-	rightVector: Vector3
-	upVector: Vector3
-	x: number
-	y: number
-	z: number
 end
 
 declare class CatalogSearchParams
@@ -7582,16 +7586,14 @@ declare class CatalogSearchParams
 end
 
 declare class Color3
+	@deprecated
+		function lerp(self, color: Color3, alpha: number): Color3
 	B: number
 	G: number
 	R: number
-	b: number
 	function Lerp(self, color: Color3, alpha: number): Color3
 	function ToHSV(self): (number, number, number)
 	function ToHex(self): string
-	function lerp(self, color: Color3, alpha: number): Color3
-	g: number
-	r: number
 end
 
 declare class ColorSequence
@@ -7710,10 +7712,10 @@ declare class PhysicalProperties
 end
 
 declare class RBXScriptConnection
+	@deprecated
+		function disconnect(self): nil
 	Connected: boolean
-	connected: boolean
 	function Disconnect(self): nil
-	function disconnect(self): nil
 end
 
 
@@ -7817,6 +7819,8 @@ declare class UDim2
 end
 
 declare class Vector2
+	@deprecated
+		function lerp(self, v: Vector2, alpha: number): Vector2
 	Magnitude: number
 	Unit: Vector2
 	X: number
@@ -7838,11 +7842,6 @@ declare class Vector2
 	function __mul(self, other: Vector2 | number): Vector2
 	function __sub(self, other: Vector2): Vector2
 	function __unm(self): Vector2
-	function lerp(self, v: Vector2, alpha: number): Vector2
-	magnitude: number
-	unit: Vector2
-	x: number
-	y: number
 end
 
 declare class Vector2int16
@@ -7856,6 +7855,8 @@ declare class Vector2int16
 end
 
 declare class Vector3
+	@deprecated
+		function lerp(self, goal: Vector3, alpha: number): Vector3
 	Magnitude: number
 	Unit: Vector3
 	X: number
@@ -7878,12 +7879,6 @@ declare class Vector3
 	function __mul(self, other: Vector3 | number): Vector3
 	function __sub(self, other: Vector3): Vector3
 	function __unm(self): Vector3
-	function lerp(self, goal: Vector3, alpha: number): Vector3
-	magnitude: number
-	unit: Vector3
-	x: number
-	y: number
-	z: number
 end
 
 declare class Vector3int16


### PR DESCRIPTION
Use `Tags` array containing `Deprecated` for `DataTypes.json`, so that the existing "deprecated" logic in `dumpRobloxTypes.py` works correctly. This means that functions on data types are now correctly marked with `@deprecated` annotations, and deprecated properties are removed (unless `INCLUDE_DEPRECATED_MEMBERS` is set)

Fixes #1477 