### PR TITLE
Improve anonymous autofilled function completions with snippets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - Type annotations are included in the snippet by default, matching the types inferred from context
   - New `luau-lsp.completion.anonymousAutofilledFunction.enabled` setting replaces the deprecated `luau-lsp.completion.showAnonymousAutofilledFunction`
   - New `luau-lsp.completion.anonymousAutofilledFunction.addTypeAnnotations` setting controls whether type annotations are included in the snippet (default: `true`)
+  - New `luau-lsp.completion.anonymousAutofilledFunction.addTabstopForParameters` setting controls whether snippet tabstops are placed on parameter names (default: `true`)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Improved anonymous autofilled function completions ([#688](https://github.com/JohnnyMorganz/luau-lsp/issues/688)):
+  - The generated snippet now places the cursor (`$0`) inside the function body and adds snippet tabstops on each parameter name for quick editing
+  - Type annotations are included in the snippet by default, matching the types inferred from context
+  - New `luau-lsp.completion.anonymousAutofilledFunction.enabled` setting replaces the deprecated `luau-lsp.completion.showAnonymousAutofilledFunction`
+  - New `luau-lsp.completion.anonymousAutofilledFunction.addTypeAnnotations` setting controls whether type annotations are included in the snippet (default: `true`)
+
 ### Fixed
 
 - Fixed incorrect description for `require()` when platform is set to "standard." ([#1479](<https://github.com/JohnnyMorganz/luau-lsp/issues/1479>))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-### Added
+### Changed
 
 - Improved anonymous autofilled function completions ([#688](https://github.com/JohnnyMorganz/luau-lsp/issues/688)):
-  - The generated snippet now places the cursor (`$0`) inside the function body and adds snippet tabstops on each parameter name for quick editing
-  - Type annotations are included in the snippet by default, matching the types inferred from context
-  - New `luau-lsp.completion.anonymousAutofilledFunction.enabled` setting replaces the deprecated `luau-lsp.completion.showAnonymousAutofilledFunction`
-  - New `luau-lsp.completion.anonymousAutofilledFunction.addTypeAnnotations` setting controls whether type annotations are included in the snippet (default: `true`)
-  - New `luau-lsp.completion.anonymousAutofilledFunction.addTabstopForParameters` setting controls whether snippet tabstops are placed on parameter names (default: `true`)
+  - The generated snippet now places the cursor (`$0`) inside the function body and adds snippet tabstops on each parameter name for quick editing. If you do not want tabstops on parameter names, disable `luau-lsp.completion.anonymousAutofilledFunction.addTabstopForParameters` (default: `true`)
+  - Type annotations in the generated snippet can be disabled via setting `luau-lsp.completion.anonymousAutofilledFunction.addTypeAnnotations` (default: `true`)
+  - Deprecated setting `luau-lsp.completion.showAnonymousAutofilledFunction` in favour of `luau-lsp.completion.anonymousAutofilledFunction.enabled`
 
 ### Fixed
 
@@ -1990,6 +1988,7 @@ local y = tbl.data -- Should give "This is some special information"
 ### Added
 
 - Added configuration options to enable certain Language Server features. By default, they are all enabled:
+
   - `luau-lsp.completion.enabled`: Autocomplete
   - `luau-lsp.hover.enabled`: Hover
   - `luau-lsp.signatureHelp.enabled`: Signature Help

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -545,6 +545,20 @@
           "markdownDescription": "Whether to show the auto-generated anonymous function completion item when autocompleting callback arguments",
           "type": "boolean",
           "default": true,
+          "scope": "resource",
+          "markdownDeprecationMessage": "**Deprecated**: Please use `#luau-lsp.completion.anonymousAutofilledFunction.enabled#` instead.",
+          "deprecationMessage": "Deprecated: Please use luau-lsp.completion.anonymousAutofilledFunction.enabled instead."
+        },
+        "luau-lsp.completion.anonymousAutofilledFunction.enabled": {
+          "markdownDescription": "Whether to show the auto-generated anonymous function completion item when autocompleting callback arguments",
+          "type": "boolean",
+          "default": true,
+          "scope": "resource"
+        },
+        "luau-lsp.completion.anonymousAutofilledFunction.addTypeAnnotations": {
+          "markdownDescription": "Whether to include type annotations in the generated anonymous function snippet",
+          "type": "boolean",
+          "default": true,
           "scope": "resource"
         },
         "luau-lsp.completion.showDeprecatedItems": {

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -561,6 +561,12 @@
           "default": true,
           "scope": "resource"
         },
+        "luau-lsp.completion.anonymousAutofilledFunction.addTabstopForParameters": {
+          "markdownDescription": "Whether to add snippet tabstops on each parameter name in the generated anonymous function snippet, allowing quick navigation and editing",
+          "type": "boolean",
+          "default": true,
+          "scope": "resource"
+        },
         "luau-lsp.completion.showDeprecatedItems": {
           "markdownDescription": "Whether to show deprecated items in autocomplete suggestions",
           "type": "boolean",

--- a/src/include/LSP/ClientConfiguration.hpp
+++ b/src/include/LSP/ClientConfiguration.hpp
@@ -163,6 +163,13 @@ struct ClientCompletionImportsConfiguration
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(ClientCompletionImportsConfiguration, enabled, suggestServices, includedServices, excludedServices,
     suggestRequires, requireStyle, stringRequires, separateGroupsWithLine, ignoreGlobs, useConst);
 
+struct ClientCompletionAnonymousAutofillConfiguration
+{
+    bool enabled = true;
+    bool addTypeAnnotations = true;
+};
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(ClientCompletionAnonymousAutofillConfiguration, enabled, addTypeAnnotations);
+
 struct ClientCompletionConfiguration
 {
     bool enabled = true;
@@ -184,15 +191,36 @@ struct ClientCompletionConfiguration
     /// Whether to show keywords (`if` / `then` / `and` / etc.) during autocomplete
     bool showKeywords = true;
     /// Whether to show the "function (anonymous autofilled)" generated function entry
+    /// DEPRECATED: USE `completion.anonymousAutofilledFunction.enabled` INSTEAD
     bool showAnonymousAutofilledFunction = true;
+    /// Configuration for the anonymous autofilled function completion entry
+    ClientCompletionAnonymousAutofillConfiguration anonymousAutofilledFunction{};
     /// Whether to show deprecated items in autocomplete suggestions
     bool showDeprecatedItems = true;
     /// Enables the fragment autocomplete system for performance improvements
     bool enableFragmentAutocomplete = true;
 };
 
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(ClientCompletionConfiguration, enabled, autocompleteEnd, suggestImports, imports, addParentheses,
-    addTabstopAfterParentheses, fillCallArguments, showPropertiesOnMethodCall, showKeywords, showAnonymousAutofilledFunction, showDeprecatedItems, enableFragmentAutocomplete);
+inline void to_json(nlohmann::json& nlohmann_json_j, const ClientCompletionConfiguration& nlohmann_json_t)
+{
+    NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_TO, enabled, autocompleteEnd, suggestImports, imports, addParentheses,
+        addTabstopAfterParentheses, fillCallArguments, showPropertiesOnMethodCall, showKeywords, showAnonymousAutofilledFunction,
+        anonymousAutofilledFunction, showDeprecatedItems, enableFragmentAutocomplete))
+}
+
+inline void from_json(const nlohmann::json& nlohmann_json_j, ClientCompletionConfiguration& nlohmann_json_t)
+{
+    ClientCompletionConfiguration nlohmann_json_default_obj;
+    NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_FROM_WITH_DEFAULT, enabled, autocompleteEnd, suggestImports, imports, addParentheses,
+        addTabstopAfterParentheses, fillCallArguments, showPropertiesOnMethodCall, showKeywords, anonymousAutofilledFunction, showDeprecatedItems,
+        enableFragmentAutocomplete))
+    // Backward compatibility: deprecated showAnonymousAutofilledFunction propagates to the new sub-config
+    // only if the new sub-config key was not explicitly set
+    if (nlohmann_json_j.contains("showAnonymousAutofilledFunction") && !nlohmann_json_j.contains("anonymousAutofilledFunction"))
+        nlohmann_json_t.anonymousAutofilledFunction.enabled = nlohmann_json_j["showAnonymousAutofilledFunction"].get<bool>();
+    // Keep the deprecated field in sync so existing code reading it still works
+    nlohmann_json_t.showAnonymousAutofilledFunction = nlohmann_json_t.anonymousAutofilledFunction.enabled;
+}
 
 struct ClientSignatureHelpConfiguration
 {

--- a/src/include/LSP/ClientConfiguration.hpp
+++ b/src/include/LSP/ClientConfiguration.hpp
@@ -169,8 +169,10 @@ struct ClientCompletionAnonymousAutofillConfiguration
     bool enabled = true;
     /// Whether to include type annotations in the generated function snippet
     bool addTypeAnnotations = true;
+    /// Whether to add snippet tabstops on each parameter name for quick editing
+    bool addTabstopForParameters = true;
 };
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(ClientCompletionAnonymousAutofillConfiguration, enabled, addTypeAnnotations);
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(ClientCompletionAnonymousAutofillConfiguration, enabled, addTypeAnnotations, addTabstopForParameters);
 
 struct ClientCompletionConfiguration
 {

--- a/src/include/LSP/ClientConfiguration.hpp
+++ b/src/include/LSP/ClientConfiguration.hpp
@@ -165,7 +165,9 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(ClientCompletionImportsConfigura
 
 struct ClientCompletionAnonymousAutofillConfiguration
 {
+    /// Whether to show the "function (anonymous autofilled)" generated function completion entry
     bool enabled = true;
+    /// Whether to include type annotations in the generated function snippet
     bool addTypeAnnotations = true;
 };
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(ClientCompletionAnonymousAutofillConfiguration, enabled, addTypeAnnotations);
@@ -200,27 +202,9 @@ struct ClientCompletionConfiguration
     /// Enables the fragment autocomplete system for performance improvements
     bool enableFragmentAutocomplete = true;
 };
-
-inline void to_json(nlohmann::json& nlohmann_json_j, const ClientCompletionConfiguration& nlohmann_json_t)
-{
-    NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_TO, enabled, autocompleteEnd, suggestImports, imports, addParentheses,
-        addTabstopAfterParentheses, fillCallArguments, showPropertiesOnMethodCall, showKeywords, showAnonymousAutofilledFunction,
-        anonymousAutofilledFunction, showDeprecatedItems, enableFragmentAutocomplete))
-}
-
-inline void from_json(const nlohmann::json& nlohmann_json_j, ClientCompletionConfiguration& nlohmann_json_t)
-{
-    ClientCompletionConfiguration nlohmann_json_default_obj;
-    NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(NLOHMANN_JSON_FROM_WITH_DEFAULT, enabled, autocompleteEnd, suggestImports, imports, addParentheses,
-        addTabstopAfterParentheses, fillCallArguments, showPropertiesOnMethodCall, showKeywords, anonymousAutofilledFunction, showDeprecatedItems,
-        enableFragmentAutocomplete))
-    // Backward compatibility: deprecated showAnonymousAutofilledFunction propagates to the new sub-config
-    // only if the new sub-config key was not explicitly set
-    if (nlohmann_json_j.contains("showAnonymousAutofilledFunction") && !nlohmann_json_j.contains("anonymousAutofilledFunction"))
-        nlohmann_json_t.anonymousAutofilledFunction.enabled = nlohmann_json_j["showAnonymousAutofilledFunction"].get<bool>();
-    // Keep the deprecated field in sync so existing code reading it still works
-    nlohmann_json_t.showAnonymousAutofilledFunction = nlohmann_json_t.anonymousAutofilledFunction.enabled;
-}
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(ClientCompletionConfiguration, enabled, autocompleteEnd, suggestImports, imports, addParentheses,
+    addTabstopAfterParentheses, fillCallArguments, showPropertiesOnMethodCall, showKeywords, showAnonymousAutofilledFunction, anonymousAutofilledFunction,
+    showDeprecatedItems, enableFragmentAutocomplete);
 
 struct ClientSignatureHelpConfiguration
 {

--- a/src/operations/Completion.cpp
+++ b/src/operations/Completion.cpp
@@ -433,7 +433,7 @@ static std::optional<std::string> tryGetTypePackAnnotation(const Luau::ScopePtr&
 }
 
 static std::string buildGeneratedFunctionSnippet(
-    const Luau::FunctionType* ftv, const Luau::ScopePtr& scope, bool addTypeAnnotations)
+    const Luau::FunctionType* ftv, const Luau::ScopePtr& scope, bool addTypeAnnotations, bool addTabstopForParameters)
 {
     std::string snippet = "function(";
 
@@ -455,7 +455,10 @@ static std::string buildGeneratedFunctionSnippet(
         else
             name = "a" + std::to_string(argIdx);
 
-        snippet += "${" + std::to_string(snippetIndex++) + ":" + name + "}";
+        if (addTabstopForParameters)
+            snippet += "${" + std::to_string(snippetIndex++) + ":" + name + "}";
+        else
+            snippet += name;
 
         if (addTypeAnnotations)
             if (auto typeStr = tryGetTypeAnnotation(scope, args[argIdx]))
@@ -788,8 +791,9 @@ std::vector<lsp::CompletionItem> WorkspaceFolder::completion(const lsp::Completi
                     Luau::ScopePtr scope;
                     if (localModule)
                         scope = Luau::findScopeAtPosition(*localModule, position);
-                    item.insertText =
-                        buildGeneratedFunctionSnippet(ftv, scope, config.completion.anonymousAutofilledFunction.addTypeAnnotations);
+                    item.insertText = buildGeneratedFunctionSnippet(ftv, scope,
+                        config.completion.anonymousAutofilledFunction.addTypeAnnotations,
+                        config.completion.anonymousAutofilledFunction.addTabstopForParameters);
                     item.insertTextFormat = lsp::InsertTextFormat::Snippet;
                 }
                 else

--- a/src/operations/Completion.cpp
+++ b/src/operations/Completion.cpp
@@ -404,10 +404,9 @@ static bool canSuggestTypePack(Luau::TypePackId tp)
     return true;
 }
 
-static std::optional<std::string> tryGetTypeAnnotation(const Luau::ScopePtr& scope, Luau::TypeId ty)
+template <typename T>
+static std::optional<std::string> tryGetAnnotation(const Luau::ScopePtr& scope, T ty)
 {
-    if (!canSuggestType(ty))
-        return std::nullopt;
     Luau::ToStringOptions opts;
     opts.useLineBreaks = false;
     opts.hideTableKind = true;
@@ -419,19 +418,18 @@ static std::optional<std::string> tryGetTypeAnnotation(const Luau::ScopePtr& sco
     return result.name;
 }
 
+static std::optional<std::string> tryGetTypeAnnotation(const Luau::ScopePtr& scope, Luau::TypeId ty)
+{
+    if (!canSuggestType(ty))
+        return std::nullopt;
+    return tryGetAnnotation(scope, ty);
+}
+
 static std::optional<std::string> tryGetTypePackAnnotation(const Luau::ScopePtr& scope, Luau::TypePackId tp)
 {
     if (!canSuggestTypePack(tp))
         return std::nullopt;
-    Luau::ToStringOptions opts;
-    opts.useLineBreaks = false;
-    opts.hideTableKind = true;
-    opts.functionTypeArguments = true;
-    opts.scope = scope;
-    auto result = Luau::toStringDetailed(tp, opts);
-    if (result.error || result.invalid || result.cycle || result.truncated)
-        return std::nullopt;
-    return result.name;
+    return tryGetAnnotation(scope, tp);
 }
 
 static std::string buildGeneratedFunctionSnippet(
@@ -469,20 +467,12 @@ static std::string buildGeneratedFunctionSnippet(
         if (!first)
             snippet += ", ";
 
+        std::optional<std::string> varArgType;
         if (addTypeAnnotations)
-        {
-            if (const Luau::VariadicTypePack* pack = Luau::get<Luau::VariadicTypePack>(Luau::follow(*tail)))
-            {
-                if (auto typeStr = tryGetTypeAnnotation(scope, pack->ty))
-                    snippet += "...: " + *typeStr;
-                else
-                    snippet += "...";
-            }
-            else
-                snippet += "...";
-        }
-        else
-            snippet += "...";
+            if (const auto* pack = Luau::get<Luau::VariadicTypePack>(Luau::follow(*tail)))
+                varArgType = tryGetTypeAnnotation(scope, pack->ty);
+
+        snippet += varArgType ? "...: " + *varArgType : "...";
     }
 
     snippet += ")";

--- a/src/operations/Completion.cpp
+++ b/src/operations/Completion.cpp
@@ -375,6 +375,140 @@ static bool isIdentifier(std::string_view s)
     return Luau::isIdentifier(s) && !isKeyword(s);
 }
 
+static bool canSuggestType(Luau::TypeId ty)
+{
+    ty = Luau::follow(ty);
+    if (Luau::get<Luau::AnyType>(ty) || Luau::get<Luau::ErrorType>(ty) || Luau::get<Luau::GenericType>(ty) || Luau::get<Luau::FreeType>(ty))
+        return false;
+    if (Luau::get<Luau::MetatableType>(ty))
+        return false;
+    if (const Luau::TableType* ttv = Luau::get<Luau::TableType>(ty))
+    {
+        if (ttv->name)
+            return true;
+        if (ttv->syntheticName)
+            return false;
+    }
+    return true;
+}
+
+static bool canSuggestTypePack(Luau::TypePackId tp)
+{
+    tp = Luau::follow(tp);
+    if (Luau::get<Luau::ErrorTypePack>(tp) || Luau::get<Luau::GenericTypePack>(tp) || Luau::get<Luau::FreeTypePack>(tp))
+        return false;
+    auto [head, tail] = Luau::flatten(tp);
+    for (Luau::TypeId headTy : head)
+        if (!canSuggestType(headTy))
+            return false;
+    return true;
+}
+
+static std::optional<std::string> tryGetTypeAnnotation(const Luau::ScopePtr& scope, Luau::TypeId ty)
+{
+    if (!canSuggestType(ty))
+        return std::nullopt;
+    Luau::ToStringOptions opts;
+    opts.useLineBreaks = false;
+    opts.hideTableKind = true;
+    opts.functionTypeArguments = true;
+    opts.scope = scope;
+    auto result = Luau::toStringDetailed(ty, opts);
+    if (result.error || result.invalid || result.cycle || result.truncated)
+        return std::nullopt;
+    return result.name;
+}
+
+static std::optional<std::string> tryGetTypePackAnnotation(const Luau::ScopePtr& scope, Luau::TypePackId tp)
+{
+    if (!canSuggestTypePack(tp))
+        return std::nullopt;
+    Luau::ToStringOptions opts;
+    opts.useLineBreaks = false;
+    opts.hideTableKind = true;
+    opts.functionTypeArguments = true;
+    opts.scope = scope;
+    auto result = Luau::toStringDetailed(tp, opts);
+    if (result.error || result.invalid || result.cycle || result.truncated)
+        return std::nullopt;
+    return result.name;
+}
+
+static std::string buildGeneratedFunctionSnippet(
+    const Luau::FunctionType* ftv, const Luau::ScopePtr& scope, bool addTypeAnnotations)
+{
+    std::string snippet = "function(";
+
+    auto [args, tail] = Luau::flatten(ftv->argTypes);
+
+    bool first = true;
+    size_t snippetIndex = 1;
+
+    for (size_t argIdx = 0; argIdx < args.size(); ++argIdx)
+    {
+        if (!first)
+            snippet += ", ";
+        else
+            first = false;
+
+        std::string name;
+        if (argIdx < ftv->argNames.size() && ftv->argNames[argIdx])
+            name = ftv->argNames[argIdx]->name;
+        else
+            name = "a" + std::to_string(argIdx);
+
+        snippet += "${" + std::to_string(snippetIndex++) + ":" + name + "}";
+
+        if (addTypeAnnotations)
+            if (auto typeStr = tryGetTypeAnnotation(scope, args[argIdx]))
+                snippet += ": " + *typeStr;
+    }
+
+    if (tail && (Luau::isVariadic(*tail) || Luau::get<Luau::FreeTypePack>(Luau::follow(*tail))))
+    {
+        if (!first)
+            snippet += ", ";
+
+        if (addTypeAnnotations)
+        {
+            if (const Luau::VariadicTypePack* pack = Luau::get<Luau::VariadicTypePack>(Luau::follow(*tail)))
+            {
+                if (auto typeStr = tryGetTypeAnnotation(scope, pack->ty))
+                    snippet += "...: " + *typeStr;
+                else
+                    snippet += "...";
+            }
+            else
+                snippet += "...";
+        }
+        else
+            snippet += "...";
+    }
+
+    snippet += ")";
+
+    if (addTypeAnnotations)
+    {
+        auto [rets, retTail] = Luau::flatten(ftv->retTypes);
+        if (const size_t totalRetSize = rets.size() + (retTail ? 1 : 0); totalRetSize > 0)
+        {
+            if (auto returnTypes = tryGetTypePackAnnotation(scope, ftv->retTypes))
+            {
+                snippet += ": ";
+                bool wrap = totalRetSize != 1;
+                if (wrap)
+                    snippet += "(";
+                snippet += *returnTypes;
+                if (wrap)
+                    snippet += ")";
+            }
+        }
+    }
+
+    snippet += "\n\t$0\nend";
+    return snippet;
+}
+
 static std::pair<std::string, std::string> computeLabelDetailsForFunction(const Luau::AutocompleteEntry& entry, const Luau::FunctionType* ftv)
 {
     std::string detail = "(";
@@ -627,7 +761,8 @@ std::vector<lsp::CompletionItem> WorkspaceFolder::completion(const lsp::Completi
         if (!config.completion.showKeywords && entry.kind == Luau::AutocompleteEntryKind::Keyword)
             continue;
 
-        if (!config.completion.showAnonymousAutofilledFunction && entry.kind == Luau::AutocompleteEntryKind::GeneratedFunction)
+        if ((!config.completion.anonymousAutofilledFunction.enabled || !config.completion.showAnonymousAutofilledFunction) &&
+            entry.kind == Luau::AutocompleteEntryKind::GeneratedFunction)
             continue;
 
         lsp::CompletionItem item;
@@ -655,7 +790,24 @@ std::vector<lsp::CompletionItem> WorkspaceFolder::completion(const lsp::Completi
         item.sortText = sortText(frontend, item.label, item, entry, tags, *platform);
 
         if (entry.kind == Luau::AutocompleteEntryKind::GeneratedFunction)
-            item.insertText = entry.insertText;
+        {
+            if (canUseSnippets(client->capabilities) && entry.type)
+            {
+                if (auto ftv = Luau::get<Luau::FunctionType>(Luau::follow(*entry.type)))
+                {
+                    Luau::ScopePtr scope;
+                    if (localModule)
+                        scope = Luau::findScopeAtPosition(*localModule, position);
+                    item.insertText =
+                        buildGeneratedFunctionSnippet(ftv, scope, config.completion.anonymousAutofilledFunction.addTypeAnnotations);
+                    item.insertTextFormat = lsp::InsertTextFormat::Snippet;
+                }
+                else
+                    item.insertText = entry.insertText;
+            }
+            else
+                item.insertText = entry.insertText;
+        }
 
         if (entry.kind == Luau::AutocompleteEntryKind::RequirePath)
         {

--- a/tests/Autocomplete.test.cpp
+++ b/tests/Autocomplete.test.cpp
@@ -2167,4 +2167,185 @@ TEST_CASE_FIXTURE(Fixture, "sourcemap_autocomplete_shows_self_alias_children")
     checkFileCompletionExists(result, "Helper.luau", "@self/Helper");
 }
 
+TEST_CASE_FIXTURE(Fixture, "anonymous_autofilled_function_new_enabled_config_hides_entry")
+{
+    client->globalConfig.completion.anonymousAutofilledFunction.enabled = false;
+
+    auto [source, marker] = sourceWithMarker(R"(
+        local function foo(cb: () -> ())
+        end
+        foo(|)
+    )");
+
+    auto uri = newDocument("foo.luau", source);
+
+    lsp::CompletionParams params;
+    params.textDocument = lsp::TextDocumentIdentifier{uri};
+    params.position = marker;
+
+    auto result = workspace.completion(params, nullptr);
+    CHECK_FALSE(getItem(result, "function (anonymous autofilled)"));
+}
+
+TEST_CASE_FIXTURE(Fixture, "deprecated_show_anonymous_autofilled_function_false_hides_entry")
+{
+    client->globalConfig.completion.showAnonymousAutofilledFunction = false;
+
+    auto [source, marker] = sourceWithMarker(R"(
+        local function foo(cb: () -> ())
+        end
+        foo(|)
+    )");
+
+    auto uri = newDocument("foo.luau", source);
+
+    lsp::CompletionParams params;
+    params.textDocument = lsp::TextDocumentIdentifier{uri};
+    params.position = marker;
+
+    auto result = workspace.completion(params, nullptr);
+    CHECK_FALSE(getItem(result, "function (anonymous autofilled)"));
+}
+
+TEST_CASE_FIXTURE(Fixture, "anonymous_autofilled_function_snippet_has_body_tabstop")
+{
+    enableSnippetSupport(client->capabilities);
+
+    auto [source, marker] = sourceWithMarker(R"(
+        local function foo(cb: () -> ())
+        end
+        foo(|)
+    )");
+
+    auto uri = newDocument("foo.luau", source);
+
+    lsp::CompletionParams params;
+    params.textDocument = lsp::TextDocumentIdentifier{uri};
+    params.position = marker;
+
+    auto result = workspace.completion(params, nullptr);
+    auto item = requireItem(result, "function (anonymous autofilled)");
+
+    REQUIRE(item.insertText);
+    CHECK_EQ(item.insertTextFormat, lsp::InsertTextFormat::Snippet);
+    CHECK_EQ(*item.insertText, "function()\n\t$0\nend");
+}
+
+TEST_CASE_FIXTURE(Fixture, "anonymous_autofilled_function_snippet_has_param_tabstops")
+{
+    enableSnippetSupport(client->capabilities);
+
+    auto [source, marker] = sourceWithMarker(R"(
+        local function foo(cb: (x: number, y: string) -> ())
+        end
+        foo(|)
+    )");
+
+    auto uri = newDocument("foo.luau", source);
+
+    lsp::CompletionParams params;
+    params.textDocument = lsp::TextDocumentIdentifier{uri};
+    params.position = marker;
+
+    auto result = workspace.completion(params, nullptr);
+    auto item = requireItem(result, "function (anonymous autofilled)");
+
+    REQUIRE(item.insertText);
+    CHECK_EQ(item.insertTextFormat, lsp::InsertTextFormat::Snippet);
+    CHECK_EQ(*item.insertText, "function(${1:x}: number, ${2:y}: string)\n\t$0\nend");
+}
+
+TEST_CASE_FIXTURE(Fixture, "anonymous_autofilled_function_snippet_includes_return_type")
+{
+    enableSnippetSupport(client->capabilities);
+
+    auto [source, marker] = sourceWithMarker(R"(
+        local function foo(cb: () -> number)
+        end
+        foo(|)
+    )");
+
+    auto uri = newDocument("foo.luau", source);
+
+    lsp::CompletionParams params;
+    params.textDocument = lsp::TextDocumentIdentifier{uri};
+    params.position = marker;
+
+    auto result = workspace.completion(params, nullptr);
+    auto item = requireItem(result, "function (anonymous autofilled)");
+
+    REQUIRE(item.insertText);
+    CHECK_EQ(*item.insertText, "function(): number\n\t$0\nend");
+}
+
+TEST_CASE_FIXTURE(Fixture, "anonymous_autofilled_function_snippet_uses_unnamed_param_fallback")
+{
+    enableSnippetSupport(client->capabilities);
+
+    auto [source, marker] = sourceWithMarker(R"(
+        local function foo(cb: (number, string) -> ())
+        end
+        foo(|)
+    )");
+
+    auto uri = newDocument("foo.luau", source);
+
+    lsp::CompletionParams params;
+    params.textDocument = lsp::TextDocumentIdentifier{uri};
+    params.position = marker;
+
+    auto result = workspace.completion(params, nullptr);
+    auto item = requireItem(result, "function (anonymous autofilled)");
+
+    REQUIRE(item.insertText);
+    CHECK_EQ(*item.insertText, "function(${1:a0}: number, ${2:a1}: string)\n\t$0\nend");
+}
+
+TEST_CASE_FIXTURE(Fixture, "anonymous_autofilled_function_snippet_no_type_annotations")
+{
+    enableSnippetSupport(client->capabilities);
+    client->globalConfig.completion.anonymousAutofilledFunction.addTypeAnnotations = false;
+
+    auto [source, marker] = sourceWithMarker(R"(
+        local function foo(cb: (x: number, y: string) -> number)
+        end
+        foo(|)
+    )");
+
+    auto uri = newDocument("foo.luau", source);
+
+    lsp::CompletionParams params;
+    params.textDocument = lsp::TextDocumentIdentifier{uri};
+    params.position = marker;
+
+    auto result = workspace.completion(params, nullptr);
+    auto item = requireItem(result, "function (anonymous autofilled)");
+
+    REQUIRE(item.insertText);
+    CHECK_EQ(*item.insertText, "function(${1:x}, ${2:y})\n\t$0\nend");
+}
+
+TEST_CASE_FIXTURE(Fixture, "anonymous_autofilled_function_no_snippet_support_uses_plain_text")
+{
+    auto [source, marker] = sourceWithMarker(R"(
+        local function foo(cb: (x: number) -> ())
+        end
+        foo(|)
+    )");
+
+    auto uri = newDocument("foo.luau", source);
+
+    lsp::CompletionParams params;
+    params.textDocument = lsp::TextDocumentIdentifier{uri};
+    params.position = marker;
+
+    auto result = workspace.completion(params, nullptr);
+    auto item = requireItem(result, "function (anonymous autofilled)");
+
+    REQUIRE(item.insertText);
+    CHECK_EQ(item.insertTextFormat, lsp::InsertTextFormat::PlainText);
+    // Falls back to Luau's plain text (no snippet syntax)
+    CHECK_FALSE(item.insertText->find("${") != std::string::npos);
+}
+
 TEST_SUITE_END();

--- a/tests/Autocomplete.test.cpp
+++ b/tests/Autocomplete.test.cpp
@@ -2347,4 +2347,29 @@ TEST_CASE_FIXTURE(Fixture, "anonymous_autofilled_function_no_snippet_support_use
     CHECK_EQ(item.insertText->find("${"), std::string::npos);
 }
 
+TEST_CASE_FIXTURE(Fixture, "anonymous_autofilled_function_snippet_no_param_tabstops")
+{
+    enableSnippetSupport(client->capabilities);
+    client->globalConfig.completion.anonymousAutofilledFunction.addTabstopForParameters = false;
+
+    auto [source, marker] = sourceWithMarker(R"(
+        local function foo(cb: (x: number, y: string) -> ())
+        end
+        foo(|)
+    )");
+
+    auto uri = newDocument("foo.luau", source);
+
+    lsp::CompletionParams params;
+    params.textDocument = lsp::TextDocumentIdentifier{uri};
+    params.position = marker;
+
+    auto result = workspace.completion(params, nullptr);
+    auto item = requireItem(result, "function (anonymous autofilled)");
+
+    REQUIRE(item.insertText);
+    CHECK_EQ(item.insertTextFormat, lsp::InsertTextFormat::Snippet);
+    CHECK_EQ(*item.insertText, "function(x: number, y: string)\n\t$0\nend");
+}
+
 TEST_SUITE_END();

--- a/tests/Autocomplete.test.cpp
+++ b/tests/Autocomplete.test.cpp
@@ -2344,8 +2344,7 @@ TEST_CASE_FIXTURE(Fixture, "anonymous_autofilled_function_no_snippet_support_use
 
     REQUIRE(item.insertText);
     CHECK_EQ(item.insertTextFormat, lsp::InsertTextFormat::PlainText);
-    // Falls back to Luau's plain text (no snippet syntax)
-    CHECK_FALSE(item.insertText->find("${") != std::string::npos);
+    CHECK_EQ(item.insertText->find("${"), std::string::npos);
 }
 
 TEST_SUITE_END();


### PR DESCRIPTION
This PR improves the anonymous autofilled function completion with better snippet generation and configurable behaviour.

Instead of using the insertText provided by Luau for GeneratedFunction, we create the inserted text from scratch. This allows us to generate a function snippet with configurable tabstops: tabbing to parameter names, and finishing with the cursor position inside of the function body.

We can now also configure whether type parameters are inserted or not.

Falls back to plain text insertion when snippet support is unavailable.

## New Configuration

- `luau-lsp.completion.anonymousAutofilledFunction.enabled`
- `luau-lsp.completion.anonymousAutofilledFunction.addTypeAnnotations`
- `luau-lsp.completion.anonymousAutofilledFunction.addTabstopForParameters`

The deprecated `luau-lsp.completion.showAnonymousAutofilledFunction` setting is marked as deprecated with guidance to use the new `enabled` setting.

Work towards improving #688 