### PR TITLE
Respect .client.luau and .server.luau suffixes when classifying script context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Fixed `@self` string-require aliases resolving from the filesystem instead of the sourcemap tree for non-DataModel roots ([#1511](https://github.com/JohnnyMorganz/luau-lsp/issues/1511))
+- Auto-import server/client boundary filtering now respects `.client.luau`/`.server.luau` file suffixes, fixing misclassification of `RunContext = Client` scripts emitted by Rojo's `emitLegacyScripts: false` ([#1594](https://github.com/JohnnyMorganz/luau-lsp/issues/1594))
 
 ### Changed
 

--- a/src/platform/roblox/RobloxSourcemap.cpp
+++ b/src/platform/roblox/RobloxSourcemap.cpp
@@ -1,6 +1,7 @@
 #include "Luau/TypeFwd.h"
 #include "Platform/RobloxPlatform.hpp"
 
+#include "LSP/Utils.hpp"
 #include "LSP/Workspace.hpp"
 #include "Luau/BuiltinDefinitions.h"
 #include "Luau/ConstraintSolver.h"
@@ -475,6 +476,23 @@ bool RobloxPlatform::updateSourceMap()
     }
 }
 
+// Rojo's `emitLegacyScripts: false` maps `*.client.luau` to a `Script` with
+// `RunContext = Client` (and `*.server.luau` to `RunContext = Server`). The sourcemap
+// cannot express RunContext, so the class name alone would misclassify these as server
+// scripts (#1594). For scripts emitted by Rojo's default sync rules, the file suffix
+// reflects the run context, so it takes precedence over the bare `Script` class.
+static std::optional<ScriptContext> scriptContextFromFilePathSuffix(const SourceNode* node)
+{
+    if (auto filePath = node->getScriptFilePath())
+    {
+        if (endsWith(*filePath, ".client.lua") || endsWith(*filePath, ".client.luau"))
+            return ScriptContext::Client;
+        if (endsWith(*filePath, ".server.lua") || endsWith(*filePath, ".server.luau"))
+            return ScriptContext::Server;
+    }
+    return std::nullopt;
+}
+
 void RobloxPlatform::writePathsToMap(SourceNode* node, const std::string& base, ScriptContext parentNameContext)
 {
     LUAU_TIMETRACE_SCOPE("RobloxPlatform::writePathsToMap", "LSP");
@@ -486,10 +504,10 @@ void RobloxPlatform::writePathsToMap(SourceNode* node, const std::string& base, 
         realPathsToSourceNodes.insert_or_assign(*realPath, node);
     }
 
-    if (node->className == "Script")
-        node->scriptContext = ScriptContext::Server;
-    else if (node->className == "LocalScript")
-        node->scriptContext = ScriptContext::Client;
+    if (node->className == "LocalScript")
+        node->scriptContext = ScriptContext::Client; // client by class invariant, never overridden
+    else if (node->className == "Script")
+        node->scriptContext = scriptContextFromFilePathSuffix(node).value_or(ScriptContext::Server);
     else
         node->scriptContext = parentNameContext;
 

--- a/tests/AutoImports.test.cpp
+++ b/tests/AutoImports.test.cpp
@@ -2230,4 +2230,89 @@ TEST_CASE_FIXTURE(Fixture, "string_requires_server_can_see_server")
     CHECK(getItem(result, "SharedModule"));
 }
 
