### PR TITLE
Add `User` type & parameter forward compatibility

### DIFF
--- a/scripts/DataTypes.json
+++ b/scripts/DataTypes.json
@@ -5679,6 +5679,14 @@
                     "ValueType": {
                         "Name": "number"
                     }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "ToString",
+                    "Parameters": [],
+                    "ReturnType": {
+                        "Name": "string"
+                    }
                 }
             ],
             "Name": "User"

--- a/scripts/DataTypes.json
+++ b/scripts/DataTypes.json
@@ -2575,6 +2575,69 @@
                 }
             ],
             "Name": "SecurityCapabilities"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Function",
+                    "Name": "fromId",
+                    "Parameters": [
+                        {
+                            "Name": "id",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "User"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "fromId",
+                    "Parameters": [
+                        {
+                            "Name": "id",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        },
+                        {
+                            "Name": "domainType",
+                            "Type": {
+                                "Category": "Enum",
+                                "Name": "DomainType"
+                            }
+                        },
+                        {
+                            "Name": "domainId",
+                            "Type": {
+                                "Name": "number"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "User"
+                    }
+                },
+                {
+                    "MemberType": "Function",
+                    "Name": "fromString",
+                    "Parameters": [
+                        {
+                            "Name": "userStr",
+                            "Type": {
+                                "Name": "string"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Name": "User"
+                    }
+                }
+            ],
+            "Name": "User"
         }
     ],
     "DataTypes": [
@@ -5592,6 +5655,33 @@
                 }
             ],
             "Name": "SecurityCapabilities"
+        },
+        {
+            "Members": [
+                {
+                    "MemberType": "Property",
+                    "Name": "Id",
+                    "ValueType": {
+                        "Name": "number"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "DomainType",
+                    "ValueType": {
+                        "Category": "Enum",
+                        "Name": "DomainType"
+                    }
+                },
+                {
+                    "MemberType": "Property",
+                    "Name": "DomainId",
+                    "ValueType": {
+                        "Name": "number"
+                    }
+                }
+            ],
+            "Name": "User"
         }
     ]
 }

--- a/scripts/dumpRobloxTypes.py
+++ b/scripts/dumpRobloxTypes.py
@@ -885,6 +885,13 @@ def resolveType(type: Union[ApiValueType, CorrectionsValueType]) -> str:
 
 def resolveParameter(param: ApiParameter):
     paramType = resolveType(param["Type"])
+
+    if paramType == "User":
+        # HACK: The User type is a special case where we only want to
+        # union it with number when its a parameter, so we
+        # don't use TYPE_INDEX to handle this case.
+        paramType = "(User | number)"
+
     isOptional = paramType[-1] == "?"
     isVariadic = paramType.startswith("...")
     if isVariadic:


### PR DESCRIPTION
Implements the  `User` DataType, and adds a compatibility alias to make sure it doesn't cause any type errors due to the incoming API changes from 725.

For context, Roblox has changed the signature of several functions to use this new `User` type in place of the `number` type they were previously using to represent `Player.UserId`.

```
Changed the parameters of Function Players:GetPlayerByUserId 
	from: (userId: number)
	  to: (userId: User)

Changed the parameters of Function Players:GetUserThumbnailAsync 
	from: (userId: number, thumbnailType: Enum.ThumbnailType, thumbnailSize: Enum.ThumbnailSize)
	  to: (userId: User, thumbnailType: Enum.ThumbnailType, thumbnailSize: Enum.ThumbnailSize)

Changed the parameters of Function Players:GetHumanoidDescriptionFromUserId 
	from: (userId: number)
	  to: (userId: User)
	  
(...etc)
```

I made sure it is written as `(User | number)` in parameter types.