### PR TITLE
Fix use-after-free crashes after sourcemap updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Sync to upstream Luau 0.728
 
+### Fixed
+
+- Fixed use-after-free crashes after a sourcemap update. Studio Plugin updates left stale entries in the virtual/real path maps and stale cached DataModel types on pruned source nodes, allowing later type checks to reference destroyed sourcemap types. Additionally, incremental (fragment) autocomplete could read the stale type graph of a not-yet-rechecked module which referenced destroyed sourcemap types ([#1331](https://github.com/JohnnyMorganz/luau-lsp/issues/1331))
+
 ## [1.68.1] - 2026-06-14
 
 ### Changed

--- a/src/include/Platform/RobloxPlatform.hpp
+++ b/src/include/Platform/RobloxPlatform.hpp
@@ -99,6 +99,12 @@ private:
 
     void clearSourcemapTypes();
 
+    /// Clears `realPathsToSourceNodes`/`virtualPathsToSourceNodes` and repopulates them by walking
+    /// `rootSourceNode`. Must be used (rather than calling `writePathsToMap` directly) whenever the
+    /// tree may have been pruned, since `writePathsToMap` only overwrites entries for nodes still in
+    /// the tree and would otherwise leave stale entries pointing at pruned/freed nodes.
+    void rebuildPathMaps();
+
 public:
     // The root source node from a parsed Rojo source map
     SourceNode* rootSourceNode = nullptr;

--- a/src/include/Platform/RobloxPlatform.hpp
+++ b/src/include/Platform/RobloxPlatform.hpp
@@ -58,6 +58,10 @@ struct SourceNode
     /// Walk a slash-delimited path (supporting `.`, `..`, and `./` prefixes) from this node.
     /// Returns nullptr if any segment fails to resolve.
     const SourceNode* walkPath(const std::string& path) const;
+    /// Recursively clear the cached sourcemap-generated types (`tys`) for this node and its descendants.
+    /// Must be called whenever the types the cache points into are about to be destroyed, including on
+    /// nodes detached from the tree (which `RobloxPlatform::clearSourcemapTypes` cannot reach)
+    void clearCachedTypes() const;
 
     bool containsFilePaths() const;
     ordered_json toJson() const;

--- a/src/platform/roblox/RobloxSourceNode.cpp
+++ b/src/platform/roblox/RobloxSourceNode.cpp
@@ -158,6 +158,13 @@ const SourceNode* SourceNode::walkPath(const std::string& path) const
     return base;
 }
 
+void SourceNode::clearCachedTypes() const
+{
+    tys.clear();
+    for (const auto& child : children)
+        child->clearCachedTypes();
+}
+
 SourceNode* SourceNode::fromJson(const json& j, Luau::TypedAllocator<SourceNode>& allocator)
 {
     auto name = j.at("name").get<std::string>();

--- a/src/platform/roblox/RobloxSourcemap.cpp
+++ b/src/platform/roblox/RobloxSourcemap.cpp
@@ -508,6 +508,14 @@ void RobloxPlatform::writePathsToMap(SourceNode* node, const std::string& base, 
     }
 }
 
+void RobloxPlatform::rebuildPathMaps()
+{
+    realPathsToSourceNodes.clear();
+    virtualPathsToSourceNodes.clear();
+    if (rootSourceNode)
+        writePathsToMap(rootSourceNode, rootSourceNode->className == "DataModel" ? "game" : "ProjectRoot");
+}
+
 void RobloxPlatform::updateSourceNodeMap(const std::string& sourceMapContents)
 {
     LUAU_TIMETRACE_SCOPE("RobloxPlatform::updateSourceNodeMap", "LSP");
@@ -534,8 +542,7 @@ void RobloxPlatform::updateSourceNodeMap(const std::string& sourceMapContents)
     hydrateSourcemapWithPluginInfo();
 
     // Write paths
-    std::string base = rootSourceNode->className == "DataModel" ? "game" : "ProjectRoot";
-    writePathsToMap(rootSourceNode, base);
+    rebuildPathMaps();
 }
 
 // TODO: expressiveTypes is used because of a Luau issue where we can't cast a most specific Instance type (which we create here)

--- a/src/platform/roblox/RobloxSourcemap.cpp
+++ b/src/platform/roblox/RobloxSourcemap.cpp
@@ -374,24 +374,27 @@ static void clearSourcemapGeneratedTypes(Luau::GlobalTypes& globals)
     }
 }
 
