### PR TITLE
Fix plugin README to use correct studioPlugin setting names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Fixed signature help parameter highlighting when a parameter type references an exported table type from another module inside a union or intersection type ([#1507](https://github.com/JohnnyMorganz/luau-lsp/issues/1507))
+- Updated plugin README to reference the correct setting names `luau-lsp.studioPlugin.enabled` and `luau-lsp.studioPlugin.port` instead of the deprecated `luau-lsp.plugin.enabled` and `luau-lsp.plugin.port` ([#1522](https://github.com/JohnnyMorganz/luau-lsp/issues/1522))
 
 ## [1.68.0] - 2026-05-16
 

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -11,7 +11,7 @@ This plugin acts as a bridge between Roblox Studio and an external Luau Language
 1. Install the plugin in Roblox Studio [(Get it from the Creator Store)](https://www.roblox.com/library/10913122509/Luau-Language-Server-Companion)
 2. Ensure the Luau Language Server extension is installed in your editor (e.g., VS Code)
 3. Enable the plugin feature in your editor settings:
-   - VS Code: Set `luau-lsp.plugin.enabled` to `true`
+   - VS Code: Set `luau-lsp.studioPlugin.enabled` to `true`
 
 ## Usage
 
@@ -28,7 +28,7 @@ Click the **Settings** button to open the configuration module (`LuauLSP_Setting
 | Setting              | Type         | Default              | Description                                                             |
 | -------------------- | ------------ | -------------------- | ----------------------------------------------------------------------- |
 | `host`               | `string`     | `"http://localhost"` | Language server hostname                                                |
-| `port`               | `number`     | `3667`               | Language server port (configured via `luau-lsp.plugin.port` in VS Code) |
+| `port`               | `number`     | `3667`               | Language server port (configured via `luau-lsp.studioPlugin.port` in VS Code) |
 | `startAutomatically` | `boolean`    | `false`              | Auto-connect when Studio starts                                         |
 | `include`            | `{Instance}` | Core services        | Instances to track for changes                                          |
 | `logLevel`           | `string`     | `"INFO"`             | Logging verbosity (`DEBUG`, `INFO`, `WARN`, `ERROR`)                    |

--- a/plugin/src/LSPManager.luau
+++ b/plugin/src/LSPManager.luau
@@ -136,7 +136,7 @@ function LSPManager._logHttpError(self: LSPManager, operation: string, result: a
 			return
 		end
 		Log.warn(
-			`{operation} on {self._address} failed. Is the server enabled? Check the settings 'luau-lsp.plugin.enabled' and 'luau-lsp.plugin.port' in your editor`
+			`{operation} on {self._address} failed. Is the server enabled? Check the settings 'luau-lsp.studioPlugin.enabled' and 'luau-lsp.studioPlugin.port' in your editor`
 		)
 	else
 		Log.warn(`{operation} on {self._address} failed: {result}`)

--- a/plugin/src/Settings/DefaultSettings.luau
+++ b/plugin/src/Settings/DefaultSettings.luau
@@ -1,13 +1,13 @@
 --- Configuration for the Luau Language Server
 --- https://devforum.roblox.com/t/luau-language-server-for-external-editors/2185389
---- Make sure that `luau-lsp.plugin.enabled` is set to `true` in VSCode for the plugin to connect
+--- Make sure that `luau-lsp.studioPlugin.enabled` is set to `true` in VSCode for the plugin to connect
 
 return {
 	--- The host to connect to the language server.
 	host = "http://localhost",
 
 	--- The port to connect to the language server.
-	--- In VSCode, this is configured using `luau-lsp.plugin.port`
+	--- In VSCode, this is configured using `luau-lsp.studioPlugin.port`
 	--- Note, this port is *different* to your Rojo port
 	port = 3667,
 


### PR DESCRIPTION
Update references from deprecated `luau-lsp.plugin.enabled` and
`luau-lsp.plugin.port` to the current `luau-lsp.studioPlugin.enabled`
and `luau-lsp.studioPlugin.port`.

Fixes #1522