+
+TEST_CASE_FIXTURE(Fixture, "instance_requires_run_context_client_script_acts_as_client")
+{
+    client->globalConfig.completion.imports.enabled = true;
+    client->globalConfig.completion.imports.stringRequires.enabled = false;
+    loadSourcemap(SOURCEMAP_FOR_RUN_CONTEXT_AUTO_IMPORTS);
+
+    auto [source, marker] = sourceWithMarker(R"(|)");
+    auto uri = newDocument("features/main.client.luau", source);
+
+    lsp::CompletionParams params;
+    params.textDocument = lsp::TextDocumentIdentifier{uri};
+    params.position = marker;
+
+    auto result = workspace.completion(params, nullptr);
+
+    CHECK(getItem(result, "SharedModule"));
+    CHECK(getItem(result, "ClientModule"));
+
+    CHECK_FALSE(getItem(result, "ServerModule"));
+}
+
+TEST_CASE_FIXTURE(Fixture, "instance_requires_run_context_server_script_acts_as_server")
+{
+    client->globalConfig.completion.imports.enabled = true;
+    client->globalConfig.completion.imports.stringRequires.enabled = false;
+    loadSourcemap(SOURCEMAP_FOR_RUN_CONTEXT_AUTO_IMPORTS);
+
+    auto [source, marker] = sourceWithMarker(R"(|)");
+    auto uri = newDocument("features/boot.server.luau", source);
+
+    lsp::CompletionParams params;
+    params.textDocument = lsp::TextDocumentIdentifier{uri};
+    params.position = marker;
+
+    auto result = workspace.completion(params, nullptr);
+
+    CHECK(getItem(result, "SharedModule"));
+    CHECK(getItem(result, "ServerModule"));
+
+    CHECK_FALSE(getItem(result, "ClientModule"));
+}
+
+TEST_CASE_FIXTURE(Fixture, "string_requires_run_context_client_script_acts_as_client")
+{
+    client->globalConfig.completion.imports.enabled = true;
+    client->globalConfig.completion.imports.stringRequires.enabled = true;
+    loadSourcemap(SOURCEMAP_FOR_RUN_CONTEXT_AUTO_IMPORTS);
+
+    auto [source, marker] = sourceWithMarker(R"(|)");
+    auto uri = newDocument("features/main.client.luau", source);
+
+    lsp::CompletionParams params;
+    params.textDocument = lsp::TextDocumentIdentifier{uri};
+    params.position = marker;
+
+    auto result = workspace.completion(params, nullptr);
+
+    CHECK(getItem(result, "SharedModule"));
+    CHECK(getItem(result, "ClientModule"));
+
+    CHECK_FALSE(getItem(result, "ServerModule"));
+}
+
+TEST_CASE_FIXTURE(Fixture, "string_requires_run_context_server_script_acts_as_server")
+{
+    client->globalConfig.completion.imports.enabled = true;
+    client->globalConfig.completion.imports.stringRequires.enabled = true;
+    loadSourcemap(SOURCEMAP_FOR_RUN_CONTEXT_AUTO_IMPORTS);
+
+    auto [source, marker] = sourceWithMarker(R"(|)");
+    auto uri = newDocument("features/boot.server.luau", source);
+
+    lsp::CompletionParams params;
+    params.textDocument = lsp::TextDocumentIdentifier{uri};
+    params.position = marker;
+
+    auto result = workspace.completion(params, nullptr);
+
+    CHECK(getItem(result, "SharedModule"));
+    CHECK(getItem(result, "ServerModule"));
+
+    CHECK_FALSE(getItem(result, "ClientModule"));
+}
+
 TEST_SUITE_END();

--- a/tests/RobloxTestConstants.h
+++ b/tests/RobloxTestConstants.h
@@ -90,3 +90,52 @@ static const std::string SOURCEMAP_FOR_SERVER_CLIENT_BOUNDARY_AUTO_IMPORTS = R"(
     ]
 }
 )";
