### PR TITLE
Add nearestAbsolute auto-import require style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Added a new auto-import require style `completion.imports.requireStyle: "nearestAbsolute"` which requires modules relative to the nearest fixed variable that resolves to a known ancestor instance (e.g. `local Main = script:FindFirstAncestor("PluginName")` or `local Main = script.Parent.Parent`), producing requires like `require(Main.X.Y)`. Falls back to `auto` when no such variable is an ancestor of the module
+
 ### Fixed
 
 - Fixed `@self` string-require aliases resolving from the filesystem instead of the sourcemap tree for non-DataModel roots ([#1511](https://github.com/JohnnyMorganz/luau-lsp/issues/1511))

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -624,12 +624,14 @@
           "enum": [
             "auto",
             "alwaysRelative",
-            "alwaysAbsolute"
+            "alwaysAbsolute",
+            "nearestAbsolute"
           ],
           "enumDescriptions": [
             "Automatically compute the style of require to use based on heuristics",
             "Always require the module relative to the current file",
-            "Always require the module absolute based on root"
+            "Always require the module absolute based on root",
+            "Require the module relative to the nearest fixed variable that resolves to a known ancestor instance (e.g. `local Main = script:FindFirstAncestor(\"PluginName\")` or `local Main = script.Parent.Parent`), falling back to `auto` when no such variable exists"
           ],
           "scope": "resource"
         },

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -631,7 +631,7 @@
             "Automatically compute the style of require to use based on heuristics",
             "Always require the module relative to the current file",
             "Always require the module absolute based on root",
-            "Require the module relative to the nearest fixed variable that resolves to a known ancestor instance (e.g. `local Main = script:FindFirstAncestor(\"PluginName\")` or `local Main = script.Parent.Parent`), falling back to `auto` when no such variable exists"
+            "Require the module relative to the nearest fixed variable that resolves to a known ancestor instance"
           ],
           "scope": "resource"
         },

--- a/src/include/LSP/ClientConfiguration.hpp
+++ b/src/include/LSP/ClientConfiguration.hpp
@@ -124,11 +124,13 @@ enum struct ImportRequireStyle
     Auto,
     AlwaysRelative,
     AlwaysAbsolute,
+    NearestAbsolute,
 };
 NLOHMANN_JSON_SERIALIZE_ENUM(ImportRequireStyle, {
                                                      {ImportRequireStyle::Auto, "auto"},
                                                      {ImportRequireStyle::AlwaysRelative, "alwaysRelative"},
                                                      {ImportRequireStyle::AlwaysAbsolute, "alwaysAbsolute"},
+                                                     {ImportRequireStyle::NearestAbsolute, "nearestAbsolute"},
                                                  })
 
 struct ClientCompletionImportsStringRequiresConfiguration

--- a/src/include/Platform/InstanceRequireAutoImporter.hpp
+++ b/src/include/Platform/InstanceRequireAutoImporter.hpp
@@ -14,8 +14,8 @@ namespace Luau::LanguageServer::AutoImports
 struct FixedVariable
 {
     std::string variableName;
-    Luau::AstExpr* expr;
-    size_t endLine;
+    Luau::AstExpr* expr = nullptr;
+    size_t endLine = 0;
 };
 
 struct RobloxFindImportsVisitor : FindImportsVisitor