-static void clearTypesFromSourcemapNodes(SourceNode* node)
-{
-    node->tys.clear();
-    for (const auto& child : node->children)
-        clearTypesFromSourcemapNodes(child);
-}
-
 void RobloxPlatform::clearSourcemapTypes()
 {
     LUAU_TIMETRACE_SCOPE("RobloxPlatform::clearSourcemapTypes", "LSP");
-    for (const auto& [name, _] : workspaceFolder->frontend.sourceNodes)
+    for (const auto& [name, sourceNode] : workspaceFolder->frontend.sourceNodes)
+    {
         workspaceFolder->frontend.markDirty(name);
+
+        // Marking the module dirty is not enough: the retained type graph of an already-checked
+        // module may reference the sourcemap-generated types (in instanceTypes) that we are about
+        // to free, and fragment autocomplete deliberately reads the stale type graph of a dirty
+        // module. Flag the module as having invalid dependencies so its stale type graph is not
+        // used until it has been rechecked (Frontend::recordItemResult resets the flag)
+        sourceNode->setInvalidModuleDependency(true, /* forAutocomplete= */ false);
+        sourceNode->setInvalidModuleDependency(true, /* forAutocomplete= */ true);
+    }
     instanceTypes.clear();             // NOTE: used across BOTH instances of handleSourcemapUpdate, don't clear in between!
     clearSourcemapGeneratedTypes(workspaceFolder->frontend.globals);
     if (!FFlag::LuauSolverV2)
         clearSourcemapGeneratedTypes(workspaceFolder->frontend.globalsForAutocomplete);
     if (rootSourceNode)
-        clearTypesFromSourcemapNodes(rootSourceNode);
+        rootSourceNode->clearCachedTypes();
 }
 
 bool RobloxPlatform::updateSourceMapFromContents(const std::string& sourceMapContents)

--- a/src/platform/roblox/RobloxStudioPlugin.cpp
+++ b/src/platform/roblox/RobloxStudioPlugin.cpp
@@ -170,9 +170,7 @@ void RobloxPlatform::onStudioPluginFullChange(const json& dataModel)
     // Rebuild the path maps from scratch: hydration may have pruned nodes, and writePathsToMap
     // only overwrites entries for nodes still in the tree. A stale entry pointing at a pruned
     // node would let later type checks reach its (freed) cached sourcemap types
-    realPathsToSourceNodes.clear();
-    virtualPathsToSourceNodes.clear();
-    writePathsToMap(rootSourceNode, rootSourceNode->className == "DataModel" ? "game" : "ProjectRoot");
+    rebuildPathMaps();
     updateSourcemapTypes();
 }
 
@@ -187,9 +185,7 @@ void RobloxPlatform::onStudioPluginClear()
     if (rootSourceNode)
     {
         clearPluginManagedNodesFromSourcemap(rootSourceNode);
-        realPathsToSourceNodes.clear();
-        virtualPathsToSourceNodes.clear();
-        writePathsToMap(rootSourceNode, rootSourceNode->className == "DataModel" ? "game" : "ProjectRoot");
+        rebuildPathMaps();
         updateSourcemapTypes();
     }
 }

