### PR TITLE
Fix iterator invalidation crash in workspaceSymbol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - String requires (including `@game` aliases and relative requires between DataModel siblings with non-mirrored filesystem layouts) now resolve correctly when using `luau-lsp analyze` with a sourcemap ([#1473](https://github.com/JohnnyMorganz/luau-lsp/issues/1473))
 - Auto-imported string requires from `init.luau` files now correctly use `@self/` paths for child modules when sourcemap-based requires are in use
 - Deprecated properties for Data Types (e.g. `Vector3.magnitude`, `Vector2.y`, `CFrame.p`) are now correctly filtered from autocompletion when `showDeprecatedItems` is disabled, and deprecated functions are annotated with `@deprecated` in generated type definitions ([#1477](https://github.com/JohnnyMorganz/luau-lsp/issues/1477))
+- Fixed an iterator-invalidation crash in `workspace/symbol` when a source module's source becomes unreadable or new dependencies are discovered during the request
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Sync to upstream Luau 0.720
 - Sourcemap-based auto-imports (both instance and string versions) are now server/client boundary aware: we no longer suggest server scripts from client context and vice versa ([#1065](https://github.com/JohnnyMorganz/luau-lsp/issues/1065))
+- Improved performance of `workspace/symbol` request on large workspaces by deduplicating common transitive files when parsing the workspace
 
 ## [1.66.1] - 2026-04-27
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,6 +142,7 @@ target_sources(Luau.LanguageServer.Test PRIVATE
         tests/GoToDefinition.test.cpp
         tests/Glob.test.cpp
         tests/Workspace.test.cpp
+        tests/WorkspaceSymbol.test.cpp
         tests/RequireGraph.test.cpp
         tests/OnTypeFormatting.test.cpp
         tests/AnalyzeCli.test.cpp

--- a/src/operations/WorkspaceSymbol.cpp
+++ b/src/operations/WorkspaceSymbol.cpp
@@ -106,10 +106,8 @@ std::optional<std::vector<lsp::WorkspaceSymbol>> WorkspaceFolder::workspaceSymbo
 {
     std::vector<lsp::WorkspaceSymbol> result;
 
-    // Snapshot the module names before parsing: frontend.parse mutates
-    // frontend.sourceModules via getSourceNode (insert a new dependency, or
-    // erase when source is unreadable), which would invalidate iterators if
-    // we iterated frontend.sourceModules directly while parsing.
+    // parseModules mutates frontend.sourceModules (insert/erase via
+    // getSourceNode), so we cannot iterate the map directly while parsing.
     std::vector<Luau::ModuleName> moduleNames;
     moduleNames.reserve(frontend.sourceModules.size());
     for (const auto& [moduleName, _] : frontend.sourceModules)

--- a/src/operations/WorkspaceSymbol.cpp
+++ b/src/operations/WorkspaceSymbol.cpp
@@ -106,9 +106,22 @@ std::optional<std::vector<lsp::WorkspaceSymbol>> WorkspaceFolder::workspaceSymbo
 {
     std::vector<lsp::WorkspaceSymbol> result;
 
-    for (const auto& [moduleName, sourceModule] : frontend.sourceModules)
+    // Snapshot the module names before parsing: frontend.parse mutates
+    // frontend.sourceModules via getSourceNode (insert a new dependency, or
+    // erase when source is unreadable), which would invalidate iterators if
+    // we iterated frontend.sourceModules directly while parsing.
+    std::vector<Luau::ModuleName> moduleNames;
+    moduleNames.reserve(frontend.sourceModules.size());
+    for (const auto& [moduleName, _] : frontend.sourceModules)
+        moduleNames.push_back(moduleName);
+
+    frontend.parseModules(moduleNames);
+
+    for (const auto& moduleName : moduleNames)
     {
-        frontend.parse(moduleName);
+        auto sourceModule = frontend.getSourceModule(moduleName);
+        if (!sourceModule)
+            continue;
 
         // Find relevant text document
         if (auto textDocument = fileResolver.getOrCreateTextDocumentFromModuleName(moduleName))

--- a/tests/WorkspaceSymbol.test.cpp
+++ b/tests/WorkspaceSymbol.test.cpp
@@ -1,0 +1,36 @@
+#include "doctest.h"
+#include "Fixture.h"
+
+TEST_SUITE_BEGIN("WorkspaceSymbol");
+
+TEST_CASE_FIXTURE(Fixture, "does_not_invalidate_iterator_when_source_becomes_unreadable")
+{
+    // Reproduces a crash in WorkspaceFolder::workspaceSymbol where the loop
+    // iterates `frontend.sourceModules` while calling `frontend.parse(moduleName)`
+    // inside the body. `parse` -> `parseGraph` -> `getSourceNode` mutates
+    // `sourceModules` (erases when source becomes unreadable, inserts when a
+    // new dependency is discovered), invalidating the range-for iterator.
+    //
+    // Setup: open several documents so iteration has multiple steps, then
+    // close them all. closeTextDocument removes them from managedFiles and
+    // marks the source modules dirty. The files are not on disk, so the next
+    // parse() hits the `sourceModules.erase(name)` path inside getSourceNode,
+    // invalidating the for-loop iterator. Under ASAN this surfaces as
+    // heap-use-after-free.
+    auto a = newDocument("a.luau", "local x = 1");
+    auto b = newDocument("b.luau", "local x = 2");
+    auto c = newDocument("c.luau", "local x = 3");
+    auto d = newDocument("d.luau", "local x = 4");
+    auto e = newDocument("e.luau", "local x = 5");
+
+    workspace.closeTextDocument(a);
+    workspace.closeTextDocument(b);
+    workspace.closeTextDocument(c);
+    workspace.closeTextDocument(d);
+    workspace.closeTextDocument(e);
+
+    lsp::WorkspaceSymbolParams params;
+    workspace.workspaceSymbol(params);
+}
+
+TEST_SUITE_END();


### PR DESCRIPTION
`WorkspaceFolder::workspaceSymbol` iterated `frontend.sourceModules` while calling `frontend.parse(moduleName)` inside the loop body. `parse` -> `parseGraph` -> `getSourceNode` mutates `sourceModules` (erases when source becomes unreadable, inserts when a new dependency is discovered), invalidating the range-for iterator and causing a heap-use-after-free on the iterator's key. The crash surfaced in production as `EXC_BAD_ACCESS` inside `getCheckResult`'s `sourceNodes.find(name)` hash lookup, after the dangling `moduleName` reference was passed back into the Frontend.

The fix snapshots the module names into a `std::vector` first, then drives parsing through `Frontend::parseModules` — the existing batched API already used in `Workspace.cpp:248,433`. `parseModules` dedupes transitive dependencies across the batch, so this is also less work than calling `parse()` once per module. After parsing, each source module is looked up fresh from the frontend and any that were erased are skipped.

A regression test in `tests/WorkspaceSymbol.test.cpp` reproduces the crash by closing several open documents whose source files don't exist on disk — the next `parse()` then hits the `sourceModules.erase` path inside `getSourceNode`. Without the fix, ASAN reports a heap-use-after-free with the freed-by stack pointing at `sourceModules.erase` inside `getSourceNode`, called from the `workspaceSymbol` loop.