+
+static const std::string SOURCEMAP_FOR_RUN_CONTEXT_AUTO_IMPORTS = R"(
+{
+    "name": "game",
+    "className": "DataModel",
+    "children": [
+        {
+            "name": "Workspace",
+            "className": "Workspace",
+            "children": [
+                {"name": "LegacyScript", "className": "Script", "filePaths": ["workspace/LegacyScript.lua"]},
+                {"name": "MyLocalScript", "className": "LocalScript", "filePaths": ["workspace/MyLocalScript.client.luau"]}
+            ]
+        },
+        {
+            "name": "ReplicatedStorage",
+            "className": "ReplicatedStorage",
+            "children": [
+                {"name": "SharedModule", "className": "ModuleScript", "filePaths": ["shared/SharedModule.luau"]},
+                {
+                    "name": "Features",
+                    "className": "Folder",
+                    "children": [
+                        {"name": "main", "className": "Script", "filePaths": ["features/main.client.luau"]},
+                        {"name": "boot", "className": "Script", "filePaths": ["features/boot.server.luau"]},
+                        {"name": "Widget", "className": "Script", "filePaths": ["features/Widget/init.client.luau"]}
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "ServerScriptService",
+            "className": "ServerScriptService",
+            "children": [{"name": "ServerModule", "className": "ModuleScript", "filePaths": ["server/ServerModule.luau"]}]
+        },
+        {
+            "name": "StarterPlayer",
+            "className": "StarterPlayer",
+            "children": [
+                {
+                    "name": "StarterPlayerScripts",
+                    "className": "StarterPlayerScripts",
+                    "children": [{"name": "ClientModule", "className": "ModuleScript", "filePaths": ["client/ClientModule.luau"]}]
+                }
+            ]
+        }
+    ]
+}
+)";

--- a/tests/Sourcemap.test.cpp
+++ b/tests/Sourcemap.test.cpp
@@ -1,5 +1,6 @@
 #include "doctest.h"
 #include "Fixture.h"
+#include "RobloxTestConstants.h"
 #include "Platform/RobloxPlatform.hpp"
 #include "Protocol/Workspace.hpp"
 #include "LuauFileUtils.hpp"
@@ -1881,6 +1882,53 @@ TEST_CASE_FIXTURE(Fixture, "source_node_get_script_context_resolution")
     auto clientModule = (*starterPlayer)->findChild("ClientModule");
     REQUIRE(clientModule);
     CHECK_EQ((*clientModule)->scriptContext, ScriptContext::Client);
+}
+
+
+TEST_CASE_FIXTURE(Fixture, "script_context_resolution_respects_file_path_suffixes")
+{
+    auto platform = dynamic_cast<RobloxPlatform*>(workspace.platform.get());
+    REQUIRE(platform);
+
+    loadSourcemap(SOURCEMAP_FOR_RUN_CONTEXT_AUTO_IMPORTS);
+    REQUIRE(platform->rootSourceNode);
+    auto root = platform->rootSourceNode;
+
+    // RunContext-style client script: Script class + .client.luau suffix -> Client
+    auto replicatedStorage = root->findChild("ReplicatedStorage");
+    REQUIRE(replicatedStorage);
+    auto features = (*replicatedStorage)->findChild("Features");
+    REQUIRE(features);
+    auto mainScript = (*features)->findChild("main");
+    REQUIRE(mainScript);
+    CHECK_EQ((*mainScript)->scriptContext, ScriptContext::Client);
+
+    // RunContext-style server script: Script class + .server.luau suffix -> Server
+    auto bootScript = (*features)->findChild("boot");
+    REQUIRE(bootScript);
+    CHECK_EQ((*bootScript)->scriptContext, ScriptContext::Server);
+
+    // A folder synced from init.client.luau: the suffix is on the init file
+    auto widget = (*features)->findChild("Widget");
+    REQUIRE(widget);
+    CHECK_EQ((*widget)->scriptContext, ScriptContext::Client);
+
+    // No suffix: class name fallback is preserved
+    auto workspaceNode = root->findChild("Workspace");
+    REQUIRE(workspaceNode);
+    auto legacyScript = (*workspaceNode)->findChild("LegacyScript");
+    REQUIRE(legacyScript);
+    CHECK_EQ((*legacyScript)->scriptContext, ScriptContext::Server);
+
+    // LocalScript: unconditionally Client (class invariant, suffix never consulted)
+    auto localScript = (*workspaceNode)->findChild("MyLocalScript");
+    REQUIRE(localScript);
+    CHECK_EQ((*localScript)->scriptContext, ScriptContext::Client);
+
+    // ModuleScript still inherits from its container
+    auto sharedModule = (*replicatedStorage)->findChild("SharedModule");
+    REQUIRE(sharedModule);
+    CHECK_EQ((*sharedModule)->scriptContext, ScriptContext::Shared);
 }
 
 TEST_SUITE_END();


### PR DESCRIPTION
Addresses #1594.

`writePathsToMap` decides a script's context from className alone, so a `Script` with `RunContext = Client` reads as server and gets offered `ServerScriptService` modules. This checks the file suffix first when the class is a bare `Script`, and falls back to the class name when there isn't one:

```cpp
if (node->className == "LocalScript")
    node->scriptContext = ScriptContext::Client;
else if (node->className == "Script")
    node->scriptContext = scriptContextFromFilePathSuffix(node).value_or(ScriptContext::Server);
else
    node->scriptContext = parentNameContext;
```

`LocalScript` stays unconditionally Client. That one is a class invariant rather than a guess, and letting a filename override it could only make things worse. Anything that isn't a script still inherits from its container, as before.

Worth being upfront about what this leaves alone. Rojo lets a sync rule use whatever pattern it likes, so a project naming its files `*.rc-client.luau` is still misclassified. Same for `RunContext` set through a `.meta.json`, where a `.server.luau` declared as client reads as server, which is what happens today anyway. In all of those the class-name fallback applies, so they keep their current behaviour rather than getting a worse one. Covering the rest properly probably wants the run context in the sourcemap itself, which is Rojo's end.

Tests: four in `AutoImports` covering instance and string requires from both a client and a server RunContext script, and one in `Sourcemap` checking the classification directly, fallbacks included.

Full suite passes locally, including `--new-solver` and `--fflags=true`.
