### PR TITLE
Fix macOS "Test Extension" CI failure by bumping @vscode/test-electron

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
       - name: Install dependencies
         run: npm ci
         working-directory: editors/code
@@ -137,7 +137,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
       - run: npm install
         working-directory: editors/code
       - run: xvfb-run -a npm test

--- a/editors/code/package-lock.json
+++ b/editors/code/package-lock.json
@@ -26,7 +26,7 @@
         "@typescript-eslint/eslint-plugin": "^7.16.0",
         "@typescript-eslint/parser": "^7.16.0",
         "@vscode/test-cli": "^0.0.12",
-        "@vscode/test-electron": "^2.5.2",
+        "@vscode/test-electron": "^3.1.0",
         "esbuild": "^0.28.1",
         "eslint": "^8.57.0",
         "mocha": "^11.1.0",
@@ -1307,9 +1307,9 @@
       }
     },
     "node_modules/@vscode/test-electron": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.5.2.tgz",
-      "integrity": "sha512-8ukpxv4wYe0iWMRQU18jhzJOHkeGKbnw7xWRX3Zw1WJA4cEKbHcmmLPdPrPtL6rhDcrlCZN+xKRpv09n4gRHYg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-3.1.0.tgz",
+      "integrity": "sha512-CRqv5u+YYoseuNVJ6Tyo4k0sF0mx4qnKMihRB0PjsUF8Dc0WKtCXo6CNL6nWWm5esfFQsQA/pejMj4ZbpJVLTw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1320,7 +1320,7 @@
         "semver": "^7.6.2"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=22"
       }
     },
     "node_modules/accepts": {
@@ -7805,9 +7805,9 @@
       }
     },
     "@vscode/test-electron": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.5.2.tgz",
-      "integrity": "sha512-8ukpxv4wYe0iWMRQU18jhzJOHkeGKbnw7xWRX3Zw1WJA4cEKbHcmmLPdPrPtL6rhDcrlCZN+xKRpv09n4gRHYg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-3.1.0.tgz",
+      "integrity": "sha512-CRqv5u+YYoseuNVJ6Tyo4k0sF0mx4qnKMihRB0PjsUF8Dc0WKtCXo6CNL6nWWm5esfFQsQA/pejMj4ZbpJVLTw==",
       "dev": true,
       "requires": {
         "http-proxy-agent": "^7.0.2",

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -891,7 +891,7 @@
     "@typescript-eslint/eslint-plugin": "^7.16.0",
     "@typescript-eslint/parser": "^7.16.0",
     "@vscode/test-cli": "^0.0.12",
-    "@vscode/test-electron": "^2.5.2",
+    "@vscode/test-electron": "^3.1.0",
     "eslint": "^8.57.0",
     "mocha": "^11.1.0",
     "prettier": "^3.8.2",


### PR DESCRIPTION
Every recent PR fails the macOS leg of the "Test Extension" job with:
  Test error: Error: spawn .../Visual Studio Code.app/Contents/MacOS/Electron ENOENT

@vscode/test-electron 2.5.2 (the pinned version) hardcodes the macOS
Electron binary path as Contents/MacOS/Electron. VS Code stable builds
from ~1.110 onward (currently downloading 1.132.0) no longer ship the
binary under that name, so the spawn fails. This was fixed upstream in
@vscode/test-electron 3.1.0, which resolves the executable via the
app's Info.plist (falling back to the legacy name for older builds).

Bump the devDependency to ^3.1.0, which requires Node >=22, so also
bump the CI Node setup for the lint/test extension jobs from 20 to 22
to match.