--- a/src/platform/roblox/RobloxStudioPlugin.cpp
+++ b/src/platform/roblox/RobloxStudioPlugin.cpp
@@ -51,6 +51,10 @@ static bool mutateSourceNodeWithPluginInfo(SourceNode* sourceNode, const PluginN
 
         if (child->pluginManaged && pluginChildNames.find(child->name) == pluginChildNames.end())
         {
+            // The pruned subtree stays allocated but becomes unreachable from the root, so
+            // clearSourcemapTypes can no longer clear its cached types. Clear them now so a
+            // retained reference to the node cannot resurrect types from a destroyed arena
+            child->clearCachedTypes();
             it = sourceNode->children.erase(it);
             didUpdateSourcemap = true;
         }
@@ -96,6 +100,7 @@ void RobloxPlatform::clearPluginManagedNodesFromSourcemap(SourceNode* sourceNode
 
         if (child->pluginManaged)
         {
+            child->clearCachedTypes();
             it = sourceNode->children.erase(it);
         }
         else
@@ -161,6 +166,12 @@ void RobloxPlatform::onStudioPluginFullChange(const json& dataModel)
     setPluginInfo(PluginNode::fromJson(dataModel, pluginNodeAllocator));
 
     hydrateSourcemapWithPluginInfo();
+
+    // Rebuild the path maps from scratch: hydration may have pruned nodes, and writePathsToMap
+    // only overwrites entries for nodes still in the tree. A stale entry pointing at a pruned
+    // node would let later type checks reach its (freed) cached sourcemap types
+    realPathsToSourceNodes.clear();
+    virtualPathsToSourceNodes.clear();
     writePathsToMap(rootSourceNode, rootSourceNode->className == "DataModel" ? "game" : "ProjectRoot");
     updateSourcemapTypes();
 }
@@ -176,6 +187,8 @@ void RobloxPlatform::onStudioPluginClear()
     if (rootSourceNode)
     {
         clearPluginManagedNodesFromSourcemap(rootSourceNode);
+        realPathsToSourceNodes.clear();
+        virtualPathsToSourceNodes.clear();
         writePathsToMap(rootSourceNode, rootSourceNode->className == "DataModel" ? "game" : "ProjectRoot");
         updateSourcemapTypes();
     }

--- a/tests/Autocomplete.test.cpp
+++ b/tests/Autocomplete.test.cpp
@@ -62,67 +62,6 @@ struct FragmentAutocompleteFixture : Fixture
 
 TEST_SUITE_BEGIN("Autocomplete");
 
-// Use-after-free regression test: a sourcemap update destroys the sourcemap-generated types
-// that the retained type graph of an already-checked module references. Fragment autocomplete
-// reads the stale type graph of a dirty module, so it must be skipped until the module is
-// rechecked (without this, the completion below crashes under ASAN)
-TEST_CASE_FIXTURE(FragmentAutocompleteFixture, "fragment_autocomplete_is_not_used_after_sourcemap_update_destroys_types")
-{
-    // Enable pull-based diagnostics so the sourcemap update does not synchronously recheck
-    client->capabilities.textDocument = lsp::TextDocumentClientCapabilities{};
-    client->capabilities.textDocument->diagnostic = lsp::DiagnosticClientCapabilities{};
-
-    loadSourcemap(R"(
-        {
-            "name": "game",
-            "className": "DataModel",
-            "children": [
-                { "name": "Script", "className": "ModuleScript", "filePaths": ["foo.luau"] }
-            ]
-        }
-    )");
-
-    auto oldSource = R"(
-        local p = script.Parent
-    )";
-    auto [newSource, marker] = sourceWithMarker(R"(
-        local p = script.Parent
-        local x = p|
-    )");
-
-    auto uri = newDocument("foo.luau", oldSource);
-    auto moduleName = workspace.fileResolver.getModuleName(uri);
-    bool forAutocomplete = !FFlag::LuauSolverV2;
-
-    // Initial check with retained type graphs: `p` references a sourcemap-generated type
-    workspace.checkStrict(moduleName, /* cancellationToken= */ nullptr, forAutocomplete);
-    REQUIRE(workspace.frontend.allModuleDependenciesValid(moduleName, forAutocomplete));
-
-    // Reloading the sourcemap destroys the sourcemap-generated types
-    loadSourcemap(R"(
-        {
-            "name": "game",
-            "className": "DataModel",
-            "children": [
-                { "name": "Script", "className": "ModuleScript", "filePaths": ["foo.luau"] },
-                { "name": "Folder", "className": "Folder" }
-            ]
-        }
-    )");
-
-    REQUIRE(workspace.frontend.isDirty(moduleName, forAutocomplete));
-    CHECK_FALSE(workspace.frontend.allModuleDependenciesValid(moduleName, forAutocomplete));
-
-    updateDocument(uri, newSource);
-
-    lsp::CompletionParams params;
-    params.textDocument = lsp::TextDocumentIdentifier{uri};
-    params.position = marker;
-
-    auto results = workspace.completion(params, /* cancellationToken= */ nullptr);
-    CHECK(!results.empty());
-}
-
 TEST_CASE_FIXTURE(Fixture, "function_autocomplete_has_documentation")
 {
     auto [source, marker] = sourceWithMarker(R"(
@@ -2589,6 +2528,67 @@ TEST_CASE_FIXTURE(Fixture, "anonymous_autofilled_function_snippet_no_param_tabst
     REQUIRE(item.insertText);
     CHECK_EQ(item.insertTextFormat, lsp::InsertTextFormat::Snippet);
     CHECK_EQ(*item.insertText, "function(x: number, y: string)\n\t$0\nend");
+}
+
+// Use-after-free regression test: a sourcemap update destroys the sourcemap-generated types
+// that the retained type graph of an already-checked module references. Fragment autocomplete
+// reads the stale type graph of a dirty module, so it must be skipped until the module is
+// rechecked (without this, the completion below crashes under ASAN)
+TEST_CASE_FIXTURE(FragmentAutocompleteFixture, "fragment_autocomplete_is_not_used_after_sourcemap_update_destroys_types")
+{
+    // Enable pull-based diagnostics so the sourcemap update does not synchronously recheck
+    client->capabilities.textDocument = lsp::TextDocumentClientCapabilities{};
+    client->capabilities.textDocument->diagnostic = lsp::DiagnosticClientCapabilities{};
+
+    loadSourcemap(R"(
+        {
+            "name": "game",
+            "className": "DataModel",
+            "children": [
+                { "name": "Script", "className": "ModuleScript", "filePaths": ["foo.luau"] }
+            ]
+        }
+    )");
+
+    auto oldSource = R"(
+        local p = script.Parent
+    )";
+    auto [newSource, marker] = sourceWithMarker(R"(
+        local p = script.Parent
+        local x = p|
+    )");
+
+    auto uri = newDocument("foo.luau", oldSource);
+    auto moduleName = workspace.fileResolver.getModuleName(uri);
+    bool forAutocomplete = !FFlag::LuauSolverV2;
+
+    // Initial check with retained type graphs: `p` references a sourcemap-generated type
+    workspace.checkStrict(moduleName, /* cancellationToken= */ nullptr, forAutocomplete);
+    REQUIRE(workspace.frontend.allModuleDependenciesValid(moduleName, forAutocomplete));
+
+    // Reloading the sourcemap destroys the sourcemap-generated types
+    loadSourcemap(R"(
+        {
+            "name": "game",
+            "className": "DataModel",
+            "children": [
+                { "name": "Script", "className": "ModuleScript", "filePaths": ["foo.luau"] },
+                { "name": "Folder", "className": "Folder" }
+            ]
+        }
+    )");
+
+    REQUIRE(workspace.frontend.isDirty(moduleName, forAutocomplete));
+    CHECK_FALSE(workspace.frontend.allModuleDependenciesValid(moduleName, forAutocomplete));
+
+    updateDocument(uri, newSource);
+
+    lsp::CompletionParams params;
+    params.textDocument = lsp::TextDocumentIdentifier{uri};
+    params.position = marker;
+
+    auto results = workspace.completion(params, /* cancellationToken= */ nullptr);
+    CHECK(!results.empty());
 }
 
 TEST_SUITE_END();

--- a/tests/Autocomplete.test.cpp
+++ b/tests/Autocomplete.test.cpp
@@ -62,6 +62,67 @@ struct FragmentAutocompleteFixture : Fixture
 
 TEST_SUITE_BEGIN("Autocomplete");
 
+// Use-after-free regression test: a sourcemap update destroys the sourcemap-generated types
+// that the retained type graph of an already-checked module references. Fragment autocomplete
+// reads the stale type graph of a dirty module, so it must be skipped until the module is
+// rechecked (without this, the completion below crashes under ASAN)
+TEST_CASE_FIXTURE(FragmentAutocompleteFixture, "fragment_autocomplete_is_not_used_after_sourcemap_update_destroys_types")
+{
+    // Enable pull-based diagnostics so the sourcemap update does not synchronously recheck
+    client->capabilities.textDocument = lsp::TextDocumentClientCapabilities{};
+    client->capabilities.textDocument->diagnostic = lsp::DiagnosticClientCapabilities{};
+
+    loadSourcemap(R"(
+        {
+            "name": "game",
+            "className": "DataModel",
+            "children": [
+                { "name": "Script", "className": "ModuleScript", "filePaths": ["foo.luau"] }
+            ]
+        }
+    )");
+
+    auto oldSource = R"(
+        local p = script.Parent
+    )";
+    auto [newSource, marker] = sourceWithMarker(R"(
+        local p = script.Parent
+        local x = p|
+    )");
+
+    auto uri = newDocument("foo.luau", oldSource);
+    auto moduleName = workspace.fileResolver.getModuleName(uri);
+    bool forAutocomplete = !FFlag::LuauSolverV2;
+
+    // Initial check with retained type graphs: `p` references a sourcemap-generated type
+    workspace.checkStrict(moduleName, /* cancellationToken= */ nullptr, forAutocomplete);
+    REQUIRE(workspace.frontend.allModuleDependenciesValid(moduleName, forAutocomplete));
+
+    // Reloading the sourcemap destroys the sourcemap-generated types
+    loadSourcemap(R"(
+        {
+            "name": "game",
+            "className": "DataModel",
+            "children": [
+                { "name": "Script", "className": "ModuleScript", "filePaths": ["foo.luau"] },
+                { "name": "Folder", "className": "Folder" }
+            ]
+        }
+    )");
+
+    REQUIRE(workspace.frontend.isDirty(moduleName, forAutocomplete));
+    CHECK_FALSE(workspace.frontend.allModuleDependenciesValid(moduleName, forAutocomplete));
+
+    updateDocument(uri, newSource);
+
+    lsp::CompletionParams params;
+    params.textDocument = lsp::TextDocumentIdentifier{uri};
+    params.position = marker;
+
+    auto results = workspace.completion(params, /* cancellationToken= */ nullptr);
+    CHECK(!results.empty());
+}
+
 TEST_CASE_FIXTURE(Fixture, "function_autocomplete_has_documentation")
 {
     auto [source, marker] = sourceWithMarker(R"(

--- a/tests/Sourcemap.test.cpp
+++ b/tests/Sourcemap.test.cpp
@@ -1432,6 +1432,58 @@ TEST_CASE_FIXTURE(Fixture, "plugin_clear_clears_cached_types_on_pruned_nodes")
     CHECK_FALSE(platform->resolveToVirtualPath(childBUri));
 }
 
+// Use-after-free regression test: without proper cleanup on prune, the pruned node remains
+// reachable through stale path map entries and its cached types point into the destroyed
+// instanceTypes arena, so a later check binds `script` to a freed type (crashes under ASAN)
+TEST_CASE_FIXTURE(Fixture, "plugin_prune_does_not_leave_dangling_types_reachable_by_later_checks")
+{
+    client->globalConfig.diagnostics.strictDatamodelTypes = true;
+
+    auto platform = dynamic_cast<RobloxPlatform*>(workspace.platform.get());
+
+    auto pluginData1 = json::parse(R"(
+        {
+            "Name": "game",
+            "ClassName": "DataModel",
+            "Children": [
+                {
+                    "Name": "Folder",
+                    "ClassName": "Folder",
+                    "Children": [
+                        { "Name": "Script", "ClassName": "ModuleScript", "FilePaths": ["script.luau"] }
+                    ]
+                }
+            ]
+        }
+    )");
+    platform->onStudioPluginFullChange(pluginData1);
+
+    // Check a document backed by the plugin-provided node: `script` is bound to a
+    // sourcemap-generated type, which gets cached on the source node
+    auto uri = newDocument("script.luau", R"(
+        local p = script.Parent
+        return {}
+    )");
+    workspace.frontend.check(workspace.fileResolver.getModuleName(uri));
+
+    // Prune the subtree. This destroys and rebuilds the instanceTypes arena, and internally
+    // triggers a recheck of the (dirty) managed document via recomputeDiagnostics
+    auto pluginData2 = json::parse(R"(
+        {
+            "Name": "game",
+            "ClassName": "DataModel",
+            "Children": []
+        }
+    )");
+    platform->onStudioPluginFullChange(pluginData2);
+
+    // A later fresh check must also not be able to reach the pruned node
+    auto moduleName = workspace.fileResolver.getModuleName(uri);
+    workspace.frontend.markDirty(moduleName);
+    workspace.frontend.check(moduleName);
+    CHECK(workspace.frontend.getSourceModule(moduleName));
+}
+
 TEST_CASE_FIXTURE(Fixture, "sourcemap_update_invalidates_stale_module_type_graphs")
 {
     // Use an unmanaged on-disk file: recomputeDiagnostics (triggered by the sourcemap update

--- a/tests/Sourcemap.test.cpp
+++ b/tests/Sourcemap.test.cpp
@@ -1326,6 +1326,142 @@ TEST_CASE_FIXTURE(Fixture, "plugin_prunes_children_removed_from_plugin_info")
     CHECK_FALSE(platform->rootSourceNode->findChild("ChildB"));
 }
 
+TEST_CASE_FIXTURE(Fixture, "plugin_update_removes_stale_path_map_entries_for_pruned_nodes")
+{
+    auto platform = dynamic_cast<RobloxPlatform*>(workspace.platform.get());
+
+    auto pluginData1 = json::parse(R"(
+        {
+            "Name": "game",
+            "ClassName": "DataModel",
+            "Children": [
+                { "Name": "ChildA", "ClassName": "Folder" },
+                { "Name": "ChildB", "ClassName": "ModuleScript", "FilePaths": ["ChildB.luau"] }
+            ]
+        }
+    )");
+    platform->onStudioPluginFullChange(pluginData1);
+
+    auto childBUri = workspace.rootUri.resolvePath("ChildB.luau");
+    REQUIRE(platform->virtualPathsToSourceNodes.count("game/ChildB") == 1);
+    REQUIRE(platform->resolveToVirtualPath(childBUri) == "game/ChildB");
+
+    // Second plugin update prunes ChildB
+    auto pluginData2 = json::parse(R"(
+        {
+            "Name": "game",
+            "ClassName": "DataModel",
+            "Children": [
+                { "Name": "ChildA", "ClassName": "Folder" }
+            ]
+        }
+    )");
+    platform->onStudioPluginFullChange(pluginData2);
+
+    // The path maps must not retain entries pointing at the pruned node, otherwise later
+    // type checks can resolve the node and resurrect its freed cached types
+    CHECK(platform->virtualPathsToSourceNodes.count("game/ChildB") == 0);
+    CHECK_FALSE(platform->resolveToVirtualPath(childBUri));
+}
+
+TEST_CASE_FIXTURE(Fixture, "plugin_update_clears_cached_types_on_pruned_nodes")
+{
+    auto platform = dynamic_cast<RobloxPlatform*>(workspace.platform.get());
+
+    auto pluginData1 = json::parse(R"(
+        {
+            "Name": "game",
+            "ClassName": "DataModel",
+            "Children": [
+                { "Name": "ChildB", "ClassName": "Folder" }
+            ]
+        }
+    )");
+    platform->onStudioPluginFullChange(pluginData1);
+
+    auto childB = platform->rootSourceNode->findChild("ChildB");
+    REQUIRE(childB);
+    const SourceNode* childBNode = *childB;
+
+    // Simulate a type having been generated and cached for this node during a previous check
+    childBNode->tys.insert_or_assign(&workspace.frontend.globals, workspace.frontend.builtinTypes->anyType);
+
+    // Second plugin update prunes ChildB. The node stays allocated but is detached from the
+    // tree, so clearSourcemapTypes can no longer reach it - the cache must be cleared on prune
+    auto pluginData2 = json::parse(R"(
+        {
+            "Name": "game",
+            "ClassName": "DataModel",
+            "Children": []
+        }
+    )");
+    platform->onStudioPluginFullChange(pluginData2);
+
+    CHECK_FALSE(platform->rootSourceNode->findChild("ChildB"));
+    CHECK(childBNode->tys.empty());
+}
+
+TEST_CASE_FIXTURE(Fixture, "plugin_clear_clears_cached_types_on_pruned_nodes")
+{
+    auto platform = dynamic_cast<RobloxPlatform*>(workspace.platform.get());
+
+    auto pluginData = json::parse(R"(
+        {
+            "Name": "game",
+            "ClassName": "DataModel",
+            "Children": [
+                { "Name": "ChildB", "ClassName": "ModuleScript", "FilePaths": ["ChildB.luau"] }
+            ]
+        }
+    )");
+    platform->onStudioPluginFullChange(pluginData);
+
+    auto childB = platform->rootSourceNode->findChild("ChildB");
+    REQUIRE(childB);
+    const SourceNode* childBNode = *childB;
+    childBNode->tys.insert_or_assign(&workspace.frontend.globals, workspace.frontend.builtinTypes->anyType);
+
+    auto childBUri = workspace.rootUri.resolvePath("ChildB.luau");
+    REQUIRE(platform->resolveToVirtualPath(childBUri) == "game/ChildB");
+
+    platform->onStudioPluginClear();
+
+    CHECK_FALSE(platform->rootSourceNode->findChild("ChildB"));
+    CHECK(childBNode->tys.empty());
+    CHECK(platform->virtualPathsToSourceNodes.count("game/ChildB") == 0);
+    CHECK_FALSE(platform->resolveToVirtualPath(childBUri));
+}
+
+TEST_CASE_FIXTURE(Fixture, "sourcemap_update_invalidates_stale_module_type_graphs")
+{
+    // Use an unmanaged on-disk file: recomputeDiagnostics (triggered by the sourcemap update
+    // when expressive DataModel types are enabled) would immediately recheck a managed file,
+    // which prevents observing the invalidation
+    auto uri = Uri::file(tempDir.write_child("foo.luau", "local x = 1"));
+    auto moduleName = workspace.fileResolver.getModuleName(uri);
+
+    workspace.frontend.check(moduleName);
+    REQUIRE(workspace.frontend.allModuleDependenciesValid(moduleName, /* forAutocomplete= */ false));
+
+    loadSourcemap(R"(
+        {
+            "name": "game",
+            "className": "DataModel",
+            "children": []
+        }
+    )");
+
+    // The retained type graph of an already-checked module may reference the sourcemap types
+    // that were just destroyed. It must not be considered valid for incremental (fragment)
+    // autocomplete until the module has been rechecked
+    CHECK_FALSE(workspace.frontend.allModuleDependenciesValid(moduleName, /* forAutocomplete= */ false));
+    CHECK_FALSE(workspace.frontend.allModuleDependenciesValid(moduleName, /* forAutocomplete= */ true));
+
+    // A recheck makes the module valid again
+    workspace.frontend.check(moduleName);
+    CHECK(workspace.frontend.allModuleDependenciesValid(moduleName, /* forAutocomplete= */ false));
+}
+
 TEST_CASE_FIXTURE(Fixture, "nested_plugin_children_are_all_marked_plugin_managed")
 {
     auto platform = dynamic_cast<RobloxPlatform*>(workspace.platform.get());


### PR DESCRIPTION
## Summary

Fixes use-after-free crashes that occur after Studio Plugin updates or sourcemap reloads. The issue was that pruned source nodes and stale path map entries remained reachable, allowing later type checks to reference destroyed sourcemap-generated types.

## Key Changes

- **Path map cleanup**: Clear `realPathsToSourceNodes` and `virtualPathsToSourceNodes` maps after hydrating plugin info or clearing plugin-managed nodes, preventing stale entries from pointing to pruned nodes
- **Cached type cleanup**: Add `SourceNode::clearCachedTypes()` method to recursively clear cached types on nodes and their descendants. Call this on pruned nodes immediately (before they become unreachable) and on all source nodes before destroying the `instanceTypes` arena
- **Module dependency invalidation**: Mark all source modules as having invalid dependencies before clearing sourcemap types, preventing fragment autocomplete from reading stale type graphs that reference destroyed types
- **Comprehensive test coverage**: Add regression tests covering:
  - Path map entry removal for pruned nodes
  - Cached type clearing on pruned nodes during updates and clears
  - Use-after-free scenario with dangling types reachable by later checks
  - Fragment autocomplete safety after sourcemap updates

## Implementation Details

The fix addresses three related issues:
1. Pruned nodes stay allocated but become unreachable from the tree root, so `clearSourcemapTypes()` cannot reach them to clear their caches
2. Stale path map entries allow pruned nodes to be resolved and their freed cached types to be resurrected
3. Fragment autocomplete deliberately reads the stale type graph of dirty modules, which may reference destroyed sourcemap types

The solution clears cached types on pruned nodes immediately when they're detached, clears path maps after hydration, and marks modules as having invalid dependencies before destroying the sourcemap type arena.