### PR TITLE
Add more Moonwave documentation support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-- Sync to upstream Luau 0.726
+- Sync to upstream Luau 0.728
 - Moonwave flag tags (e.g. `@yields`, `@server`, `@private`) are now rendered as readable labels (e.g. **Yields**) instead of the raw tag name
 - Moonwave declaration and metadata tags (`@class`, `@function`, `@method`, `@prop`, `@interface`, `@type`, `@__index`, `@external`, `@ignore`) are no longer shown as raw text in hover documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Added support for more Moonwave tags in hover documentation: `@deprecated` and `@since` are now rendered with their version and description, `@field` entries are shown in a "Fields" list, and `@readonly` is boldified
+
 ### Changed
 
 - Sync to upstream Luau 0.726
+- Moonwave flag tags (e.g. `@yields`, `@server`, `@private`) are now rendered as readable labels (e.g. **Yields**) instead of the raw tag name
+- Moonwave declaration and metadata tags (`@class`, `@function`, `@method`, `@prop`, `@interface`, `@type`, `@__index`, `@external`, `@ignore`) are no longer shown as raw text in hover documentation
 
 ## [1.68.1] - 2026-06-14
 

--- a/src/DocumentationParser.cpp
+++ b/src/DocumentationParser.cpp
@@ -167,7 +167,7 @@ std::string printMoonwaveDocumentation(const std::vector<std::string>& comments)
             // Boldify
             result += "**" + comment + "**\n";
         else if (Luau::startsWith(comment, "@deprecated "))
-            result = "**Deprecated** " + comment.substr(12) + "\n" + result;
+            result = "**Deprecated** " + comment.substr(12) + "\n\n" + result;
         else if (Luau::startsWith(comment, "@tag ") || Luau::startsWith(comment, "@within "))
             // Ignore
             continue;

--- a/src/DocumentationParser.cpp
+++ b/src/DocumentationParser.cpp
@@ -162,18 +162,12 @@ std::string printMoonwaveDocumentation(const std::vector<std::string>& comments)
             returns.emplace_back(comment);
         else if (Luau::startsWith(comment, "@error "))
             throws.emplace_back(comment);
-        else if (
-            comment == "@yields"
-            || comment == "@unreleased"
-            || comment == "@server"
-            || comment == "@client"
-            || comment == "@plugin"
-            || comment == "@private"
-            || comment == "@ignore"
-            || comment == "@readonly"
-        )
+        else if (comment == "@yields" || comment == "@unreleased" || comment == "@server" || comment == "@client" || comment == "@plugin" ||
+                 comment == "@private" || comment == "@ignore" || comment == "@readonly")
             // Boldify
             result += "**" + comment + "**\n";
+        else if (Luau::startsWith(comment, "@deprecated "))
+            result = "**Deprecated** " + comment.substr(12) + "\n" + result;
         else if (Luau::startsWith(comment, "@tag ") || Luau::startsWith(comment, "@within "))
             // Ignore
             continue;
@@ -279,7 +273,8 @@ struct AttachCommentsVisitor : public Luau::AstVisitor
 
         // Sort by end position descending (closest to target first)
         std::sort(candidates.begin(), candidates.end(),
-            [](const Luau::Comment& a, const Luau::Comment& b) {
+            [](const Luau::Comment& a, const Luau::Comment& b)
+            {
                 return a.location.end > b.location.end;
             });
 

--- a/src/DocumentationParser.cpp
+++ b/src/DocumentationParser.cpp
@@ -150,6 +150,7 @@ std::string printMoonwaveDocumentation(const std::vector<std::string>& comments)
         return "";
 
     std::string result;
+    std::vector<std::string> fields{};
     std::vector<std::string> params{};
     std::vector<std::string> returns{};
     std::vector<std::string> throws{};
@@ -162,17 +163,72 @@ std::string printMoonwaveDocumentation(const std::vector<std::string>& comments)
             returns.emplace_back(comment);
         else if (Luau::startsWith(comment, "@error "))
             throws.emplace_back(comment);
-        else if (comment == "@yields" || comment == "@unreleased" || comment == "@server" || comment == "@client" || comment == "@plugin" ||
-                 comment == "@private" || comment == "@ignore" || comment == "@readonly")
-            // Boldify
-            result += "**" + comment + "**\n";
+        else if (Luau::startsWith(comment, "@field "))
+            fields.emplace_back(comment);
+        else if (comment == "@private")
+            result += "**Private**\n";
+        else if (comment == "@yields")
+            result += "**Yields**\n";
+        else if (comment == "@unreleased")
+            result += "**Unreleased**\n";
+        else if (comment == "@server")
+            result += "**Server**\n";
+        else if (comment == "@client")
+            result += "**Client**\n";
+        else if (comment == "@plugin")
+            result += "**Plugin**\n";
+        else if (comment == "@readonly")
+            result += "**Read Only**\n";
         else if (Luau::startsWith(comment, "@deprecated "))
-            result = "**Deprecated** " + comment.substr(12) + "\n\n" + result;
-        else if (Luau::startsWith(comment, "@tag ") || Luau::startsWith(comment, "@within "))
+        {
+            result += "**Deprecated** ";
+
+            auto description = comment.substr(12);
+            auto version = description;
+
+            if (auto space = description.find(' '); space != std::string::npos)
+            {
+                version = description.substr(0, space);
+                description = description.substr(space);
+            }
+
+            if (version == description)
+                result += "`" + version + "`" + "\n";
+            else
+                result += "`" + version + "`" + description + "\n";
+        }
+        else if (Luau::startsWith(comment, "@since "))
+            result += "**Since** `" + comment.substr(7) + "`\n";
+        else if (comment == "@ignore" || Luau::startsWith(comment, "@tag ") || Luau::startsWith(comment, "@within ") ||
+                 Luau::startsWith(comment, "@class ") || Luau::startsWith(comment, "@function ") || Luau::startsWith(comment, "@method ") ||
+                 Luau::startsWith(comment, "@prop ") || Luau::startsWith(comment, "@interface ") || Luau::startsWith(comment, "@type ") ||
+                 Luau::startsWith(comment, "@__index ") || Luau::startsWith(comment, "@external "))
             // Ignore
             continue;
         else
             result += comment + "\n";
+    }
+
+    if (!fields.empty())
+    {
+        result += "\n\n**Fields**\n";
+        for (auto& field : fields)
+        {
+            auto fieldText = field.substr(7);
+
+            // Parse name
+            auto fieldName = fieldText;
+            if (auto space = fieldText.find(' '); space != std::string::npos)
+            {
+                fieldName = fieldText.substr(0, space);
+                fieldText = fieldText.substr(space);
+            }
+
+            if (fieldText == fieldName)
+                result += "\n- `" + fieldName + "`";
+            else
+                result += "\n- `" + fieldName + "`" + fieldText;
+        }
     }
 
     if (!params.empty())

