### PR TITLE
Fix ReflectionService method signatures and type stub aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `ReflectionService` method signatures to use proper typed return types (`ReflectedClass`, `ReflectedMethod`, `ReflectedEvent`, `ReflectedProperty`) instead of `{ any }`, and corrected `filter` parameter types to `ReflectionClassFilter`/`ReflectionMemberFilter` instead of `{ [string]: any }`. Also fixed `applyCorrections` in the type dump generator to correctly propagate `Declared` type overrides from `Corrections.json`.
+
 ### Changed
 
 - Sync to upstream Luau 0.726

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-### Fixed
-
-- Fixed `ReflectionService` method signatures to use proper typed return types (`ReflectedClass`, `ReflectedMethod`, `ReflectedEvent`, `ReflectedProperty`) instead of `{ any }`, and corrected `filter` parameter types to `ReflectionClassFilter`/`ReflectionMemberFilter` instead of `{ [string]: any }`. Also fixed `applyCorrections` in the type dump generator to correctly propagate `Declared` type overrides from `Corrections.json`.
-
 ### Changed
 
 - Sync to upstream Luau 0.726

--- a/scripts/Corrections.json
+++ b/scripts/Corrections.json
@@ -2392,6 +2392,34 @@
                     }
                 },
                 {
+                    "Name": "GetEventsOfClass",
+                    "Parameters": [
+                        {
+                            "Name": "filter",
+                            "Type": {
+                                "Declared": "ReflectionMemberFilter?"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Declared": "{ ReflectedEvent }"
+                    }
+                },
+                {
+                    "Name": "GetMethodsOfClass",
+                    "Parameters": [
+                        {
+                            "Name": "filter",
+                            "Type": {
+                                "Declared": "ReflectionMemberFilter?"
+                            }
+                        }
+                    ],
+                    "ReturnType": {
+                        "Declared": "{ ReflectedMethod }"
+                    }
+                },
+                {
                     "Name": "GetPropertiesOfClass",
                     "Parameters": [
                         {

--- a/scripts/dumpRobloxTypes.py
+++ b/scripts/dumpRobloxTypes.py
@@ -79,6 +79,10 @@ LUAU_SNIPPET_PATCHES = {
 
     "declare Workspace: any": "",
     "declare Game: any": "",
+
+    "type ReflectedClassOrNil = any": "type ReflectedClassOrNil = ReflectedClass?",
+    "type ReflectedClasses = any": "type ReflectedClasses = { ReflectedClass }",
+    "type ReflectedProperties = any": "type ReflectedProperties = { ReflectedProperty }",
 }
 
 TYPE_INDEX = {
@@ -1262,6 +1266,10 @@ def applyCorrections(dump: ApiDump, corrections: CorrectionsDump):
                                     otherMember["ReturnType"]["Generic"] = member[
                                         "ReturnType"
                                     ]["Generic"]
+                                if "Declared" in member["ReturnType"]:
+                                    otherMember["ReturnType"]["Declared"] = member[
+                                        "ReturnType"
+                                    ]["Declared"]
                             elif "ValueType" in member:
                                 otherMember["ValueType"]["Name"] = (
                                     member["ValueType"]["Name"]
@@ -1289,6 +1297,10 @@ def applyCorrections(dump: ApiDump, corrections: CorrectionsDump):
                                                 if "Generic" in param["Type"]:
                                                     otherParam["Type"]["Generic"] = (
                                                         param["Type"]["Generic"]
+                                                    )
+                                                if "Declared" in param["Type"]:
+                                                    otherParam["Type"]["Declared"] = (
+                                                        param["Type"]["Declared"]
                                                     )
                                             if "Default" in param:
                                                 otherParam["Default"] = param["Default"]

--- a/scripts/dumpRobloxTypes.py
+++ b/scripts/dumpRobloxTypes.py
@@ -80,9 +80,9 @@ LUAU_SNIPPET_PATCHES = {
     "declare Workspace: any": "",
     "declare Game: any": "",
 
-    "type ReflectedClassOrNil = any": "",
-    "type ReflectedClasses = any": "",
-    "type ReflectedProperties = any": "",
+    "type ReflectedClassOrNil = any": "type ReflectedClassOrNil = ReflectedClass?",
+    "type ReflectedClasses = any": "type ReflectedClasses = { ReflectedClass }",
+    "type ReflectedProperties = any": "type ReflectedProperties = { ReflectedProperty }",
 
     "type ReflectionClassFilter = {": "export type ReflectionClassFilter = {",
     "type ReflectionMemberFilter = {": "export type ReflectionMemberFilter = {",
@@ -114,9 +114,6 @@ TYPE_INDEX = {
     "table": "{ any }",
     "CoordinateFrame": "CFrame",
     "OptionalCoordinateFrame": "CFrame?",
-    "ReflectedClassOrNil": "ReflectedClass?",
-    "ReflectedClasses": "{ ReflectedClass }",
-    "ReflectedProperties": "{ ReflectedProperty }",
 }
 
 IGNORED_INSTANCES: List[str] = [

--- a/scripts/dumpRobloxTypes.py
+++ b/scripts/dumpRobloxTypes.py
@@ -80,9 +80,18 @@ LUAU_SNIPPET_PATCHES = {
     "declare Workspace: any": "",
     "declare Game: any": "",
 
-    "type ReflectedClassOrNil = any": "type ReflectedClassOrNil = ReflectedClass?",
-    "type ReflectedClasses = any": "type ReflectedClasses = { ReflectedClass }",
-    "type ReflectedProperties = any": "type ReflectedProperties = { ReflectedProperty }",
+    "type ReflectedClassOrNil = any": "",
+    "type ReflectedClasses = any": "",
+    "type ReflectedProperties = any": "",
+
+    "type ReflectionClassFilter = {": "export type ReflectionClassFilter = {",
+    "type ReflectionMemberFilter = {": "export type ReflectionMemberFilter = {",
+    "type ReflectionType = {": "export type ReflectionType = {",
+    "type ReflectionParameter = {": "export type ReflectionParameter = {",
+    "type ReflectedProperty = {": "export type ReflectedProperty = {",
+    "type ReflectedMethod = {": "export type ReflectedMethod = {",
+    "type ReflectedEvent = {": "export type ReflectedEvent = {",
+    "type ReflectedClass = {": "export type ReflectedClass = {",
 }
 
 TYPE_INDEX = {
@@ -105,6 +114,9 @@ TYPE_INDEX = {
     "table": "{ any }",
     "CoordinateFrame": "CFrame",
     "OptionalCoordinateFrame": "CFrame?",
+    "ReflectedClassOrNil": "ReflectedClass?",
+    "ReflectedClasses": "{ ReflectedClass }",
+    "ReflectedProperties": "{ ReflectedProperty }",
 }
 
 IGNORED_INSTANCES: List[str] = [

--- a/scripts/globalTypes.LocalUserSecurity.d.luau
+++ b/scripts/globalTypes.LocalUserSecurity.d.luau
@@ -55,9 +55,6 @@ type InfoTypeArray = any
 type OpenCloudModel = any
 type ProductIdentifierArray = any
 type RankedItemArray = any
-type ReflectedClassOrNil = ReflectedClass?
-type ReflectedClasses = { ReflectedClass }
-type ReflectedProperties = { ReflectedProperty }
 type UniqueId = any
 type VideoSampleArray = any
 type WebViewParams = any
@@ -8287,19 +8284,19 @@ type Creator = {
     CreatorType: EnumCreatorType
 }
 
-type ReflectionClassFilter = {
+export type ReflectionClassFilter = {
   Security: SecurityCapabilities?, -- default: SecurityCapabilities.fromCurrent()
   IsA: string?, -- default: nil
   ExcludeDisplay: boolean?, -- default: false
 }
 
-type ReflectionMemberFilter = {
+export type ReflectionMemberFilter = {
   Security: SecurityCapabilities?, -- default: SecurityCapabilities.fromCurrent()
   ExcludeInherited: boolean?, -- default: false
   ExcludeDisplay: boolean?, -- default: false
 }
 
-type ReflectionType = {
+export type ReflectionType = {
   EngineType: string,
   ScriptType: string?,
   EnumType: string?,
@@ -8307,13 +8304,13 @@ type ReflectionType = {
   -- ContentType: EnumAssetType?,
 }
 
-type ReflectionParameter = {
+export type ReflectionParameter = {
   Name: string,
   Type: ReflectionType,
   DefaultValue: any?
 }
 
-type ReflectedProperty = {
+export type ReflectedProperty = {
   Name: string,
   Serialized: boolean,
   Owner: string?,
@@ -8338,7 +8335,7 @@ type ReflectedProperty = {
   },
 }
 
-type ReflectedMethod = {
+export type ReflectedMethod = {
   Name: string,
   Owner: string,
   Parameters: { ReflectionParameter },
@@ -8356,7 +8353,7 @@ type ReflectedMethod = {
   },
 }
 
-type ReflectedEvent = {
+export type ReflectedEvent = {
   Name: string,
   Owner: string,
   Parameters: { ReflectionParameter },
@@ -8371,7 +8368,7 @@ type ReflectedEvent = {
   },
 }
 
-type ReflectedClass = {
+export type ReflectedClass = {
   Name: string,
   Serialized: boolean,
   Superclass: string?,
@@ -14048,11 +14045,11 @@ declare class ReflectionMetadataYieldFunctions extends Instance
 end
 
 declare class ReflectionService extends Instance
-	function GetClass(self, className: string, filter: ReflectionClassFilter?): ReflectedClassOrNil
-	function GetClasses(self, filter: ReflectionClassFilter?): ReflectedClasses
+	function GetClass(self, className: string, filter: ReflectionClassFilter?): ReflectedClass?
+	function GetClasses(self, filter: ReflectionClassFilter?): { ReflectedClass }
 	function GetEventsOfClass(self, className: string, filter: ReflectionMemberFilter?): { ReflectedEvent }
 	function GetMethodsOfClass(self, className: string, filter: ReflectionMemberFilter?): { ReflectedMethod }
-	function GetPropertiesOfClass(self, className: string, filter: ReflectionMemberFilter?): ReflectedProperties
+	function GetPropertiesOfClass(self, className: string, filter: ReflectionMemberFilter?): { ReflectedProperty }
 end
 
 declare class RemoteCommandService extends Instance

--- a/scripts/globalTypes.LocalUserSecurity.d.luau
+++ b/scripts/globalTypes.LocalUserSecurity.d.luau
@@ -55,9 +55,9 @@ type InfoTypeArray = any
 type OpenCloudModel = any
 type ProductIdentifierArray = any
 type RankedItemArray = any
-type ReflectedClassOrNil = any
-type ReflectedClasses = any
-type ReflectedProperties = any
+type ReflectedClassOrNil = ReflectedClass?
+type ReflectedClasses = { ReflectedClass }
+type ReflectedProperties = { ReflectedProperty }
 type UniqueId = any
 type VideoSampleArray = any
 type WebViewParams = any
@@ -14048,11 +14048,11 @@ declare class ReflectionMetadataYieldFunctions extends Instance
 end
 
 declare class ReflectionService extends Instance
-	function GetClass(self, className: string, filter: { [string]: any }?): { [string]: any }?
-	function GetClasses(self, filter: { [string]: any }?): { any }
-	function GetEventsOfClass(self, className: string, filter: { [string]: any }?): { any }
-	function GetMethodsOfClass(self, className: string, filter: { [string]: any }?): { any }
-	function GetPropertiesOfClass(self, className: string, filter: { [string]: any }?): { any }
+	function GetClass(self, className: string, filter: ReflectionClassFilter?): ReflectedClassOrNil
+	function GetClasses(self, filter: ReflectionClassFilter?): ReflectedClasses
+	function GetEventsOfClass(self, className: string, filter: ReflectionMemberFilter?): { ReflectedEvent }
+	function GetMethodsOfClass(self, className: string, filter: ReflectionMemberFilter?): { ReflectedMethod }
+	function GetPropertiesOfClass(self, className: string, filter: ReflectionMemberFilter?): ReflectedProperties
 end
 
 declare class RemoteCommandService extends Instance

--- a/scripts/globalTypes.LocalUserSecurity.d.luau
+++ b/scripts/globalTypes.LocalUserSecurity.d.luau
@@ -55,6 +55,9 @@ type InfoTypeArray = any
 type OpenCloudModel = any
 type ProductIdentifierArray = any
 type RankedItemArray = any
+type ReflectedClassOrNil = ReflectedClass?
+type ReflectedClasses = { ReflectedClass }
+type ReflectedProperties = { ReflectedProperty }
 type UniqueId = any
 type VideoSampleArray = any
 type WebViewParams = any
@@ -14045,11 +14048,11 @@ declare class ReflectionMetadataYieldFunctions extends Instance
 end
 
 declare class ReflectionService extends Instance
-	function GetClass(self, className: string, filter: ReflectionClassFilter?): ReflectedClass?
-	function GetClasses(self, filter: ReflectionClassFilter?): { ReflectedClass }
+	function GetClass(self, className: string, filter: ReflectionClassFilter?): ReflectedClassOrNil
+	function GetClasses(self, filter: ReflectionClassFilter?): ReflectedClasses
 	function GetEventsOfClass(self, className: string, filter: ReflectionMemberFilter?): { ReflectedEvent }
 	function GetMethodsOfClass(self, className: string, filter: ReflectionMemberFilter?): { ReflectedMethod }
-	function GetPropertiesOfClass(self, className: string, filter: ReflectionMemberFilter?): { ReflectedProperty }
+	function GetPropertiesOfClass(self, className: string, filter: ReflectionMemberFilter?): ReflectedProperties
 end
 
 declare class RemoteCommandService extends Instance

--- a/scripts/globalTypes.None.d.luau
+++ b/scripts/globalTypes.None.d.luau
@@ -55,6 +55,9 @@ type InfoTypeArray = any
 type OpenCloudModel = any
 type ProductIdentifierArray = any
 type RankedItemArray = any
+type ReflectedClassOrNil = ReflectedClass?
+type ReflectedClasses = { ReflectedClass }
+type ReflectedProperties = { ReflectedProperty }
 type UniqueId = any
 type VideoSampleArray = any
 type WebViewParams = any
@@ -13984,11 +13987,11 @@ declare class ReflectionMetadataYieldFunctions extends Instance
 end
 
 declare class ReflectionService extends Instance
-	function GetClass(self, className: string, filter: ReflectionClassFilter?): ReflectedClass?
-	function GetClasses(self, filter: ReflectionClassFilter?): { ReflectedClass }
+	function GetClass(self, className: string, filter: ReflectionClassFilter?): ReflectedClassOrNil
+	function GetClasses(self, filter: ReflectionClassFilter?): ReflectedClasses
 	function GetEventsOfClass(self, className: string, filter: ReflectionMemberFilter?): { ReflectedEvent }
 	function GetMethodsOfClass(self, className: string, filter: ReflectionMemberFilter?): { ReflectedMethod }
-	function GetPropertiesOfClass(self, className: string, filter: ReflectionMemberFilter?): { ReflectedProperty }
+	function GetPropertiesOfClass(self, className: string, filter: ReflectionMemberFilter?): ReflectedProperties
 end
 
 declare class RemoteCommandService extends Instance

--- a/scripts/globalTypes.None.d.luau
+++ b/scripts/globalTypes.None.d.luau
@@ -55,9 +55,6 @@ type InfoTypeArray = any
 type OpenCloudModel = any
 type ProductIdentifierArray = any
 type RankedItemArray = any
-type ReflectedClassOrNil = ReflectedClass?
-type ReflectedClasses = { ReflectedClass }
-type ReflectedProperties = { ReflectedProperty }
 type UniqueId = any
 type VideoSampleArray = any
 type WebViewParams = any
@@ -8287,19 +8284,19 @@ type Creator = {
     CreatorType: EnumCreatorType
 }
 
-type ReflectionClassFilter = {
+export type ReflectionClassFilter = {
   Security: SecurityCapabilities?, -- default: SecurityCapabilities.fromCurrent()
   IsA: string?, -- default: nil
   ExcludeDisplay: boolean?, -- default: false
 }
 
-type ReflectionMemberFilter = {
+export type ReflectionMemberFilter = {
   Security: SecurityCapabilities?, -- default: SecurityCapabilities.fromCurrent()
   ExcludeInherited: boolean?, -- default: false
   ExcludeDisplay: boolean?, -- default: false
 }
 
-type ReflectionType = {
+export type ReflectionType = {
   EngineType: string,
   ScriptType: string?,
   EnumType: string?,
@@ -8307,13 +8304,13 @@ type ReflectionType = {
   -- ContentType: EnumAssetType?,
 }
 
-type ReflectionParameter = {
+export type ReflectionParameter = {
   Name: string,
   Type: ReflectionType,
   DefaultValue: any?
 }
 
-type ReflectedProperty = {
+export type ReflectedProperty = {
   Name: string,
   Serialized: boolean,
   Owner: string?,
@@ -8338,7 +8335,7 @@ type ReflectedProperty = {
   },
 }
 
-type ReflectedMethod = {
+export type ReflectedMethod = {
   Name: string,
   Owner: string,
   Parameters: { ReflectionParameter },
@@ -8356,7 +8353,7 @@ type ReflectedMethod = {
   },
 }
 
-type ReflectedEvent = {
+export type ReflectedEvent = {
   Name: string,
   Owner: string,
   Parameters: { ReflectionParameter },
@@ -8371,7 +8368,7 @@ type ReflectedEvent = {
   },
 }
 
-type ReflectedClass = {
+export type ReflectedClass = {
   Name: string,
   Serialized: boolean,
   Superclass: string?,
@@ -13987,11 +13984,11 @@ declare class ReflectionMetadataYieldFunctions extends Instance
 end
 
 declare class ReflectionService extends Instance
-	function GetClass(self, className: string, filter: ReflectionClassFilter?): ReflectedClassOrNil
-	function GetClasses(self, filter: ReflectionClassFilter?): ReflectedClasses
+	function GetClass(self, className: string, filter: ReflectionClassFilter?): ReflectedClass?
+	function GetClasses(self, filter: ReflectionClassFilter?): { ReflectedClass }
 	function GetEventsOfClass(self, className: string, filter: ReflectionMemberFilter?): { ReflectedEvent }
 	function GetMethodsOfClass(self, className: string, filter: ReflectionMemberFilter?): { ReflectedMethod }
-	function GetPropertiesOfClass(self, className: string, filter: ReflectionMemberFilter?): ReflectedProperties
+	function GetPropertiesOfClass(self, className: string, filter: ReflectionMemberFilter?): { ReflectedProperty }
 end
 
 declare class RemoteCommandService extends Instance

--- a/scripts/globalTypes.None.d.luau
+++ b/scripts/globalTypes.None.d.luau
@@ -55,9 +55,9 @@ type InfoTypeArray = any
 type OpenCloudModel = any
 type ProductIdentifierArray = any
 type RankedItemArray = any
-type ReflectedClassOrNil = any
-type ReflectedClasses = any
-type ReflectedProperties = any
+type ReflectedClassOrNil = ReflectedClass?
+type ReflectedClasses = { ReflectedClass }
+type ReflectedProperties = { ReflectedProperty }
 type UniqueId = any
 type VideoSampleArray = any
 type WebViewParams = any
@@ -13987,11 +13987,11 @@ declare class ReflectionMetadataYieldFunctions extends Instance
 end
 
 declare class ReflectionService extends Instance
-	function GetClass(self, className: string, filter: { [string]: any }?): { [string]: any }?
-	function GetClasses(self, filter: { [string]: any }?): { any }
-	function GetEventsOfClass(self, className: string, filter: { [string]: any }?): { any }
-	function GetMethodsOfClass(self, className: string, filter: { [string]: any }?): { any }
-	function GetPropertiesOfClass(self, className: string, filter: { [string]: any }?): { any }
+	function GetClass(self, className: string, filter: ReflectionClassFilter?): ReflectedClassOrNil
+	function GetClasses(self, filter: ReflectionClassFilter?): ReflectedClasses
+	function GetEventsOfClass(self, className: string, filter: ReflectionMemberFilter?): { ReflectedEvent }
+	function GetMethodsOfClass(self, className: string, filter: ReflectionMemberFilter?): { ReflectedMethod }
+	function GetPropertiesOfClass(self, className: string, filter: ReflectionMemberFilter?): ReflectedProperties
 end
 
 declare class RemoteCommandService extends Instance

--- a/scripts/globalTypes.PluginSecurity.d.luau
+++ b/scripts/globalTypes.PluginSecurity.d.luau
@@ -55,9 +55,6 @@ type InfoTypeArray = any
 type OpenCloudModel = any
 type ProductIdentifierArray = any
 type RankedItemArray = any
-type ReflectedClassOrNil = ReflectedClass?
-type ReflectedClasses = { ReflectedClass }
-type ReflectedProperties = { ReflectedProperty }
 type UniqueId = any
 type VideoSampleArray = any
 type WebViewParams = any
@@ -8287,19 +8284,19 @@ type Creator = {
     CreatorType: EnumCreatorType
 }
 
-type ReflectionClassFilter = {
+export type ReflectionClassFilter = {
   Security: SecurityCapabilities?, -- default: SecurityCapabilities.fromCurrent()
   IsA: string?, -- default: nil
   ExcludeDisplay: boolean?, -- default: false
 }
 
-type ReflectionMemberFilter = {
+export type ReflectionMemberFilter = {
   Security: SecurityCapabilities?, -- default: SecurityCapabilities.fromCurrent()
   ExcludeInherited: boolean?, -- default: false
   ExcludeDisplay: boolean?, -- default: false
 }
 
-type ReflectionType = {
+export type ReflectionType = {
   EngineType: string,
   ScriptType: string?,
   EnumType: string?,
@@ -8307,13 +8304,13 @@ type ReflectionType = {
   -- ContentType: EnumAssetType?,
 }
 
-type ReflectionParameter = {
+export type ReflectionParameter = {
   Name: string,
   Type: ReflectionType,
   DefaultValue: any?
 }
 
-type ReflectedProperty = {
+export type ReflectedProperty = {
   Name: string,
   Serialized: boolean,
   Owner: string?,
@@ -8338,7 +8335,7 @@ type ReflectedProperty = {
   },
 }
 
-type ReflectedMethod = {
+export type ReflectedMethod = {
   Name: string,
   Owner: string,
   Parameters: { ReflectionParameter },
@@ -8356,7 +8353,7 @@ type ReflectedMethod = {
   },
 }
 
-type ReflectedEvent = {
+export type ReflectedEvent = {
   Name: string,
   Owner: string,
   Parameters: { ReflectionParameter },
@@ -8371,7 +8368,7 @@ type ReflectedEvent = {
   },
 }
 
-type ReflectedClass = {
+export type ReflectedClass = {
   Name: string,
   Serialized: boolean,
   Superclass: string?,
@@ -14276,11 +14273,11 @@ declare class ReflectionMetadataYieldFunctions extends Instance
 end
 
 declare class ReflectionService extends Instance
-	function GetClass(self, className: string, filter: ReflectionClassFilter?): ReflectedClassOrNil
-	function GetClasses(self, filter: ReflectionClassFilter?): ReflectedClasses
+	function GetClass(self, className: string, filter: ReflectionClassFilter?): ReflectedClass?
+	function GetClasses(self, filter: ReflectionClassFilter?): { ReflectedClass }
 	function GetEventsOfClass(self, className: string, filter: ReflectionMemberFilter?): { ReflectedEvent }
 	function GetMethodsOfClass(self, className: string, filter: ReflectionMemberFilter?): { ReflectedMethod }
-	function GetPropertiesOfClass(self, className: string, filter: ReflectionMemberFilter?): ReflectedProperties
+	function GetPropertiesOfClass(self, className: string, filter: ReflectionMemberFilter?): { ReflectedProperty }
 end
 
 declare class RemoteCommandService extends Instance

--- a/scripts/globalTypes.PluginSecurity.d.luau
+++ b/scripts/globalTypes.PluginSecurity.d.luau
@@ -55,9 +55,9 @@ type InfoTypeArray = any
 type OpenCloudModel = any
 type ProductIdentifierArray = any
 type RankedItemArray = any
-type ReflectedClassOrNil = any
-type ReflectedClasses = any
-type ReflectedProperties = any
+type ReflectedClassOrNil = ReflectedClass?
+type ReflectedClasses = { ReflectedClass }
+type ReflectedProperties = { ReflectedProperty }
 type UniqueId = any
 type VideoSampleArray = any
 type WebViewParams = any
@@ -14276,11 +14276,11 @@ declare class ReflectionMetadataYieldFunctions extends Instance
 end
 
 declare class ReflectionService extends Instance
-	function GetClass(self, className: string, filter: { [string]: any }?): { [string]: any }?
-	function GetClasses(self, filter: { [string]: any }?): { any }
-	function GetEventsOfClass(self, className: string, filter: { [string]: any }?): { any }
-	function GetMethodsOfClass(self, className: string, filter: { [string]: any }?): { any }
-	function GetPropertiesOfClass(self, className: string, filter: { [string]: any }?): { any }
+	function GetClass(self, className: string, filter: ReflectionClassFilter?): ReflectedClassOrNil
+	function GetClasses(self, filter: ReflectionClassFilter?): ReflectedClasses
+	function GetEventsOfClass(self, className: string, filter: ReflectionMemberFilter?): { ReflectedEvent }
+	function GetMethodsOfClass(self, className: string, filter: ReflectionMemberFilter?): { ReflectedMethod }
+	function GetPropertiesOfClass(self, className: string, filter: ReflectionMemberFilter?): ReflectedProperties
 end
 
 declare class RemoteCommandService extends Instance

--- a/scripts/globalTypes.PluginSecurity.d.luau
+++ b/scripts/globalTypes.PluginSecurity.d.luau
@@ -55,6 +55,9 @@ type InfoTypeArray = any
 type OpenCloudModel = any
 type ProductIdentifierArray = any
 type RankedItemArray = any
+type ReflectedClassOrNil = ReflectedClass?
+type ReflectedClasses = { ReflectedClass }
+type ReflectedProperties = { ReflectedProperty }
 type UniqueId = any
 type VideoSampleArray = any
 type WebViewParams = any
@@ -14273,11 +14276,11 @@ declare class ReflectionMetadataYieldFunctions extends Instance
 end
 
 declare class ReflectionService extends Instance
-	function GetClass(self, className: string, filter: ReflectionClassFilter?): ReflectedClass?
-	function GetClasses(self, filter: ReflectionClassFilter?): { ReflectedClass }
+	function GetClass(self, className: string, filter: ReflectionClassFilter?): ReflectedClassOrNil
+	function GetClasses(self, filter: ReflectionClassFilter?): ReflectedClasses
 	function GetEventsOfClass(self, className: string, filter: ReflectionMemberFilter?): { ReflectedEvent }
 	function GetMethodsOfClass(self, className: string, filter: ReflectionMemberFilter?): { ReflectedMethod }
-	function GetPropertiesOfClass(self, className: string, filter: ReflectionMemberFilter?): { ReflectedProperty }
+	function GetPropertiesOfClass(self, className: string, filter: ReflectionMemberFilter?): ReflectedProperties
 end
 
 declare class RemoteCommandService extends Instance

--- a/scripts/globalTypes.RobloxScriptSecurity.d.luau
+++ b/scripts/globalTypes.RobloxScriptSecurity.d.luau
@@ -55,6 +55,9 @@ type InfoTypeArray = any
 type OpenCloudModel = any
 type ProductIdentifierArray = any
 type RankedItemArray = any
+type ReflectedClassOrNil = ReflectedClass?
+type ReflectedClasses = { ReflectedClass }
+type ReflectedProperties = { ReflectedProperty }
 type UniqueId = any
 type VideoSampleArray = any
 type WebViewParams = any
@@ -15748,11 +15751,11 @@ declare class ReflectionMetadataYieldFunctions extends Instance
 end
 
 declare class ReflectionService extends Instance
-	function GetClass(self, className: string, filter: ReflectionClassFilter?): ReflectedClass?
-	function GetClasses(self, filter: ReflectionClassFilter?): { ReflectedClass }
+	function GetClass(self, className: string, filter: ReflectionClassFilter?): ReflectedClassOrNil
+	function GetClasses(self, filter: ReflectionClassFilter?): ReflectedClasses
 	function GetEventsOfClass(self, className: string, filter: ReflectionMemberFilter?): { ReflectedEvent }
 	function GetMethodsOfClass(self, className: string, filter: ReflectionMemberFilter?): { ReflectedMethod }
-	function GetPropertiesOfClass(self, className: string, filter: ReflectionMemberFilter?): { ReflectedProperty }
+	function GetPropertiesOfClass(self, className: string, filter: ReflectionMemberFilter?): ReflectedProperties
 	function GetPropertyNames(self, className: string): { string }
 	function GetStyledPropertyNames(self, name: string): { any }
 end

--- a/scripts/globalTypes.RobloxScriptSecurity.d.luau
+++ b/scripts/globalTypes.RobloxScriptSecurity.d.luau
@@ -55,9 +55,6 @@ type InfoTypeArray = any
 type OpenCloudModel = any
 type ProductIdentifierArray = any
 type RankedItemArray = any
-type ReflectedClassOrNil = ReflectedClass?
-type ReflectedClasses = { ReflectedClass }
-type ReflectedProperties = { ReflectedProperty }
 type UniqueId = any
 type VideoSampleArray = any
 type WebViewParams = any
@@ -8287,19 +8284,19 @@ type Creator = {
     CreatorType: EnumCreatorType
 }
 
-type ReflectionClassFilter = {
+export type ReflectionClassFilter = {
   Security: SecurityCapabilities?, -- default: SecurityCapabilities.fromCurrent()
   IsA: string?, -- default: nil
   ExcludeDisplay: boolean?, -- default: false
 }
 
-type ReflectionMemberFilter = {
+export type ReflectionMemberFilter = {
   Security: SecurityCapabilities?, -- default: SecurityCapabilities.fromCurrent()
   ExcludeInherited: boolean?, -- default: false
   ExcludeDisplay: boolean?, -- default: false
 }
 
-type ReflectionType = {
+export type ReflectionType = {
   EngineType: string,
   ScriptType: string?,
   EnumType: string?,
@@ -8307,13 +8304,13 @@ type ReflectionType = {
   -- ContentType: EnumAssetType?,
 }
 
-type ReflectionParameter = {
+export type ReflectionParameter = {
   Name: string,
   Type: ReflectionType,
   DefaultValue: any?
 }
 
-type ReflectedProperty = {
+export type ReflectedProperty = {
   Name: string,
   Serialized: boolean,
   Owner: string?,
@@ -8338,7 +8335,7 @@ type ReflectedProperty = {
   },
 }
 
-type ReflectedMethod = {
+export type ReflectedMethod = {
   Name: string,
   Owner: string,
   Parameters: { ReflectionParameter },
@@ -8356,7 +8353,7 @@ type ReflectedMethod = {
   },
 }
 
-type ReflectedEvent = {
+export type ReflectedEvent = {
   Name: string,
   Owner: string,
   Parameters: { ReflectionParameter },
@@ -8371,7 +8368,7 @@ type ReflectedEvent = {
   },
 }
 
-type ReflectedClass = {
+export type ReflectedClass = {
   Name: string,
   Serialized: boolean,
   Superclass: string?,
@@ -15751,11 +15748,11 @@ declare class ReflectionMetadataYieldFunctions extends Instance
 end
 
 declare class ReflectionService extends Instance
-	function GetClass(self, className: string, filter: ReflectionClassFilter?): ReflectedClassOrNil
-	function GetClasses(self, filter: ReflectionClassFilter?): ReflectedClasses
+	function GetClass(self, className: string, filter: ReflectionClassFilter?): ReflectedClass?
+	function GetClasses(self, filter: ReflectionClassFilter?): { ReflectedClass }
 	function GetEventsOfClass(self, className: string, filter: ReflectionMemberFilter?): { ReflectedEvent }
 	function GetMethodsOfClass(self, className: string, filter: ReflectionMemberFilter?): { ReflectedMethod }
-	function GetPropertiesOfClass(self, className: string, filter: ReflectionMemberFilter?): ReflectedProperties
+	function GetPropertiesOfClass(self, className: string, filter: ReflectionMemberFilter?): { ReflectedProperty }
 	function GetPropertyNames(self, className: string): { string }
 	function GetStyledPropertyNames(self, name: string): { any }
 end

--- a/scripts/globalTypes.RobloxScriptSecurity.d.luau
+++ b/scripts/globalTypes.RobloxScriptSecurity.d.luau
@@ -55,9 +55,9 @@ type InfoTypeArray = any
 type OpenCloudModel = any
 type ProductIdentifierArray = any
 type RankedItemArray = any
-type ReflectedClassOrNil = any
-type ReflectedClasses = any
-type ReflectedProperties = any
+type ReflectedClassOrNil = ReflectedClass?
+type ReflectedClasses = { ReflectedClass }
+type ReflectedProperties = { ReflectedProperty }
 type UniqueId = any
 type VideoSampleArray = any
 type WebViewParams = any
@@ -15751,12 +15751,12 @@ declare class ReflectionMetadataYieldFunctions extends Instance
 end
 
 declare class ReflectionService extends Instance
-	function GetClass(self, className: string, filter: { [string]: any }?): { [string]: any }?
-	function GetClasses(self, filter: { [string]: any }?): { any }
-	function GetEventsOfClass(self, className: string, filter: { [string]: any }?): { any }
-	function GetMethodsOfClass(self, className: string, filter: { [string]: any }?): { any }
-	function GetPropertiesOfClass(self, className: string, filter: { [string]: any }?): { any }
-	function GetPropertyNames(self, name: string): { string }
+	function GetClass(self, className: string, filter: ReflectionClassFilter?): ReflectedClassOrNil
+	function GetClasses(self, filter: ReflectionClassFilter?): ReflectedClasses
+	function GetEventsOfClass(self, className: string, filter: ReflectionMemberFilter?): { ReflectedEvent }
+	function GetMethodsOfClass(self, className: string, filter: ReflectionMemberFilter?): { ReflectedMethod }
+	function GetPropertiesOfClass(self, className: string, filter: ReflectionMemberFilter?): ReflectedProperties
+	function GetPropertyNames(self, className: string): { string }
 	function GetStyledPropertyNames(self, name: string): { any }
 end
 

--- a/scripts/globalTypes.d.luau
+++ b/scripts/globalTypes.d.luau
@@ -55,6 +55,9 @@ type InfoTypeArray = any
 type OpenCloudModel = any
 type ProductIdentifierArray = any
 type RankedItemArray = any
+type ReflectedClassOrNil = ReflectedClass?
+type ReflectedClasses = { ReflectedClass }
+type ReflectedProperties = { ReflectedProperty }
 type UniqueId = any
 type VideoSampleArray = any
 type WebViewParams = any
@@ -15748,11 +15751,11 @@ declare class ReflectionMetadataYieldFunctions extends Instance
 end
 
 declare class ReflectionService extends Instance
-	function GetClass(self, className: string, filter: ReflectionClassFilter?): ReflectedClass?
-	function GetClasses(self, filter: ReflectionClassFilter?): { ReflectedClass }
+	function GetClass(self, className: string, filter: ReflectionClassFilter?): ReflectedClassOrNil
+	function GetClasses(self, filter: ReflectionClassFilter?): ReflectedClasses
 	function GetEventsOfClass(self, className: string, filter: ReflectionMemberFilter?): { ReflectedEvent }
 	function GetMethodsOfClass(self, className: string, filter: ReflectionMemberFilter?): { ReflectedMethod }
-	function GetPropertiesOfClass(self, className: string, filter: ReflectionMemberFilter?): { ReflectedProperty }
+	function GetPropertiesOfClass(self, className: string, filter: ReflectionMemberFilter?): ReflectedProperties
 	function GetPropertyNames(self, className: string): { string }
 	function GetStyledPropertyNames(self, name: string): { any }
 end

--- a/scripts/globalTypes.d.luau
+++ b/scripts/globalTypes.d.luau
@@ -55,9 +55,6 @@ type InfoTypeArray = any
 type OpenCloudModel = any
 type ProductIdentifierArray = any
 type RankedItemArray = any
-type ReflectedClassOrNil = ReflectedClass?
-type ReflectedClasses = { ReflectedClass }
-type ReflectedProperties = { ReflectedProperty }
 type UniqueId = any
 type VideoSampleArray = any
 type WebViewParams = any
@@ -8287,19 +8284,19 @@ type Creator = {
     CreatorType: EnumCreatorType
 }
 
-type ReflectionClassFilter = {
+export type ReflectionClassFilter = {
   Security: SecurityCapabilities?, -- default: SecurityCapabilities.fromCurrent()
   IsA: string?, -- default: nil
   ExcludeDisplay: boolean?, -- default: false
 }
 
-type ReflectionMemberFilter = {
+export type ReflectionMemberFilter = {
   Security: SecurityCapabilities?, -- default: SecurityCapabilities.fromCurrent()
   ExcludeInherited: boolean?, -- default: false
   ExcludeDisplay: boolean?, -- default: false
 }
 
-type ReflectionType = {
+export type ReflectionType = {
   EngineType: string,
   ScriptType: string?,
   EnumType: string?,
@@ -8307,13 +8304,13 @@ type ReflectionType = {
   -- ContentType: EnumAssetType?,
 }
 
-type ReflectionParameter = {
+export type ReflectionParameter = {
   Name: string,
   Type: ReflectionType,
   DefaultValue: any?
 }
 
-type ReflectedProperty = {
+export type ReflectedProperty = {
   Name: string,
   Serialized: boolean,
   Owner: string?,
@@ -8338,7 +8335,7 @@ type ReflectedProperty = {
   },
 }
 
-type ReflectedMethod = {
+export type ReflectedMethod = {
   Name: string,
   Owner: string,
   Parameters: { ReflectionParameter },
@@ -8356,7 +8353,7 @@ type ReflectedMethod = {
   },
 }
 
-type ReflectedEvent = {
+export type ReflectedEvent = {
   Name: string,
   Owner: string,
   Parameters: { ReflectionParameter },
@@ -8371,7 +8368,7 @@ type ReflectedEvent = {
   },
 }
 
-type ReflectedClass = {
+export type ReflectedClass = {
   Name: string,
   Serialized: boolean,
   Superclass: string?,
@@ -15751,11 +15748,11 @@ declare class ReflectionMetadataYieldFunctions extends Instance
 end
 
 declare class ReflectionService extends Instance
-	function GetClass(self, className: string, filter: ReflectionClassFilter?): ReflectedClassOrNil
-	function GetClasses(self, filter: ReflectionClassFilter?): ReflectedClasses
+	function GetClass(self, className: string, filter: ReflectionClassFilter?): ReflectedClass?
+	function GetClasses(self, filter: ReflectionClassFilter?): { ReflectedClass }
 	function GetEventsOfClass(self, className: string, filter: ReflectionMemberFilter?): { ReflectedEvent }
 	function GetMethodsOfClass(self, className: string, filter: ReflectionMemberFilter?): { ReflectedMethod }
-	function GetPropertiesOfClass(self, className: string, filter: ReflectionMemberFilter?): ReflectedProperties
+	function GetPropertiesOfClass(self, className: string, filter: ReflectionMemberFilter?): { ReflectedProperty }
 	function GetPropertyNames(self, className: string): { string }
 	function GetStyledPropertyNames(self, name: string): { any }
 end

--- a/scripts/globalTypes.d.luau
+++ b/scripts/globalTypes.d.luau
@@ -55,9 +55,9 @@ type InfoTypeArray = any
 type OpenCloudModel = any
 type ProductIdentifierArray = any
 type RankedItemArray = any
-type ReflectedClassOrNil = any
-type ReflectedClasses = any
-type ReflectedProperties = any
+type ReflectedClassOrNil = ReflectedClass?
+type ReflectedClasses = { ReflectedClass }
+type ReflectedProperties = { ReflectedProperty }
 type UniqueId = any
 type VideoSampleArray = any
 type WebViewParams = any
@@ -15751,12 +15751,12 @@ declare class ReflectionMetadataYieldFunctions extends Instance
 end
 
 declare class ReflectionService extends Instance
-	function GetClass(self, className: string, filter: { [string]: any }?): { [string]: any }?
-	function GetClasses(self, filter: { [string]: any }?): { any }
-	function GetEventsOfClass(self, className: string, filter: { [string]: any }?): { any }
-	function GetMethodsOfClass(self, className: string, filter: { [string]: any }?): { any }
-	function GetPropertiesOfClass(self, className: string, filter: { [string]: any }?): { any }
-	function GetPropertyNames(self, name: string): { string }
+	function GetClass(self, className: string, filter: ReflectionClassFilter?): ReflectedClassOrNil
+	function GetClasses(self, filter: ReflectionClassFilter?): ReflectedClasses
+	function GetEventsOfClass(self, className: string, filter: ReflectionMemberFilter?): { ReflectedEvent }
+	function GetMethodsOfClass(self, className: string, filter: ReflectionMemberFilter?): { ReflectedMethod }
+	function GetPropertiesOfClass(self, className: string, filter: ReflectionMemberFilter?): ReflectedProperties
+	function GetPropertyNames(self, className: string): { string }
 	function GetStyledPropertyNames(self, name: string): { any }
 end
 


### PR DESCRIPTION
The `applyCorrections` function in `dumpRobloxTypes.py` handled `Generic`
in ReturnType and parameter type corrections but silently dropped `Declared`
overrides, so all existing ReflectionService corrections in Corrections.json
were no-ops. This fix propagates `Declared` correctly for both return types
and parameters.

Additionally:
- Add `GetEventsOfClass` and `GetMethodsOfClass` to Corrections.json with
  proper `ReflectionMemberFilter?` filter types and typed array return types
- Wire the `ReflectedClassOrNil`, `ReflectedClasses`, and `ReflectedProperties`
  stub aliases (previously `= any`) to the real types already defined in
  LuauTypes.d.luau via LUAU_SNIPPET_PATCHES
- Update all five generated globalTypes*.d.luau files to reflect the corrected
  signatures immediately, without requiring a full type dump regeneration