### PR TITLE
Normalize Windows drive letter case in alias path resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Fixed incorrect description for `require()` when platform is set to "standard." ([#1479](<https://github.com/JohnnyMorganz/luau-lsp/issues/1479>))
+- Fixed module aliases pointing to absolute Windows paths (e.g. `C:\...`) causing the type checker to load the same file twice under different module names, producing spurious type mismatch errors.
 
 ## [1.67.0] - 2026-05-10
 

--- a/src/Uri.cpp
+++ b/src/Uri.cpp
@@ -634,6 +634,11 @@ Uri Uri::resolvePath(std::string_view otherPath) const
 
     resolvedPath = Luau::FileUtils::normalizePath(resolvedPath);
 
+#ifdef _WIN32
+    if (resolvedPath.length() >= 2 && resolvedPath[1] == ':' && isupper(resolvedPath[0]))
+        resolvedPath = std::string(1, tolower(resolvedPath[0])) + resolvedPath.substr(1);
+#endif
+
     if (slashAdded)
         resolvedPath = resolvedPath.substr(1);
 

--- a/tests/WorkspaceFileResolver.test.cpp
+++ b/tests/WorkspaceFileResolver.test.cpp
@@ -197,6 +197,27 @@ TEST_CASE_FIXTURE(Fixture, "resolve_alias_supports_absolute_paths")
     CHECK_EQ(resolveAlias("@test/foo", workspace.fileResolver.defaultConfig, {}), Uri::file(basePath).resolvePath("foo"));
 }
 
+#ifdef _WIN32
+TEST_CASE_FIXTURE(Fixture, "resolve_alias_normalizes_drive_letter_case_on_windows")
+{
+    // Alias values with uppercase drive letters must resolve to the same module name as
+    // files opened directly (which always have lowercase drive letters via Uri::file()).
+    // Mismatch causes the type checker to treat the same file as two distinct modules.
+    loadLuaurc(R"(
+    {
+        "aliases": {
+            "test": "C:/Users/test/folder"
+        }
+    }
+    )");
+
+    auto resolved = resolveAlias("@test/module", workspace.fileResolver.defaultConfig, {});
+    REQUIRE(resolved.has_value());
+    // fsPath() must match Uri::file() which lowercases the drive letter
+    CHECK_EQ(resolved->fsPath(), Uri::file("C:/Users/test/folder/module").fsPath());
+}
+#endif
+
 TEST_CASE_FIXTURE(Fixture, "resolve_alias_supports_tilde_expansion")
 {
     loadLuaurc(R"(


### PR DESCRIPTION
Fixes a bug where module aliases pointing to absolute Windows paths (e.g. `C:\Users\...`) cause the type checker to load the same file twice under two different module names — one with uppercase `C:` (from alias resolution) and one with lowercase `c:` (from VS Code's URI convention). The type checker then sees types from the two "modules" as incompatible, producing spurious errors like:

> TypeError: Expected this to be exactly 'Location' from `C:\...\ast.luau`, but got 'Location' from `c:\...\ast.luau`

**Root cause:** `Uri::file()` normalises the Windows drive letter to lowercase (matching VS Code's legacy convention), but `Uri::resolvePath()` does not apply the same normalisation when the input is an absolute path. When `resolveAliasLocation` resolves an alias value like `"C:\\Users\\..."`, it goes through `Uri::resolvePath` rather than `Uri::file`, so the drive letter case is preserved and the resulting module name doesn't match.

**Fix:** Apply the same drive-letter lowercase normalisation in `Uri::resolvePath` after path normalisation, consistent with `Uri::file`.