### PR TITLE
Add configuration option to ignore `.lua` files

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -231,6 +231,12 @@
           ],
           "scope": "resource"
         },
+        "luau-lsp.analyzeLuaFiles": {
+          "markdownDescription": "Whether to analyze standard `.lua` files. If disabled, only `.luau` files will be analyzed. Note: You may also need to configure `\"files.associations\": {\"*.lua\": \"lua\"}` in your settings to restore standard Lua syntax highlighting and behavior for `.lua` files.",
+          "type": "boolean",
+          "default": true,
+          "scope": "window"
+        },
         "luau-lsp.platform.type": {
           "markdownDescription": "Platform-specific support features",
           "type": "string",

--- a/editors/code/src/extension.ts
+++ b/editors/code/src/extension.ts
@@ -501,12 +501,19 @@ const startLanguageServer = async (context: vscode.ExtensionContext) => {
   const serverOptions: ServerOptions = { run, debug };
 
   const clientOptions: LanguageClientOptions = {
-    documentSelector: [
-      { language: "lua", scheme: "file" },
-      { language: "luau", scheme: "file" },
-      { language: "lua", scheme: "untitled" },
-      { language: "luau", scheme: "untitled" },
-    ],
+    documentSelector: vscode.workspace
+      .getConfiguration("luau-lsp")
+      .get<boolean>("analyzeLuaFiles", true)
+      ? [
+          { language: "luau", scheme: "file" },
+          { language: "luau", scheme: "untitled" },
+          { language: "lua", scheme: "file" },
+          { language: "lua", scheme: "untitled" },
+        ]
+      : [
+          { language: "luau", scheme: "file" },
+          { language: "luau", scheme: "untitled" },
+        ],
     diagnosticPullOptions: {
       onChange: vscode.workspace
         .getConfiguration("luau-lsp.diagnostics")
@@ -639,7 +646,8 @@ export async function activate(context: vscode.ExtensionContext) {
           });
       } else if (
         e.affectsConfiguration("luau-lsp.types") ||
-        e.affectsConfiguration("luau-lsp.platform.type")
+        e.affectsConfiguration("luau-lsp.platform.type") ||
+        e.affectsConfiguration("luau-lsp.analyzeLuaFiles")
       ) {
         vscode.window
           .showInformationMessage(

--- a/editors/code/src/roblox.ts
+++ b/editors/code/src/roblox.ts
@@ -33,6 +33,13 @@ const getStudioPluginValue = <T>(key: string, defaultValue: T): T => {
   );
 };
 
+const getFilePattern = (): string => {
+  const analyzeLua = vscode.workspace
+    .getConfiguration("luau-lsp")
+    .get<boolean>("analyzeLuaFiles", true);
+  return analyzeLua ? "**/*.{lua,luau}" : "**/*.luau";
+};
+
 const API_DOCS = "https://luau-lsp.pages.dev/api-docs/en-us.json";
 const LUAU_API_DOCS = "https://luau-lsp.pages.dev/api-docs/luau-en-us.json";
 const STUDIO_PLUGIN_URL =
@@ -326,7 +333,7 @@ const startSourcemapGeneration = async (
     spawnChildProcess();
 
     const watcher = vscode.workspace.createFileSystemWatcher(
-      new vscode.RelativePattern(workspaceFolder, "**/*.{lua,luau}"),
+      new vscode.RelativePattern(workspaceFolder, getFilePattern()),
       /* ignoreCreateEvents = */ false,
       /* ignoreChangeEvents = */ true,
       /* ignoreDeleteEvents = */ false,
@@ -417,7 +424,7 @@ const startPluginServer = async (client: LanguageClient | undefined) => {
 
   app.get("/get-file-paths", async (_req, res) => {
     try {
-      const uris = await vscode.workspace.findFiles("**/*.{lua,luau}");
+      const uris = await vscode.workspace.findFiles(getFilePattern());
       res.json({
         files: uris.map((uri: vscode.Uri) => uri.fsPath),
       });
@@ -518,7 +525,10 @@ export const onActivate = async (
 
   context.subscriptions.push(
     vscode.workspace.onDidChangeConfiguration((e) => {
-      if (e.affectsConfiguration("luau-lsp.sourcemap")) {
+      if (
+        e.affectsConfiguration("luau-lsp.sourcemap") ||
+        e.affectsConfiguration("luau-lsp.analyzeLuaFiles")
+      ) {
         if (vscode.workspace.workspaceFolders) {
           for (const folder of vscode.workspace.workspaceFolders) {
             const config = vscode.workspace.getConfiguration(
@@ -538,7 +548,8 @@ export const onActivate = async (
         }
       } else if (
         e.affectsConfiguration("luau-lsp.studioPlugin") ||
-        e.affectsConfiguration("luau-lsp.plugin")
+        e.affectsConfiguration("luau-lsp.plugin") ||
+        e.affectsConfiguration("luau-lsp.analyzeLuaFiles")
       ) {
         if (getStudioPluginValue("enabled", false)) {
           stopPluginServer(true);


### PR DESCRIPTION
This PR addresses issue #1429.

Use-case: Standalone Lua development outside of Roblox. Although older Rojo setups generate `.lua` files that require luau-lsp processing, this is legacy behavior. Because the `.luau` extension is now the standard for Luau, its tooling should hopefully remain separate from standalone Lua environments.

* Added `"luau-lsp.analyzeLuaFiles"` boolean setting to enable/disable analysis of `.lua` files in addition to `.luau` files. The setting includes documentation and a default value of `true`.
* Updated `extension.ts` to respect the new `analyzeLuaFiles` setting, so the language server only attaches to `.lua` files if enabled.