--- a/src/DocumentationParser.cpp
+++ b/src/DocumentationParser.cpp
@@ -162,7 +162,16 @@ std::string printMoonwaveDocumentation(const std::vector<std::string>& comments)
             returns.emplace_back(comment);
         else if (Luau::startsWith(comment, "@error "))
             throws.emplace_back(comment);
-        else if (comment == "@yields" || comment == "@unreleased")
+        else if (
+            comment == "@yields"
+            || comment == "@unreleased"
+            || comment == "@server"
+            || comment == "@client"
+            || comment == "@plugin"
+            || comment == "@private"
+            || comment == "@ignore"
+            || comment == "@readonly"
+        )
             // Boldify
             result += "**" + comment + "**\n";
         else if (Luau::startsWith(comment, "@tag ") || Luau::startsWith(comment, "@within "))

--- a/src/operations/Completion.cpp
+++ b/src/operations/Completion.cpp
@@ -309,7 +309,7 @@ static bool deprecated(const Luau::AutocompleteEntry& entry, std::optional<lsp::
     }
 
     if (documentation)
-        if (documentation->value.find("@deprecated") != std::string::npos)
+        if (documentation->value.find("@deprecated") != std::string::npos || documentation->value.find("**Deprecated**") != std::string::npos)
             return true;
 
     return false;

--- a/tests/Autocomplete.test.cpp
+++ b/tests/Autocomplete.test.cpp
@@ -335,7 +335,7 @@ TEST_CASE_FIXTURE(Fixture, "imported_type_reference_has_documentation")
 TEST_CASE_FIXTURE(Fixture, "deprecated_marker_in_documentation_comment_applies_to_autocomplete_entry")
 {
     auto [source, marker] = sourceWithMarker(R"(
-        --- @deprecated Use `bar` instead
+        --- @deprecated v1.0.0 -- Use `bar` instead
         local function foo()
         end
 


### PR DESCRIPTION
Add more Moonwave documentation support to the tooltips. This relates to Issue #1552.

**Readable flag tags.** Previously, `@yields` and `@unreleased` were the only tags parsed for bolding, and they rendered as the raw tag name (e.g. **@yields**). Flag tags now render as readable labels instead, and I added parsing for several more. Like `@yields` and `@unreleased`, these inform the user of the intended usage context of the associated item:

- `@server` → **Server**
- `@client` → **Client**
- `@plugin` → **Plugin**
- `@private` → **Private**
- `@readonly` → **Read Only**

**`@deprecated` support.** The tag is parsed into its version and description rather than printed as plain comment text:

```
--[=[
  @function oldAdd
  Adds two numbers together.

  @param a number
  @param b number -- Number to be added to `a`.

  @return number -- Sum of `a` and `b`.

  @since v1.0.0
  @deprecated v1.2.0 -- Use `newAdd` instead.
]=]
```

The body of the tooltip now renders as:

> Adds two numbers together.
>
> **Parameters**
> - `a` number
> - `b` number -- Number to be added to `a`.
>
> **Returns**
> - `number` -- Sum of `a` and `b`.
>
> **Since** `v1.0.0`
> **Deprecated** `v1.2.0` -- Use `newAdd` instead.

**`@since` support.** As shown above, `@since` renders as a bolded **Since** notice with the version in an inline code span.

**`@field` support.** `@field` entries are collected into a **Fields** list, mirroring the existing `@param` handling — useful for `@interface` doc comments.

**Ignored declaration and metadata tags.** Tags that only carry meaning for the documentation site generator (`@class`, `@function`, `@method`, `@prop`, `@interface`, `@type`, `@__index`, `@external`, `@tag`, `@within`, `@ignore`) are no longer printed as raw text in the tooltip.

Closes #1552.