### PR TITLE
Fix BasePart:GetJoints() return type from { BasePart } to { Instance }

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Fixed `@self` string-require aliases resolving from the filesystem instead of the sourcemap tree for non-DataModel roots ([#1511](https://github.com/JohnnyMorganz/luau-lsp/issues/1511))
+- Fixed `BasePart:GetJoints()` being typed as returning `{ BasePart }` instead of `{ Instance }`, matching the Roblox API dump and documentation, which state it can return both joints and constraints ([#1579](https://github.com/JohnnyMorganz/luau-lsp/issues/1579))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Fixed `@self` string-require aliases resolving from the filesystem instead of the sourcemap tree for non-DataModel roots ([#1511](https://github.com/JohnnyMorganz/luau-lsp/issues/1511))
-- Fixed `BasePart:GetJoints()` being typed as returning `{ BasePart }` instead of `{ Instance }`, matching the Roblox API dump and documentation, which state it can return both joints and constraints ([#1579](https://github.com/JohnnyMorganz/luau-lsp/issues/1579))
 
 ### Changed
 

--- a/scripts/Corrections.json
+++ b/scripts/Corrections.json
@@ -1247,12 +1247,6 @@
                     }
                 },
                 {
-                    "Name": "GetJoints",
-                    "ReturnType": {
-                        "Generic": "JointInstance"
-                    }
-                },
-                {
                     "Name": "GetTouchingParts",
                     "ReturnType": {
                         "Generic": "BasePart"

--- a/scripts/dumpRobloxTypes.py
+++ b/scripts/dumpRobloxTypes.py
@@ -328,7 +328,7 @@ EXTRA_MEMBERS = {
     "InstanceAdornment": ["Adornee: Instance?"],
     "BasePart": [
         "function GetConnectedParts(self, recursive: boolean?): { BasePart }",
-        "function GetJoints(self): { BasePart }",
+        "function GetJoints(self): { Instance }",
         "function GetNetworkOwner(self): Player?",
         "function GetTouchingParts(self): { BasePart }",
         "function SubtractAsync(self, parts: { BasePart }, collisionfidelity: EnumCollisionFidelity?, renderFidelity: EnumRenderFidelity?): UnionOperation",

--- a/scripts/globalTypes.LocalUserSecurity.d.luau
+++ b/scripts/globalTypes.LocalUserSecurity.d.luau
@@ -13356,7 +13356,7 @@ declare extern type BasePart extends PVInstance with
 	function CanSetNetworkOwnership(self): (boolean, string)
 	function GetClosestPointOnSurface(self, position: Vector3): Vector3
 	function GetConnectedParts(self, recursive: boolean?): { BasePart }
-	function GetJoints(self): { BasePart }
+	function GetJoints(self): { Instance }
 	function GetMass(self): number
 	function GetNetworkOwner(self): Player?
 	function GetNetworkOwnershipAuto(self): boolean

--- a/scripts/globalTypes.None.d.luau
+++ b/scripts/globalTypes.None.d.luau
@@ -13316,7 +13316,7 @@ declare extern type BasePart extends PVInstance with
 	function CanSetNetworkOwnership(self): (boolean, string)
 	function GetClosestPointOnSurface(self, position: Vector3): Vector3
 	function GetConnectedParts(self, recursive: boolean?): { BasePart }
-	function GetJoints(self): { BasePart }
+	function GetJoints(self): { Instance }
 	function GetMass(self): number
 	function GetNetworkOwner(self): Player?
 	function GetNetworkOwnershipAuto(self): boolean

--- a/scripts/globalTypes.PluginSecurity.d.luau
+++ b/scripts/globalTypes.PluginSecurity.d.luau
@@ -13481,7 +13481,7 @@ declare extern type BasePart extends PVInstance with
 	function CanSetNetworkOwnership(self): (boolean, string)
 	function GetClosestPointOnSurface(self, position: Vector3): Vector3
 	function GetConnectedParts(self, recursive: boolean?): { BasePart }
-	function GetJoints(self): { BasePart }
+	function GetJoints(self): { Instance }
 	function GetMass(self): number
 	function GetNetworkOwner(self): Player?
 	function GetNetworkOwnershipAuto(self): boolean

--- a/scripts/globalTypes.RobloxScriptSecurity.d.luau
+++ b/scripts/globalTypes.RobloxScriptSecurity.d.luau
@@ -14776,7 +14776,7 @@ declare extern type BasePart extends PVInstance with
 	function CanSetNetworkOwnership(self): (boolean, string)
 	function GetClosestPointOnSurface(self, position: Vector3): Vector3
 	function GetConnectedParts(self, recursive: boolean?): { BasePart }
-	function GetJoints(self): { BasePart }
+	function GetJoints(self): { Instance }
 	function GetMass(self): number
 	function GetNetworkOwner(self): Player?
 	function GetNetworkOwnershipAuto(self): boolean

--- a/scripts/globalTypes.d.lua
+++ b/scripts/globalTypes.d.lua
@@ -14776,7 +14776,7 @@ declare extern type BasePart extends PVInstance with
 	function CanSetNetworkOwnership(self): (boolean, string)
 	function GetClosestPointOnSurface(self, position: Vector3): Vector3
 	function GetConnectedParts(self, recursive: boolean?): { BasePart }
-	function GetJoints(self): { BasePart }
+	function GetJoints(self): { Instance }
 	function GetMass(self): number
 	function GetNetworkOwner(self): Player?
 	function GetNetworkOwnershipAuto(self): boolean

--- a/scripts/globalTypes.d.luau
+++ b/scripts/globalTypes.d.luau
@@ -14776,7 +14776,7 @@ declare extern type BasePart extends PVInstance with
 	function CanSetNetworkOwnership(self): (boolean, string)
 	function GetClosestPointOnSurface(self, position: Vector3): Vector3
 	function GetConnectedParts(self, recursive: boolean?): { BasePart }
-	function GetJoints(self): { BasePart }
+	function GetJoints(self): { Instance }
 	function GetMass(self): number
 	function GetNetworkOwner(self): Player?
 	function GetNetworkOwnershipAuto(self): boolean


### PR DESCRIPTION
The Roblox API dump and creator docs both type GetJoints's return as
"Instances" ({ Instance }), since it can return both JointInstance
subclasses (Weld, Motor6D, ...) and Constraint-like instances (e.g.
WeldConstraint) that don't share a more specific common ancestor.
Also removes the now-dead GetJoints correction in Corrections.json,
which was shadowed by the EXTRA_MEMBERS override and never took effect.

Fixes #1579