### PR TITLE
Add luau-lsp.completion.imports.useConst to VSCode package.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fixed incorrect description for `require()` when platform is set to "standard." ([#1479](<https://github.com/JohnnyMorganz/luau-lsp/issues/1479>))
 - Fixed module aliases pointing to absolute Windows paths (e.g. `C:\...`) causing the type checker to load the same file twice under different module names, producing spurious type mismatch errors.
 - Fixed autocomplete-end incorrectly inserting `then`/`end` inside a string literal when Enter is pressed with the cursor inside a string used as an `if`/`while` condition ([#1453](https://github.com/JohnnyMorganz/luau-lsp/issues/1453))
+- Fixed `luau-lsp.completion.imports.useConst` setting missing from the VSCode extension manifest ([#1476](https://github.com/JohnnyMorganz/luau-lsp/issues/1476))
 
 ## [1.67.0] - 2026-05-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fixed incorrect description for `require()` when platform is set to "standard." ([#1479](<https://github.com/JohnnyMorganz/luau-lsp/issues/1479>))
 - Fixed module aliases pointing to absolute Windows paths (e.g. `C:\...`) causing the type checker to load the same file twice under different module names, producing spurious type mismatch errors.
 - Fixed autocomplete-end incorrectly inserting `then`/`end` inside a string literal when Enter is pressed with the cursor inside a string used as an `if`/`while` condition ([#1453](https://github.com/JohnnyMorganz/luau-lsp/issues/1453))
-- Fixed `luau-lsp.completion.imports.useConst` setting missing from the VSCode extension manifest ([#1476](https://github.com/JohnnyMorganz/luau-lsp/issues/1476))
+- Fixed `luau-lsp.completion.imports.useConst` setting missing from the VSCode extension manifest
 
 ## [1.67.0] - 2026-05-10
 

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -645,6 +645,12 @@
           "default": false,
           "scope": "resource"
         },
+        "luau-lsp.completion.imports.useConst": {
+          "markdownDescription": "Whether to use `const` instead of `local` for auto-imported requires and services",
+          "type": "boolean",
+          "default": false,
+          "scope": "resource"
+        },
         "luau-lsp.completion.imports.ignoreGlobs": {
           "markdownDescription": "Files that match these globs will not be shown during auto-import",
           "type": "array",


### PR DESCRIPTION
The setting was implemented in the LSP server but accidentally omitted from the VSCode extension manifest.