### PR TITLE
Add UTF-8 validation for instance names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-- Sync to upstream Luau 0.726
+- Sync to upstream Luau 0.729
+
+### Fixed
+
+- Fixed a crash in the Studio Plugin JSON encoder when an Instance name contained malformed UTF-8. Such instances are now skipped (with a warning logged) instead of corrupting the encoded output ([#1559](https://github.com/JohnnyMorganz/luau-lsp/pull/1559))
+- Fixed use-after-free crashes after a sourcemap update. Studio Plugin updates left stale entries in the virtual/real path maps and stale cached DataModel types on pruned source nodes, allowing later type checks to reference destroyed sourcemap types. Additionally, incremental (fragment) autocomplete could read the stale type graph of a not-yet-rechecked module which referenced destroyed sourcemap types ([#1331](https://github.com/JohnnyMorganz/luau-lsp/issues/1331))
 
 ## [1.68.1] - 2026-06-14
 

--- a/plugin/src/InstanceTracker.luau
+++ b/plugin/src/InstanceTracker.luau
@@ -170,10 +170,6 @@ function InstanceTracker.encode(
 ): types.EncodedInstance
 	Log.debug(`Encoding {instance:GetFullName()}`)
 
-	if not isValidUTF8(instance.Name) then
-		Log.warn(`Cannot encode instance "{instance:GetFullName()}" because its name contains invalid UTF-8.`)
-	end
-
 	local encoded: types.EncodedInstance = {
 		Name = instance.Name,
 		ClassName = instance.ClassName,
@@ -183,6 +179,11 @@ function InstanceTracker.encode(
 
 	for _, child in instance:GetChildren() do
 		if not self:shouldInclude(child, includeList) then
+			continue
+		end
+
+		if not isValidUTF8(instance.Name) then
+			Log.warn(`Cannot encode instance "{instance:GetFullName()}" because its name contains invalid UTF-8.`)
 			continue
 		end
 

--- a/plugin/src/InstanceTracker.luau
+++ b/plugin/src/InstanceTracker.luau
@@ -148,6 +148,29 @@ function InstanceTracker.shouldInclude(self: InstanceTracker, instance: Instance
 	return false
 end
 
+--- Checks if the string ends with a corrupted, malformed, or truncated UTF-8
+--- replacement character sequence (bytes 239, 191, 189)
+--- @param self -- The InstanceTracker instance.
+--- @param name -- The name of the instance.
+--- @return boolean -- True if the instance name contains trailing corruption bytes.
+function InstanceTracker.hasTrailingCorruptedBytes(self: InstanceTracker, name: string): boolean
+	local replacementChar = string.char(239, 191, 189)
+
+	if string.find(name, replacementChar .. "$") then
+		return true
+	end
+
+	if string.find(name, string.char(239) .. "$") then
+		return true
+	end
+
+	if string.find(name, string.char(239, 191) .. "$") then
+		return true
+	end
+
+	return false
+end
+
 --- Recursively encodes an Instance and its children into a serializable table.
 --- Only includes children that pass the `shouldInclude` filter.
 --- @param self -- The InstanceTracker instance.
@@ -162,6 +185,10 @@ function InstanceTracker.encode(
 	instanceFilePaths: { [Instance]: { string } }
 ): types.EncodedInstance
 	Log.debug(`Encoding {instance:GetFullName()}`)
+
+	if self:hasTrailingCorruptedBytes(instance.Name) then
+		Log.error(`Instance name ends with a truncated or incomplete UTF-8 byte sequence: "{instance.Name}"`)
+	end
 
 	local encoded: types.EncodedInstance = {
 		Name = instance.Name,

--- a/plugin/src/InstanceTracker.luau
+++ b/plugin/src/InstanceTracker.luau
@@ -148,27 +148,11 @@ function InstanceTracker.shouldInclude(self: InstanceTracker, instance: Instance
 	return false
 end
 
---- Checks if the string ends with a corrupted, malformed, or truncated UTF-8
---- replacement character sequence (bytes 239, 191, 189)
---- @param self -- The InstanceTracker instance.
---- @param name -- The name of the instance.
---- @return boolean -- True if the instance name contains trailing corruption bytes.
-function InstanceTracker.hasTrailingCorruptedBytes(self: InstanceTracker, name: string): boolean
-	local replacementChar = string.char(239, 191, 189)
-
-	if string.find(name, replacementChar .. "$") then
-		return true
-	end
-
-	if string.find(name, string.char(239) .. "$") then
-		return true
-	end
-
-	if string.find(name, string.char(239, 191) .. "$") then
-		return true
-	end
-
-	return false
+--- Verifies strings are valid UTF8
+--- @param str -- The input string.
+--- @return boolean -- Returns if its valid UTF8 or not.
+local function isValidUTF8(str: string): boolean
+	return utf8.len(str) ~= nil
 end
 
 --- Recursively encodes an Instance and its children into a serializable table.
@@ -186,8 +170,8 @@ function InstanceTracker.encode(
 ): types.EncodedInstance
 	Log.debug(`Encoding {instance:GetFullName()}`)
 
-	if self:hasTrailingCorruptedBytes(instance.Name) then
-		Log.error(`Instance name ends with a truncated or incomplete UTF-8 byte sequence: "{instance.Name}"`)
+	if not isValidUTF8(instance.Name) then
+		Log.warn(`Cannot encode instance "{instance:GetFullName()}" because its name contains invalid UTF-8.`)
 	end
 
 	local encoded: types.EncodedInstance = {


### PR DESCRIPTION
# Problem
While developing with Luau-lsp, I ran into a confusing error where Luau-lsp could not convert the tree table into valid JSON, and threw a vague `Can't convert to JSON` error.

The root cause of this problem was incredibly obscure. One of the instances that Luau-lsp was trying to parse had a decorative Unicode character in its name that had been truncated mid-character by some sort of external tool, leaving an incomplete, corrupted UTF-8 byte sequence at the very end of the instance's name. Because Luau-lsp relies on JSON-RPC to communicate with Roblox Studio, this malformed trailing byte caused the entire serialization process to crash with zero context as to which instance was actually breaking it.

# Solution
To save anyone else who has this issue from hours of debugging a confusing JSON error, this PR introduces a clear error message to help developers quickly resolve this issue:
* Added instance name truncation detection - Created the function, `InstanceTracker.hasTrailingCorruptedBytes()` to check all instance names for incomplete byte sequences.
* Added a condition inside `InstanceTracker.encode()` to verify the instance name does not have corrupted bytes. If it does, an error log will be sent to the developer's console including the exact instance that is failing.