### PR TITLE
Fix workspaceSymbol query filter and add coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Auto-imported string requires from `init.luau` files now correctly use `@self/` paths for child modules when sourcemap-based requires are in use
 - Deprecated properties for Data Types (e.g. `Vector3.magnitude`, `Vector2.y`, `CFrame.p`) are now correctly filtered from autocompletion when `showDeprecatedItems` is disabled, and deprecated functions are annotated with `@deprecated` in generated type definitions ([#1477](https://github.com/JohnnyMorganz/luau-lsp/issues/1477))
 - Fixed an iterator-invalidation crash in `workspace/symbol` when a source module's source becomes unreadable or new dependencies are discovered during the request
+- Fixed `workspace/symbol` query filter incorrectly excluding symbols whose name begins with the query string and including symbols that did not match the query
 
 ### Changed
 

--- a/src/operations/WorkspaceSymbol.cpp
+++ b/src/operations/WorkspaceSymbol.cpp
@@ -19,7 +19,7 @@ struct WorkspaceSymbolsVisitor : public Luau::AstVisitor
 
     bool matchesQuery(std::string symbolName)
     {
-        return query.empty() || toLower(symbolName).find(query);
+        return query.empty() || toLower(symbolName).find(query) != std::string::npos;
     }
 
     void createLocalSymbol(Luau::AstLocal* local, std::optional<std::string> containerName)

--- a/tests/WorkspaceSymbol.test.cpp
+++ b/tests/WorkspaceSymbol.test.cpp
@@ -1,6 +1,29 @@
 #include "doctest.h"
 #include "Fixture.h"
 
+#include <algorithm>
+
+namespace
+{
+const lsp::WorkspaceSymbol* findSymbol(const std::vector<lsp::WorkspaceSymbol>& symbols, const std::string& name)
+{
+    for (const auto& s : symbols)
+        if (s.name == name)
+            return &s;
+    return nullptr;
+}
+
+std::vector<std::string> sortedNames(const std::vector<lsp::WorkspaceSymbol>& symbols)
+{
+    std::vector<std::string> names;
+    names.reserve(symbols.size());
+    for (const auto& s : symbols)
+        names.push_back(s.name);
+    std::sort(names.begin(), names.end());
+    return names;
+}
+} // namespace
+
 TEST_SUITE_BEGIN("WorkspaceSymbol");
 
 TEST_CASE_FIXTURE(Fixture, "does_not_invalidate_iterator_when_source_becomes_unreadable")
@@ -31,6 +54,125 @@ TEST_CASE_FIXTURE(Fixture, "does_not_invalidate_iterator_when_source_becomes_unr
 
     lsp::WorkspaceSymbolParams params;
     workspace.workspaceSymbol(params);
+}
+
+TEST_CASE_FIXTURE(Fixture, "empty_query_returns_all_symbols")
+{
+    newDocument("a.luau", R"(
+        local function foo() end
+        local function bar() end
+    )");
+
+    lsp::WorkspaceSymbolParams params;
+    auto result = workspace.workspaceSymbol(params);
+
+    REQUIRE(result);
+    CHECK_EQ(sortedNames(*result), std::vector<std::string>{"bar", "foo"});
+}
+
+TEST_CASE_FIXTURE(Fixture, "matches_symbol_when_query_appears_at_start_of_name")
+{
+    // Regression: matchesQuery used to convert string::find's return value
+    // directly to bool, treating "found at index 0" as "no match".
+    newDocument("a.luau", "local function foo() end");
+
+    lsp::WorkspaceSymbolParams params;
+    params.query = "foo";
+    auto result = workspace.workspaceSymbol(params);
+
+    REQUIRE(result);
+    REQUIRE_EQ(result->size(), 1);
+    CHECK_EQ(result->at(0).name, "foo");
+}
+
+TEST_CASE_FIXTURE(Fixture, "query_filter_excludes_non_matching_symbols")
+{
+    // Regression: matchesQuery used to convert string::find's return value
+    // directly to bool, treating npos (not found) as truthy.
+    newDocument("a.luau", R"(
+        local function foo() end
+        local function bar() end
+    )");
+
+    lsp::WorkspaceSymbolParams params;
+    params.query = "foo";
+    auto result = workspace.workspaceSymbol(params);
+
+    REQUIRE(result);
+    REQUIRE_EQ(result->size(), 1);
+    CHECK_EQ(result->at(0).name, "foo");
+}
+
+TEST_CASE_FIXTURE(Fixture, "query_matches_case_insensitively")
+{
+    newDocument("a.luau", "local function MyFunction() end");
+
+    lsp::WorkspaceSymbolParams params;
+    params.query = "myfunc";
+    auto result = workspace.workspaceSymbol(params);
+
+    REQUIRE(result);
+    REQUIRE_EQ(result->size(), 1);
+    CHECK_EQ(result->at(0).name, "MyFunction");
+}
+
+TEST_CASE_FIXTURE(Fixture, "reports_correct_symbol_kinds")
+{
+    newDocument("a.luau", R"(
+        local x = 1
+        type Tee = string
+        function fn() end
+        local function localFn() end
+        local tbl = {}
+        function tbl:method() end
+    )");
+
+    lsp::WorkspaceSymbolParams params;
+    auto result = workspace.workspaceSymbol(params);
+    REQUIRE(result);
+
+    auto x = findSymbol(*result, "x");
+    REQUIRE(x);
+    CHECK(x->kind == lsp::SymbolKind::Variable);
+
+    auto tee = findSymbol(*result, "Tee");
+    REQUIRE(tee);
+    CHECK(tee->kind == lsp::SymbolKind::Interface);
+
+    auto fn = findSymbol(*result, "fn");
+    REQUIRE(fn);
+    CHECK(fn->kind == lsp::SymbolKind::Function);
+
+    auto localFn = findSymbol(*result, "localFn");
+    REQUIRE(localFn);
+    CHECK(localFn->kind == lsp::SymbolKind::Function);
+
+    auto method = findSymbol(*result, "tbl:method");
+    REQUIRE(method);
+    CHECK(method->kind == lsp::SymbolKind::Method);
+}
+
+TEST_CASE_FIXTURE(Fixture, "multi_variable_local_yields_multiple_symbols")
+{
+    newDocument("a.luau", "local a, b, c = 1, 2, 3");
+
+    lsp::WorkspaceSymbolParams params;
+    auto result = workspace.workspaceSymbol(params);
+
+    REQUIRE(result);
+    CHECK_EQ(sortedNames(*result), std::vector<std::string>{"a", "b", "c"});
+}
+
+TEST_CASE_FIXTURE(Fixture, "returns_symbols_from_multiple_files")
+{
+    newDocument("a.luau", "local foo = 1");
+    newDocument("b.luau", "local bar = 2");
+
+    lsp::WorkspaceSymbolParams params;
+    auto result = workspace.workspaceSymbol(params);
+
+    REQUIRE(result);
+    CHECK_EQ(sortedNames(*result), std::vector<std::string>{"bar", "foo"});
 }
 
 TEST_SUITE_END();


### PR DESCRIPTION
`WorkspaceSymbolsVisitor::matchesQuery` converted `std::string::find`'s return value directly to bool:

```cpp
return query.empty() || toLower(symbolName).find(query);
```

`find` returns `size_t` — `0` when the query matches at the start of the symbol name, `npos` (a very large value) when not found. The implicit bool conversion made these cases backwards: symbols whose name began with the query were filtered out, and symbols that did not match the query were kept. Compare against `std::string::npos` instead.

Also adds tests for previously-uncovered behaviour: query filtering (empty query, exact match, prefix match, case-insensitivity, exclusion of non-matching symbols), symbol kind detection (variables, type aliases, functions, local functions, methods), multi-variable locals, and multi-file aggregation.