### PR TITLE
Fix @self path alias resolution for sourcemap virtual nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `@self` string-require aliases resolving from the filesystem instead of the sourcemap tree for non-DataModel roots ([#1511](https://github.com/JohnnyMorganz/luau-lsp/issues/1511))
+
 ## [1.69.0] - 2026-07-14
 
 ### Added

--- a/src/platform/roblox/RobloxFileResolver.cpp
+++ b/src/platform/roblox/RobloxFileResolver.cpp
@@ -127,7 +127,15 @@ std::optional<Luau::ModuleInfo> RobloxPlatform::resolveStringRequire(
         std::string aliasName = requiredString.substr(1, slashPos == std::string::npos ? std::string::npos : slashPos - 1);
         std::string aliasNameLower = toLower(aliasName);
 
-        if (luauConfig.aliases.find(aliasNameLower) || aliasNameLower == "self")
+        if (aliasNameLower == "self")
+        {
+            std::string remainder = (slashPos == std::string::npos) ? "" : requiredString.substr(slashPos + 1);
+            if (remainder.empty())
+                return Luau::ModuleInfo{context->name};
+            return Luau::ModuleInfo{context->name + "/" + remainder};
+        }
+
+        if (luauConfig.aliases.find(aliasNameLower))
             return LSPPlatform::resolveStringRequire(context, requiredString, limits);
 
         if (aliasNameLower == "game" && rootSourceNode)

--- a/tests/WorkspaceFileResolver.test.cpp
+++ b/tests/WorkspaceFileResolver.test.cpp
@@ -814,6 +814,96 @@ TEST_CASE_FIXTURE(Fixture, "sourcemap_self_alias_resolves_from_module")
     CHECK_EQ(result->name, "game/Library/Helper");
 }
 
+TEST_CASE_FIXTURE(Fixture, "sourcemap_self_alias_resolves_sibling_directory_of_src")
+{
+    client->globalConfig.completion.imports.stringRequires.enabled = true;
+    loadSourcemap(R"(
+    {
+        "name": "test",
+        "className": "Script",
+        "filePaths": ["src/init.server.luau"],
+        "children": [
+            {
+                "name": "packages",
+                "className": "Folder",
+                "children": [
+                    { "name": "test", "className": "ModuleScript", "filePaths": ["packages/test.luau"] }
+                ]
+            }
+        ]
+    }
+    )");
+
+    tempDir.touch_child("packages/test.luau");
+
+    Luau::ModuleInfo baseContext{"ProjectRoot"};
+    auto result = workspace.fileResolver.platform->resolveStringRequire(&baseContext, "@self/packages/test", workspace.limits);
+
+    REQUIRE(result.has_value());
+    CHECK_EQ(result->name, "ProjectRoot/packages/test");
+}
+
+TEST_CASE_FIXTURE(Fixture, "sourcemap_self_alias_resolves_to_node_itself_with_no_remainder")
+{
+    client->globalConfig.completion.imports.stringRequires.enabled = true;
+    loadSourcemap(R"(
+    {
+        "name": "test",
+        "className": "Script",
+        "filePaths": ["src/init.server.luau"],
+        "children": [
+            {
+                "name": "packages",
+                "className": "Folder",
+                "children": [
+                    { "name": "test", "className": "ModuleScript", "filePaths": ["packages/test.luau"] }
+                ]
+            }
+        ]
+    }
+    )");
+
+    Luau::ModuleInfo baseContext{"ProjectRoot"};
+    auto result = workspace.fileResolver.platform->resolveStringRequire(&baseContext, "@self", workspace.limits);
+
+    REQUIRE(result.has_value());
+    CHECK_EQ(result->name, "ProjectRoot");
+}
+
+TEST_CASE_FIXTURE(Fixture, "sourcemap_self_alias_resolves_relative_to_calling_node_not_root")
+{
+    client->globalConfig.completion.imports.stringRequires.enabled = true;
+    loadSourcemap(R"(
+    {
+        "name": "test",
+        "className": "Script",
+        "filePaths": ["src/init.server.luau"],
+        "children": [
+            {
+                "name": "packages",
+                "className": "Folder",
+                "children": [
+                    { "name": "test", "className": "ModuleScript", "filePaths": ["packages/test.luau"] }
+                ]
+            },
+            {
+                "name": "someChild",
+                "className": "ModuleScript",
+                "filePaths": ["src/someChild.luau"]
+            }
+        ]
+    }
+    )");
+
+    tempDir.touch_child("packages/test.luau");
+
+    Luau::ModuleInfo baseContext{"ProjectRoot/someChild"};
+    auto result = workspace.fileResolver.platform->resolveStringRequire(&baseContext, "@self/packages/test", workspace.limits);
+
+    REQUIRE(result.has_value());
+    CHECK_EQ(result->name, "ProjectRoot/someChild/packages/test");
+}
+
 TEST_CASE_FIXTURE(Fixture, "sourcemap_user_defined_game_alias_takes_precedence")
 {
     client->globalConfig.completion.imports.stringRequires.enabled = true;


### PR DESCRIPTION
Fix `@self` alias resolution for non-DataModel sourcemap roots

When a project builds an `rbxm` (e.g. a plugin or library) rather than a full `DataModel`, the sourcemap root is the script itself rather than a `DataModel` node. In this case, sibling directories mapped alongside the `$path` directory are children of the root sourcemap node, not children of a filesystem directory.

Previously, `@self` on a virtual path context was delegated to `LSPPlatform::resolveStringRequire`, which resolves `@self` using the filesystem path of the calling file as the base URI. For an `init.server.luau` inside `src/`, this meant `@self` resolved to `src/`, making sibling directories like `packages/` invisible to the LSP, even though they're valid children of the root sourcemap node at runtime.

The fix handles `@self` directly in `RobloxPlatform::resolveStringRequire` when the context is already a virtual path, using the sourcemap node's virtual path as the base instead of the filesystem path. User-defined aliases are unaffected and still delegate to `LSPPlatform` as before. Non-sourcemap files are also unaffected since they never reach this code path.

Fixes #1511