### PR TITLE
Fix signature help parameter highlighting for module-qualified types in unions/intersections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Sync to upstream Luau 0.723
 
+### Fixed
+
+- Fixed signature help parameter highlighting when a parameter type references an exported table type from another module inside a union or intersection type ([#1507](https://github.com/JohnnyMorganz/luau-lsp/issues/1507))
+
 ## [1.68.0] - 2026-05-16
 
 ### Changed

--- a/src/operations/SignatureHelp.cpp
+++ b/src/operations/SignatureHelp.cpp
@@ -147,6 +147,15 @@ std::optional<lsp::SignatureHelp> WorkspaceFolder::signatureHelp(
         size_t idx = 0;
         size_t previousParamPos = label.find('('); // start search at start of parameter list, not earlier
 
+        // Use the same ToStringOptions as toStringNamedFunction so that type names (including
+        // module-qualified ones like "second.foo") are resolved identically in both the full label
+        // and each parameter search string.
+        Luau::ToStringOptions typeStringOpts;
+        typeStringOpts.functionTypeArguments = true;
+        typeStringOpts.hideNamedFunctionTypeParameters = false;
+        typeStringOpts.hideTableKind = opts.hideTableKind;
+        typeStringOpts.scope = scope;
+
         for (; it != Luau::end(ftv->argTypes); it++, idx++)
         {
             // If the function has self, and the caller has called as a method (i.e., :), then omit the self parameter
@@ -167,11 +176,6 @@ std::optional<lsp::SignatureHelp> WorkspaceFolder::signatureHelp(
             std::string labelString;
             if (idx < ftv->argNames.size() && ftv->argNames[idx] && ftv->argNames[idx]->name != "_")
                 labelString = ftv->argNames[idx]->name + ": ";
-            // Use the same ToStringOptions as toStringNamedFunction so that module-qualified type names
-            // (e.g. "second.foo") are resolved identically in both the full label and the search string.
-            Luau::ToStringOptions typeStringOpts;
-            typeStringOpts.hideTableKind = opts.hideTableKind;
-            typeStringOpts.scope = scope;
             labelString += Luau::toString(*it, typeStringOpts);
 
             auto position = label.find(labelString, previousParamPos);
@@ -205,14 +209,10 @@ std::optional<lsp::SignatureHelp> WorkspaceFolder::signatureHelp(
                 std::variant<std::string, std::vector<size_t>> paramLabel;
                 std::string labelString = "...: ";
 
-                Luau::ToStringOptions varargStringOpts;
-                varargStringOpts.hideTableKind = opts.hideTableKind;
-                varargStringOpts.scope = scope;
-
                 if (vtp)
-                    labelString += Luau::toString(vtp->ty, varargStringOpts);
+                    labelString += Luau::toString(vtp->ty, typeStringOpts);
                 else
-                    labelString += Luau::toString(*tp, varargStringOpts);
+                    labelString += Luau::toString(*tp, typeStringOpts);
 
                 auto position = label.find(labelString, previousParamPos);
                 if (position != std::string::npos)

--- a/src/operations/SignatureHelp.cpp
+++ b/src/operations/SignatureHelp.cpp
@@ -97,7 +97,6 @@ std::optional<lsp::SignatureHelp> WorkspaceFolder::signatureHelp(
             break;
         activeParameter++;
     }
-
     auto it = module->astTypes.find(candidate->func);
     if (!it)
         return std::nullopt;
@@ -168,7 +167,12 @@ std::optional<lsp::SignatureHelp> WorkspaceFolder::signatureHelp(
             std::string labelString;
             if (idx < ftv->argNames.size() && ftv->argNames[idx] && ftv->argNames[idx]->name != "_")
                 labelString = ftv->argNames[idx]->name + ": ";
-            labelString += Luau::toString(*it);
+            // Use the same ToStringOptions as toStringNamedFunction so that module-qualified type names
+            // (e.g. "second.foo") are resolved identically in both the full label and the search string.
+            Luau::ToStringOptions typeStringOpts;
+            typeStringOpts.hideTableKind = opts.hideTableKind;
+            typeStringOpts.scope = scope;
+            labelString += Luau::toString(*it, typeStringOpts);
 
             auto position = label.find(labelString, previousParamPos);
             if (position != std::string::npos)
@@ -201,10 +205,14 @@ std::optional<lsp::SignatureHelp> WorkspaceFolder::signatureHelp(
                 std::variant<std::string, std::vector<size_t>> paramLabel;
                 std::string labelString = "...: ";
 
+                Luau::ToStringOptions varargStringOpts;
+                varargStringOpts.hideTableKind = opts.hideTableKind;
+                varargStringOpts.scope = scope;
+
                 if (vtp)
-                    labelString += Luau::toString(vtp->ty);
+                    labelString += Luau::toString(vtp->ty, varargStringOpts);
                 else
-                    labelString += Luau::toString(*tp);
+                    labelString += Luau::toString(*tp, varargStringOpts);
 
                 auto position = label.find(labelString, previousParamPos);
                 if (position != std::string::npos)

--- a/tests/SignatureHelp.test.cpp
+++ b/tests/SignatureHelp.test.cpp
@@ -133,4 +133,80 @@ TEST_CASE_FIXTURE(Fixture, "signature_help_does_not_show_first_argument_on_metho
     CHECK_EQ(std::get<std::vector<size_t>>(result->signatures[0].parameters->at(0).label), std::vector<size_t>{22, 28});
 }
 
+TEST_CASE_FIXTURE(Fixture, "signature_help_highlights_param_with_union_type_containing_exported_module_table_type")
+{
+    // Regression test for https://github.com/JohnnyMorganz/luau-lsp/issues/1507
+    // When a parameter type references an exported table type from another module in a union,
+    // the parameter label offset computation must still find the param inside the full signature label.
+    // Note: sourceWithMarker uses '|' as marker so we write the source manually to avoid conflict
+    // with the '|' union operator in the type annotation.
+    tempDir.write_child("second.luau", "export type foo = {}\nreturn nil");
+    newDocument("second.luau", "export type foo = {}\nreturn nil");
+
+    // sourceWithMarker uses '|' as its marker character, which conflicts with the '|' union operator,
+    // so position the cursor manually. After dedent the source becomes:
+    //   Line 0: "local second = require("./second")"
+    //   Line 1: ""
+    //   Line 2: "local function foo(bar: second.foo | string): ()"
+    //   Line 3: "end"
+    //   Line 4: ""
+    //   Line 5: "foo()"   ← column 4 is `)`, i.e. just inside the call
+    std::string source = dedent(R"(
+        local second = require("./second")
+
+        local function foo(bar: second.foo | string): ()
+        end
+
+        foo()
+    )");
+    lsp::Position marker{5, 4};
+
+    auto uri = newDocument("first.luau", source);
+
+    lsp::SignatureHelpParams params;
+    params.textDocument = lsp::TextDocumentIdentifier{uri};
+    params.position = marker;
+
+    auto result = workspace.signatureHelp(params, nullptr);
+    REQUIRE(result);
+    REQUIRE_EQ(result->signatures.size(), 1);
+    REQUIRE(result->signatures[0].parameters);
+    REQUIRE_EQ(result->signatures[0].parameters->size(), 1);
+
+    // The parameter label must be resolved to offsets within the full signature string,
+    // not fall back to a plain string (which means the find failed).
+    CHECK(std::holds_alternative<std::vector<size_t>>(result->signatures[0].parameters->at(0).label));
+}
+
+TEST_CASE_FIXTURE(Fixture, "signature_help_highlights_param_with_intersection_type_containing_exported_module_table_type")
+{
+    // Regression test for https://github.com/JohnnyMorganz/luau-lsp/issues/1507
+    // Same as above but with an intersection type (&).
+    tempDir.write_child("second.luau", "export type foo = {}\nreturn nil");
+    newDocument("second.luau", "export type foo = {}\nreturn nil");
+
+    auto [source, marker] = sourceWithMarker(R"(
+        local second = require("./second")
+
+        local function foo(bar: second.foo & {baz: string}): ()
+        end
+
+        foo(|)
+    )");
+
+    auto uri = newDocument("first.luau", source);
+
+    lsp::SignatureHelpParams params;
+    params.textDocument = lsp::TextDocumentIdentifier{uri};
+    params.position = marker;
+
+    auto result = workspace.signatureHelp(params, nullptr);
+    REQUIRE(result);
+    REQUIRE_EQ(result->signatures.size(), 1);
+    REQUIRE(result->signatures[0].parameters);
+    REQUIRE_EQ(result->signatures[0].parameters->size(), 1);
+
+    CHECK(std::holds_alternative<std::vector<size_t>>(result->signatures[0].parameters->at(0).label));
+}
+
 TEST_SUITE_END();


### PR DESCRIPTION
When a parameter type references an exported table type from another module
inside a union or intersection (e.g. `second.foo | string`), the parameter
label offset search failed because `Luau::toString(*it)` was called without a
scope, producing just `foo`, while `toStringNamedFunction` (which builds the
full signature label) used the call-site scope and produced `second.foo`.

The fix passes the same `ToStringOptions` (scope + hideTableKind) to
`Luau::toString` when computing parameter label strings, ensuring both the
full label and the search string use the same representation of
module-qualified type names.

Fixes #1507