### PR TITLE
Add `completion.showMethodsOnIndex` setting to hide methods on `.` access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Added `luau-lsp.completion.showMethodsOnIndex` (default: `true`) to control whether methods (functions which expect `self`) are shown when performing a field access with a dot (e.g. `foo.bar`). Set to `false` to hide them, mirroring `luau-lsp.completion.showPropertiesOnMethodCall` for the `:` case
+
 ### Changed
 
 - Sync to upstream Luau 0.723

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -535,6 +535,12 @@
           "default": false,
           "scope": "resource"
         },
+        "luau-lsp.completion.showMethodsOnIndex": {
+          "markdownDescription": "Whether to show methods (functions which expect `self`) when performing a field access with a dot (e.g., `foo.bar`)",
+          "type": "boolean",
+          "default": true,
+          "scope": "resource"
+        },
         "luau-lsp.completion.showKeywords": {
           "markdownDescription": "Whether to show keywords (`if` / `then` / `and` / etc.) during autocomplete",
           "type": "boolean",

--- a/src/include/LSP/ClientConfiguration.hpp
+++ b/src/include/LSP/ClientConfiguration.hpp
@@ -192,6 +192,8 @@ struct ClientCompletionConfiguration
     bool fillCallArguments = true;
     /// Whether to show non-function properties when performing a method call with a colon
     bool showPropertiesOnMethodCall = false;
+    /// Whether to show methods (functions which expect `self`) when performing a field access with a dot
+    bool showMethodsOnIndex = true;
     /// Whether to show keywords (`if` / `then` / `and` / etc.) during autocomplete
     bool showKeywords = true;
     /// Whether to show the "function (anonymous autofilled)" generated function entry
@@ -205,8 +207,8 @@ struct ClientCompletionConfiguration
     bool enableFragmentAutocomplete = true;
 };
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(ClientCompletionConfiguration, enabled, autocompleteEnd, suggestImports, imports, addParentheses,
-    addTabstopAfterParentheses, fillCallArguments, showPropertiesOnMethodCall, showKeywords, showAnonymousAutofilledFunction, anonymousAutofilledFunction,
-    showDeprecatedItems, enableFragmentAutocomplete);
+    addTabstopAfterParentheses, fillCallArguments, showPropertiesOnMethodCall, showMethodsOnIndex, showKeywords, showAnonymousAutofilledFunction,
+    anonymousAutofilledFunction, showDeprecatedItems, enableFragmentAutocomplete);
 
 struct ClientSignatureHelpConfiguration
 {

--- a/src/operations/Completion.cpp
+++ b/src/operations/Completion.cpp
@@ -798,6 +798,12 @@ std::vector<lsp::CompletionItem> WorkspaceFolder::completion(const lsp::Completi
             !(Luau::get<Luau::FunctionType>(*entry.type) || Luau::isOverloadedFunction(*entry.type)))
             continue;
 
+        // If this entry is a method which expects `self`, and we are autocompleting after a `.`
+        // (so it would have to be called as `foo.bar(foo, ...)`), then hide it if configured to do so.
+        // In a non-self index, `wrongIndexType` is only set for entries that expect `:`.
+        if (!config.completion.showMethodsOnIndex && !entry.indexedWithSelf && entry.wrongIndexType)
+            continue;
+
         if (!config.completion.showKeywords && entry.kind == Luau::AutocompleteEntryKind::Keyword)
             continue;
 


### PR DESCRIPTION
## What

Adds `luau-lsp.completion.showMethodsOnIndex` (default: `true`). When set to `false`, methods (functions which expect `self`) are hidden from completion after a `.` field access.

## Why

This is the `.`-direction mirror of the existing `completion.showPropertiesOnMethodCall` (which hides non-function properties on `:`). Today, `:`-methods accessed via `.` are only *deprioritised* (`SortText::WrongIndexType`), never hideable — so when a prefix matches only methods (e.g. typing `instance.f` → `FindFirstChild`, `FindFirstAncestor`, …), the list fills with `method(self, ...)` entries that can only really be called with `:`. This adds an opt-in to drop them.

## Implementation

- New `completion.showMethodsOnIndex` setting (config field + `NLOHMANN_DEFINE` entry + `package.json`).
- A completion filter directly beside the existing property filter: skip entries that are `wrongIndexType` in a non-self index (i.e. a method accessed with `.`).

## Notes

- Default is `true`, so existing behaviour is unchanged — it's purely opt-in. `showPropertiesOnMethodCall` defaults to `false`; if you'd prefer `false` here for consistency, happy to flip it.
- Happy to add a completion test if you'd like one.