--- a/src/include/Platform/InstanceRequireAutoImporter.hpp
+++ b/src/include/Platform/InstanceRequireAutoImporter.hpp
@@ -11,11 +11,19 @@ class RobloxPlatform;
 namespace Luau::LanguageServer::AutoImports
 {
 
+struct FixedVariable
+{
+    std::string variableName;
+    Luau::AstExpr* expr;
+    size_t endLine;
+};
+
 struct RobloxFindImportsVisitor : FindImportsVisitor
 {
     std::optional<size_t> firstServiceDefinitionLine = std::nullopt;
     std::optional<size_t> lastServiceDefinitionLine = std::nullopt;
     std::map<std::string, Luau::AstStatLocal*> serviceLineMap{};
+    std::vector<FixedVariable> fixedVariables{};
 
     size_t findBestLineForService(const std::string& serviceName, size_t minimumLineNumber) const
     {
@@ -34,6 +42,9 @@ struct RobloxFindImportsVisitor : FindImportsVisitor
 
     bool handleLocal(Luau::AstStatLocal* local, Luau::AstLocal* localName, Luau::AstExpr* expr, unsigned int startLine, unsigned int endLine) override
     {
+        if (!isRequire(expr))
+            fixedVariables.emplace_back(FixedVariable{std::string(localName->name.value), expr, endLine});
+
         if (!isGetService(expr))
             return false;
 
@@ -74,7 +85,7 @@ struct InstanceRequireAutoImporterContext
     size_t hotCommentsLineNumber = 0;
     Luau::NotNull<const RobloxFindImportsVisitor> importsVisitor;
 
-    Luau::NotNull<const RobloxPlatform> platform;
+    Luau::NotNull<RobloxPlatform> platform;
 
     std::optional<std::function<bool(const std::string&)>> moduleFilter;
 };

--- a/src/platform/roblox/InstanceRequireAutoImporter.cpp
+++ b/src/platform/roblox/InstanceRequireAutoImporter.cpp
@@ -3,6 +3,8 @@
 #include "LSP/Completion.hpp"
 #include "Platform/RobloxPlatform.hpp"
 
+#include <algorithm>
+
 namespace Luau::LanguageServer::AutoImports
 {
 
@@ -30,11 +32,64 @@ std::string optimiseAbsoluteRequire(const std::string& path)
     return path;
 }
 
+static std::optional<Luau::ModuleName> resolveFixedVariablePath(
+    RobloxPlatform& platform, const Luau::ModuleName& from, Luau::AstExpr* expr, const Luau::TypeCheckLimits& limits)
+{
+    Luau::AstExpr* dependent = nullptr;
+    if (auto* index = expr->as<Luau::AstExprIndexName>())
+        dependent = index->expr;
+    else if (auto* indexExpr = expr->as<Luau::AstExprIndexExpr>())
+        dependent = indexExpr->expr;
+    else if (auto* call = expr->as<Luau::AstExprCall>(); call && call->self)
+    {
+        if (auto* func = call->func->as<Luau::AstExprIndexName>())
+            dependent = func->expr;
+        else
+            return std::nullopt;
+    }
+
+    std::optional<Luau::ModuleInfo> info;
+    if (dependent)
+    {
+        auto context = resolveFixedVariablePath(platform, from, dependent, limits);
+        if (!context)
+            return std::nullopt;
+        Luau::ModuleInfo contextInfo{*context};
+        info = platform.resolveModule(&contextInfo, expr, limits);
+    }
+    else
+    {
+        Luau::ModuleInfo moduleContext{from};
+        info = platform.resolveModule(&moduleContext, expr, limits);
+    }
+
+    if (info && !info->name.empty())
+        return info->name;
+    return std::nullopt;
+}
+
+struct ResolvedFixedVariable
+{
+    Luau::ModuleName path;
+    std::string variableName;
+    size_t endLine;
+};
+
 std::vector<InstanceRequireResult> computeAllInstanceRequires(const InstanceRequireAutoImporterContext& ctx)
 {
     std::vector<InstanceRequireResult> results;
     size_t minimumLineNumber = computeMinimumLineNumberForRequire(*ctx.importsVisitor, ctx.hotCommentsLineNumber);
-    
+
+    std::vector<ResolvedFixedVariable> resolvedFixedVariables;
+    if (ctx.config->requireStyle == ImportRequireStyle::NearestAbsolute)
+    {
+        for (const auto& fixedVariable : ctx.importsVisitor->fixedVariables)
+        {
+            if (auto resolved = resolveFixedVariablePath(*ctx.platform, ctx.from, fixedVariable.expr, ctx.workspaceFolder->limits))
+                resolvedFixedVariables.push_back({*resolved, fixedVariable.variableName, fixedVariable.endLine});
+        }
+    }
+
     ScriptContext callerContext = ScriptContext::Shared;
     if (auto it = ctx.platform->virtualPathsToSourceNodes.find(ctx.from); it != ctx.platform->virtualPathsToSourceNodes.end())
         callerContext = it->second->scriptContext;
@@ -54,6 +109,42 @@ std::vector<InstanceRequireResult> computeAllInstanceRequires(const InstanceRequ
 
         if (!isScriptContextCompatible(callerContext, node->scriptContext))
             continue;
+
+        // Require through the closest (deepest) anchor the module is a descendant of, e.g.
+        // `require(Main.X.Y)`; fall through to the standard style computation when there is none.
+        if (ctx.config->requireStyle == ImportRequireStyle::NearestAbsolute)
+        {
+            const ResolvedFixedVariable* bestAnchor = nullptr;
+            for (const auto& fixedVariable : resolvedFixedVariables)
+            {
+                if (!Luau::startsWith(path, fixedVariable.path + "/"))
+                    continue;
+                if (!bestAnchor || fixedVariable.path.size() > bestAnchor->path.size())
+                    bestAnchor = &fixedVariable;
+            }
+
+            if (bestAnchor)
+            {
+                auto remainder = path.substr(bestAnchor->path.size() + 1);
+                auto require = convertToScriptPath(bestAnchor->variableName + "/" + remainder);
+
+                size_t anchorMinimum = std::max(minimumLineNumber, bestAnchor->endLine + 1);
+                size_t lineNumber = computeBestLineForRequire(*ctx.importsVisitor, *ctx.textDocument, require, anchorMinimum);
+
+                bool prependNewline = ctx.config->separateGroupsWithLine &&
+                                      (ctx.importsVisitor->shouldPrependNewline(lineNumber) || lineNumber == bestAnchor->endLine + 1);
+
+                results.emplace_back(InstanceRequireResult{
+                    name,
+                    path,
+                    require,
+                    std::nullopt,
+                    createRequireTextEdit(name, require, lineNumber, prependNewline, ctx.config->useConst),
+                    SortText::AutoImportsAbsolute,
+                });
+                continue;
+            }
+        }
 
         std::string requirePath;
         std::optional<std::pair<std::string, lsp::TextEdit>> serviceEdit;

--- a/src/platform/roblox/InstanceRequireAutoImporter.cpp
+++ b/src/platform/roblox/InstanceRequireAutoImporter.cpp
@@ -72,7 +72,7 @@ struct ResolvedFixedVariable
 {
     Luau::ModuleName path;
     std::string variableName;
-    size_t endLine;
+    size_t endLine = 0;
 };
 
 std::vector<InstanceRequireResult> computeAllInstanceRequires(const InstanceRequireAutoImporterContext& ctx)

--- a/tests/AutoImports.test.cpp
+++ b/tests/AutoImports.test.cpp
@@ -963,6 +963,365 @@ TEST_CASE_FIXTURE(Fixture, "auto_imports_handles_ancestor_of_module")
     CHECK_EQ(imports[0].additionalTextEdits[0].newText, "local Module = require(script.Parent.Parent)\n");
 }
 
+TEST_CASE_FIXTURE(Fixture, "nearest_absolute_requires_through_findfirstancestor_variable")
+{
+    client->globalConfig.completion.imports.enabled = true;
+    client->globalConfig.completion.imports.requireStyle = ImportRequireStyle::NearestAbsolute;
+    loadSourcemap(R"(
+    {
+        "name": "Game",
+        "className": "DataModel",
+        "children": [
+            {
+                "name": "ReplicatedStorage",
+                "className": "ReplicatedStorage",
+                "children": [
+                    {
+                        "name": "PluginName",
+                        "className": "Folder",
+                        "children": [
+                            { "name": "Main", "className": "ModuleScript", "filePaths": ["main.luau"] },
+                            {
+                                "name": "X",
+                                "className": "Folder",
+                                "children": [{ "name": "Y", "className": "ModuleScript" }]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+    )");
+
+    auto [source, marker] = sourceWithMarker(R"(local Main = script:FindFirstAncestor("PluginName")
+
+|)");
+
+    auto uri = newDocument("main.luau", source);
+
+    lsp::CompletionParams params;
+    params.textDocument = lsp::TextDocumentIdentifier{uri};
+    params.position = marker;
+
+    auto result = workspace.completion(params, nullptr);
+    auto imports = filterAutoImports(result, "Y");
+
+    REQUIRE_EQ(imports.size(), 1);
+    CHECK_EQ(imports[0].label, "Y");
+    // No service import is emitted - the anchor replaces it
+    REQUIRE_EQ(imports[0].additionalTextEdits.size(), 1);
+    CHECK_EQ(imports[0].additionalTextEdits[0].newText, "local Y = require(Main.X.Y)\n");
+    // Inserted after the anchor definition, not at the top of the file
+    CHECK_EQ(imports[0].additionalTextEdits[0].range, lsp::Range{{1, 0}, {1, 0}});
+}
+
+TEST_CASE_FIXTURE(Fixture, "nearest_absolute_requires_through_dotted_instance_variable")
+{
+    client->globalConfig.completion.imports.enabled = true;
+    client->globalConfig.completion.imports.requireStyle = ImportRequireStyle::NearestAbsolute;
+    loadSourcemap(R"(
+    {
+        "name": "Game",
+        "className": "DataModel",
+        "children": [
+            {
+                "name": "ReplicatedStorage",
+                "className": "ReplicatedStorage",
+                "children": [
+                    {
+                        "name": "PluginName",
+                        "className": "Folder",
+                        "children": [
+                            {
+                                "name": "Nested",
+                                "className": "Folder",
+                                "children": [
+                                    { "name": "Main", "className": "ModuleScript", "filePaths": ["main.luau"] }
+                                ]
+                            },
+                            {
+                                "name": "X",
+                                "className": "Folder",
+                                "children": [{ "name": "Y", "className": "ModuleScript" }]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+    )");
+
+    // `script.Parent.Parent` resolves to the PluginName folder (a known instance)
+    auto [source, marker] = sourceWithMarker(R"(local Root = script.Parent.Parent
+
+|)");
+
+    auto uri = newDocument("main.luau", source);
+
+    lsp::CompletionParams params;
+    params.textDocument = lsp::TextDocumentIdentifier{uri};
+    params.position = marker;
+
+    auto result = workspace.completion(params, nullptr);
+    auto imports = filterAutoImports(result, "Y");
+
+    REQUIRE_EQ(imports.size(), 1);
+    CHECK_EQ(imports[0].label, "Y");
+    REQUIRE_EQ(imports[0].additionalTextEdits.size(), 1);
+    CHECK_EQ(imports[0].additionalTextEdits[0].newText, "local Y = require(Root.X.Y)\n");
+}
+
+TEST_CASE_FIXTURE(Fixture, "nearest_absolute_prefers_the_closest_anchor")
+{
+    client->globalConfig.completion.imports.enabled = true;
+    client->globalConfig.completion.imports.requireStyle = ImportRequireStyle::NearestAbsolute;
+    loadSourcemap(R"(
+    {
+        "name": "Game",
+        "className": "DataModel",
+        "children": [
+            {
+                "name": "ReplicatedStorage",
+                "className": "ReplicatedStorage",
+                "children": [
+                    {
+                        "name": "PluginName",
+                        "className": "Folder",
+                        "children": [
+                            {
+                                "name": "SubFolder",
+                                "className": "Folder",
+                                "children": [
+                                    { "name": "Main", "className": "ModuleScript", "filePaths": ["main.luau"] },
+                                    { "name": "Target", "className": "ModuleScript" }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+    )");
+
+    auto [source, marker] = sourceWithMarker(R"(local Main = script:FindFirstAncestor("PluginName")
+local Sub = script:FindFirstAncestor("SubFolder")
+
+|)");
+
+    auto uri = newDocument("main.luau", source);
+
+    lsp::CompletionParams params;
+    params.textDocument = lsp::TextDocumentIdentifier{uri};
+    params.position = marker;
+
+    auto result = workspace.completion(params, nullptr);
+    auto imports = filterAutoImports(result, "Target");
+
+    REQUIRE_EQ(imports.size(), 1);
+    CHECK_EQ(imports[0].label, "Target");
+    REQUIRE_EQ(imports[0].additionalTextEdits.size(), 1);
+    // The deeper anchor (Sub -> SubFolder) is chosen to produce the shortest require chain
+    CHECK_EQ(imports[0].additionalTextEdits[0].newText, "local Target = require(Sub.Target)\n");
+    // Inserted after the last anchor definition (line 2)
+    CHECK_EQ(imports[0].additionalTextEdits[0].range, lsp::Range{{2, 0}, {2, 0}});
+}
+
+TEST_CASE_FIXTURE(Fixture, "nearest_absolute_falls_back_to_auto_when_no_anchor_is_an_ancestor")
+{
+    client->globalConfig.completion.imports.enabled = true;
+    client->globalConfig.completion.imports.requireStyle = ImportRequireStyle::NearestAbsolute;
+    loadSourcemap(R"(
+    {
+        "name": "Game",
+        "className": "DataModel",
+        "children": [
+            {
+                "name": "ReplicatedStorage",
+                "className": "ReplicatedStorage",
+                "children": [
+                    {
+                        "name": "PluginName",
+                        "className": "Folder",
+                        "children": [
+                            { "name": "Main", "className": "ModuleScript", "filePaths": ["main.luau"] }
+                        ]
+                    },
+                    {
+                        "name": "OtherFolder",
+                        "className": "Folder",
+                        "children": [{ "name": "OtherModule", "className": "ModuleScript" }]
+                    }
+                ]
+            }
+        ]
+    }
+    )");
+
+    // OtherModule is not a descendant of the anchor, so we fall back to `auto` (service + absolute)
+    auto [source, marker] = sourceWithMarker(R"(local Main = script:FindFirstAncestor("PluginName")
+
+|)");
+
+    auto uri = newDocument("main.luau", source);
+
+    lsp::CompletionParams params;
+    params.textDocument = lsp::TextDocumentIdentifier{uri};
+    params.position = marker;
+
+    auto result = workspace.completion(params, nullptr);
+    auto imports = filterAutoImports(result, "OtherModule");
+
+    REQUIRE_EQ(imports.size(), 1);
+    CHECK_EQ(imports[0].label, "OtherModule");
+    REQUIRE_EQ(imports[0].additionalTextEdits.size(), 2);
+    CHECK_EQ(imports[0].additionalTextEdits[0].newText, "local ReplicatedStorage = game:GetService(\"ReplicatedStorage\")\n");
+    CHECK_EQ(imports[0].additionalTextEdits[1].newText, "local OtherModule = require(ReplicatedStorage.OtherFolder.OtherModule)\n");
+}
+
+TEST_CASE_FIXTURE(Fixture, "nearest_absolute_separates_anchor_and_require_with_line")
+{
+    client->globalConfig.completion.imports.enabled = true;
+    client->globalConfig.completion.imports.requireStyle = ImportRequireStyle::NearestAbsolute;
+    client->globalConfig.completion.imports.separateGroupsWithLine = true;
+    loadSourcemap(R"(
+    {
+        "name": "Game",
+        "className": "DataModel",
+        "children": [
+            {
+                "name": "ReplicatedStorage",
+                "className": "ReplicatedStorage",
+                "children": [
+                    {
+                        "name": "PluginName",
+                        "className": "Folder",
+                        "children": [
+                            { "name": "Main", "className": "ModuleScript", "filePaths": ["main.luau"] },
+                            {
+                                "name": "X",
+                                "className": "Folder",
+                                "children": [{ "name": "Y", "className": "ModuleScript" }]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+    )");
+
+    auto [source, marker] = sourceWithMarker(R"(local Main = script:FindFirstAncestor("PluginName")
+
+|)");
+
+    auto uri = newDocument("main.luau", source);
+
+    lsp::CompletionParams params;
+    params.textDocument = lsp::TextDocumentIdentifier{uri};
+    params.position = marker;
+
+    auto result = workspace.completion(params, nullptr);
+    auto imports = filterAutoImports(result, "Y");
+
+    REQUIRE_EQ(imports.size(), 1);
+    CHECK_EQ(imports[0].label, "Y");
+    REQUIRE_EQ(imports[0].additionalTextEdits.size(), 1);
+    // A blank line separates the anchor group from the inserted require
+    CHECK_EQ(imports[0].additionalTextEdits[0].newText, "\nlocal Y = require(Main.X.Y)\n");
+}
+
+TEST_CASE_FIXTURE(Fixture, "nearest_absolute_handles_non_identifier_path_segments")
+{
+    client->globalConfig.completion.imports.enabled = true;
+    client->globalConfig.completion.imports.requireStyle = ImportRequireStyle::NearestAbsolute;
+    loadSourcemap(R"(
+    {
+        "name": "Game",
+        "className": "DataModel",
+        "children": [
+            {
+                "name": "ReplicatedStorage",
+                "className": "ReplicatedStorage",
+                "children": [
+                    {
+                        "name": "PluginName",
+                        "className": "Folder",
+                        "children": [
+                            { "name": "Main", "className": "ModuleScript", "filePaths": ["main.luau"] },
+                            {
+                                "name": "X",
+                                "className": "Folder",
+                                "children": [{ "name": "Weird Name", "className": "ModuleScript" }]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+    )");
+
+    auto [source, marker] = sourceWithMarker(R"(local Main = script:FindFirstAncestor("PluginName")
+
+|)");
+
+    auto uri = newDocument("main.luau", source);
+
+    lsp::CompletionParams params;
+    params.textDocument = lsp::TextDocumentIdentifier{uri};
+    params.position = marker;
+
+    auto result = workspace.completion(params, nullptr);
+    auto imports = filterAutoImports(result, "Weird_Name");
+
+    REQUIRE_EQ(imports.size(), 1);
+    CHECK_EQ(imports[0].label, "Weird_Name");
+    REQUIRE_EQ(imports[0].additionalTextEdits.size(), 1);
+    CHECK_EQ(imports[0].additionalTextEdits[0].newText, "local Weird_Name = require(Main.X[\"Weird Name\"])\n");
+}
+
+TEST_CASE_FIXTURE(Fixture, "nearest_absolute_resolves_project_root_anchor")
+{
+    client->globalConfig.completion.imports.enabled = true;
+    client->globalConfig.completion.imports.requireStyle = ImportRequireStyle::NearestAbsolute;
+    // Non-DataModel (model) project - the root maps to `ProjectRoot`
+    loadSourcemap(R"(
+    {
+        "name": "PluginName",
+        "className": "Folder",
+        "children": [
+            { "name": "Main", "className": "ModuleScript", "filePaths": ["main.luau"] },
+            {
+                "name": "X",
+                "className": "Folder",
+                "children": [{ "name": "Y", "className": "ModuleScript" }]
+            }
+        ]
+    }
+    )");
+
+    auto [source, marker] = sourceWithMarker(R"(local Main = script:FindFirstAncestor("PluginName")
+
+|)");
+
+    auto uri = newDocument("main.luau", source);
+
+    lsp::CompletionParams params;
+    params.textDocument = lsp::TextDocumentIdentifier{uri};
+    params.position = marker;
+
+    auto result = workspace.completion(params, nullptr);
+    auto imports = filterAutoImports(result, "Y");
+
+    REQUIRE_EQ(imports.size(), 1);
+    CHECK_EQ(imports[0].label, "Y");
+    REQUIRE_EQ(imports[0].additionalTextEdits.size(), 1);
+    CHECK_EQ(imports[0].additionalTextEdits[0].newText, "local Y = require(Main.X.Y)\n");
+}
+
 using namespace Luau::LanguageServer::AutoImports;
 
 static StringRequireAutoImporterContext createContext(Fixture* fixture, const Uri& uri, FindImportsVisitor* importsVisitor)


### PR DESCRIPTION
Wasn't sure if this should be part of absolute/relative, so decided instead to make it its own option. May be a bit worrisome that it is only used in Roblox, I thought maybe the same could be used for #1591? 

---

Requires modules relative to the nearest fixed variable that resolves to a known ancestor instance (e.g. `local Main = script:FindFirstAncestor("X")` or `local Main = script.Parent.Parent`), producing requires like `require(Main.X.Y)`. Anchor expressions are resolved by reusing the platform's magic module resolvers, and behaviour falls back to `auto` when no anchor is an ancestor of the module.

Closes #625.