### PR TITLE
Fix `@game` string requires in files outside the sourcemap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Fixed `@self` string-require aliases resolving from the filesystem instead of the sourcemap tree for non-DataModel roots ([#1511](https://github.com/JohnnyMorganz/luau-lsp/issues/1511))
+- Fixed `@game` string requires and their autocomplete failing in a file that the sourcemap does not cover, such as build output. `@game` is absolute, so it no longer needs the requiring file to have a sourcemap node
 
 ### Changed
 

--- a/src/include/Platform/RobloxPlatform.hpp
+++ b/src/include/Platform/RobloxPlatform.hpp
@@ -29,6 +29,19 @@ inline bool isScriptContextCompatible(ScriptContext from, ScriptContext target)
     return from == target;
 }
 
+/// The lowercase alias name and the path that follows it, for a require of the form `@alias/remainder`.
+struct AliasRequire
+{
+    std::string name;
+    std::string remainder;
+};
+
+/// Splits an alias require into its parts. Returns nullopt when the string is not an alias require.
+std::optional<AliasRequire> parseAliasRequire(const std::string& requiredString);
+
+/// The name of the built-in alias that resolves against the sourcemap root.
+const std::string kGameAlias = "game";
+
 struct SourceNode
 {
     const SourceNode* parent = nullptr; // Can be null! NOT POPULATED BY SOURCEMAP, must be written to manually

--- a/src/include/Platform/RobloxStringRequireSuggester.hpp
+++ b/src/include/Platform/RobloxStringRequireSuggester.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Platform/StringRequireSuggester.hpp"
+
 #include "Luau/Config.h"
 #include "Luau/ConfigResolver.h"
 #include "Luau/FileResolver.h"
@@ -34,6 +36,26 @@ private:
     const SourceNode* rootNode;
     std::shared_ptr<const Luau::Config> mainRequirerNodeConfig;
     WorkspaceFolder* workspaceFolder;
+};
+
+/// A requirer that the sourcemap does not cover, such as build output. It keeps its filesystem
+/// identity for relative requires and `.luaurc` aliases, and adds the built-in `@game` alias, which
+/// is absolute and so needs the sourcemap root rather than the requirer.
+class SourcemapAwareFileRequireNode : public FileRequireNode
+{
+public:
+    SourcemapAwareFileRequireNode(Uri uri, bool isDirectory, const SourceNode* rootNode, WorkspaceFolder* workspaceFolder,
+        std::shared_ptr<const Luau::Config> mainRequirerNodeConfig)
+        : FileRequireNode(std::move(uri), isDirectory, workspaceFolder, std::move(mainRequirerNodeConfig))
+        , rootNode(rootNode)
+    {
+    }
+
+    std::unique_ptr<Luau::RequireNode> resolvePathToNode(const std::string& path) const override;
+    std::vector<Luau::RequireAlias> getAvailableAliases() const override;
+
+private:
+    const SourceNode* rootNode;
 };
 
 class RobloxStringRequireSuggester : public Luau::RequireSuggester

--- a/src/include/Platform/StringRequireSuggester.hpp
+++ b/src/include/Platform/StringRequireSuggester.hpp
@@ -29,7 +29,9 @@ public:
     std::vector<std::unique_ptr<Luau::RequireNode>> getChildren() const override;
     std::vector<Luau::RequireAlias> getAvailableAliases() const override;
 
-private:
+    // Protected rather than private so a platform can subclass this node and keep its filesystem
+    // behaviour while it adds platform-specific aliases.
+protected:
     Uri uri;
     bool isDirectory = false;
 

--- a/src/platform/roblox/RobloxFileResolver.cpp
+++ b/src/platform/roblox/RobloxFileResolver.cpp
@@ -110,44 +110,57 @@ std::optional<std::string> RobloxPlatform::readSourceCode(const Luau::ModuleName
     return source;
 }
 
+std::optional<AliasRequire> parseAliasRequire(const std::string& requiredString)
+{
+    if (requiredString.empty() || requiredString[0] != '@')
+        return std::nullopt;
+
+    size_t slashPos = requiredString.find('/');
+    std::string name = toLower(requiredString.substr(1, slashPos == std::string::npos ? std::string::npos : slashPos - 1));
+    std::string remainder = (slashPos == std::string::npos) ? "" : requiredString.substr(slashPos + 1);
+    return AliasRequire{std::move(name), std::move(remainder)};
+}
+
+static Luau::ModuleInfo joinVirtualPath(const std::string& base, const std::string& remainder)
+{
+    if (remainder.empty())
+        return Luau::ModuleInfo{base};
+    return Luau::ModuleInfo{base + "/" + remainder};
+}
+
 std::optional<Luau::ModuleInfo> RobloxPlatform::resolveStringRequire(
     const Luau::ModuleInfo* context, const std::string& requiredString, const Luau::TypeCheckLimits& limits)
 {
     if (!context)
         return std::nullopt;
 
-    if (!isVirtualPath(context->name))
-        return LSPPlatform::resolveStringRequire(context, requiredString, limits);
-
-    if (!requiredString.empty() && requiredString[0] == '@')
+    if (auto alias = parseAliasRequire(requiredString))
     {
         const auto& luauConfig = fileResolver->getConfig(context->name, limits);
+        const bool userDefined = luauConfig.aliases.find(alias->name) != nullptr;
 
-        size_t slashPos = requiredString.find('/');
-        std::string aliasName = requiredString.substr(1, slashPos == std::string::npos ? std::string::npos : slashPos - 1);
-        std::string aliasNameLower = toLower(aliasName);
+        // `@game` is absolute: it is rooted at the DataModel and reads nothing from the requirer.
+        // Resolve it before the filesystem fallback, so a file that the sourcemap does not cover
+        // still resolves it. A user-defined `game` alias in `.luaurc` still wins.
+        if (alias->name == kGameAlias && !userDefined && rootSourceNode)
+            return joinVirtualPath(rootSourceNode->virtualPath, alias->remainder);
 
-        if (aliasNameLower == "self")
-        {
-            std::string remainder = (slashPos == std::string::npos) ? "" : requiredString.substr(slashPos + 1);
-            if (remainder.empty())
-                return Luau::ModuleInfo{context->name};
-            return Luau::ModuleInfo{context->name + "/" + remainder};
-        }
-
-        if (luauConfig.aliases.find(aliasNameLower))
+        // Every other alias needs an instance context, so a file outside the sourcemap falls back
+        // to the filesystem.
+        if (!isVirtualPath(context->name))
             return LSPPlatform::resolveStringRequire(context, requiredString, limits);
 
-        if (aliasNameLower == "game" && rootSourceNode)
-        {
-            std::string remainder = (slashPos == std::string::npos) ? "" : requiredString.substr(slashPos + 1);
-            if (remainder.empty())
-                return Luau::ModuleInfo{rootSourceNode->virtualPath};
-            return Luau::ModuleInfo{rootSourceNode->virtualPath + "/" + remainder};
-        }
+        if (alias->name == "self")
+            return joinVirtualPath(context->name, alias->remainder);
+
+        if (userDefined)
+            return LSPPlatform::resolveStringRequire(context, requiredString, limits);
 
         return std::nullopt;
     }
+
+    if (!isVirtualPath(context->name))
+        return LSPPlatform::resolveStringRequire(context, requiredString, limits);
 
     auto parentPath = getParentPath(context->name);
     if (!parentPath)

--- a/src/platform/roblox/RobloxStringRequireSuggester.cpp
+++ b/src/platform/roblox/RobloxStringRequireSuggester.cpp
@@ -39,15 +39,9 @@ std::unique_ptr<Luau::RequireNode> SourceNodeRequireNode::resolvePathToNode(cons
             }
         }
 
-        size_t slashPos = requireString.find('/');
-        std::string aliasName = requireString.substr(1, slashPos == std::string::npos ? std::string::npos : slashPos - 1);
-        std::string aliasNameLower = toLower(aliasName);
-
-        if (aliasNameLower == "game" && rootNode)
+        if (auto alias = parseAliasRequire(requireString); alias && alias->name == kGameAlias && rootNode)
         {
-            std::string remainder = (slashPos == std::string::npos) ? "" : requireString.substr(slashPos + 1);
-            auto targetNode = rootNode->walkPath(remainder);
-            if (targetNode)
+            if (auto targetNode = rootNode->walkPath(alias->remainder))
                 return std::make_unique<SourceNodeRequireNode>(targetNode, rootNode, mainRequirerNodeConfig, workspaceFolder);
         }
 
@@ -88,9 +82,8 @@ std::vector<Luau::RequireAlias> SourceNodeRequireNode::getAvailableAliases() con
         results.emplace_back(Luau::RequireAlias{aliasInfo.originalCase, {"Alias"}});
 
     // Add built-in @game alias if not user-defined
-    std::string gameLower = "game";
-    if (!mainRequirerNodeConfig->aliases.find(gameLower))
-        results.emplace_back(Luau::RequireAlias{"game", {"Alias"}});
+    if (!mainRequirerNodeConfig->aliases.find(kGameAlias))
+        results.emplace_back(Luau::RequireAlias{kGameAlias, {"Alias"}});
 
     if (auto filePath = node->getScriptFilePath())
     {
@@ -102,6 +95,36 @@ std::vector<Luau::RequireAlias> SourceNodeRequireNode::getAvailableAliases() con
     return results;
 }
 
+std::unique_ptr<Luau::RequireNode> SourcemapAwareFileRequireNode::resolvePathToNode(const std::string& requireString) const
+{
+    LUAU_ASSERT(mainRequirerNodeConfig);
+
+    // `@game` is rooted at the DataModel, so it resolves against the sourcemap root even though this
+    // file has no node. A user-defined `game` alias in `.luaurc` still wins, and every other form
+    // keeps the filesystem behaviour.
+    if (auto alias = parseAliasRequire(requireString);
+        alias && alias->name == kGameAlias && rootNode && !mainRequirerNodeConfig->aliases.find(kGameAlias))
+    {
+        if (auto targetNode = rootNode->walkPath(alias->remainder))
+            return std::make_unique<SourceNodeRequireNode>(targetNode, rootNode, mainRequirerNodeConfig, workspaceFolder);
+        return nullptr;
+    }
+
+    return FileRequireNode::resolvePathToNode(requireString);
+}
+
+std::vector<Luau::RequireAlias> SourcemapAwareFileRequireNode::getAvailableAliases() const
+{
+    LUAU_ASSERT(mainRequirerNodeConfig);
+
+    auto results = FileRequireNode::getAvailableAliases();
+
+    if (rootNode && !mainRequirerNodeConfig->aliases.find(kGameAlias))
+        results.emplace_back(Luau::RequireAlias{kGameAlias, {"Alias"}});
+
+    return results;
+}
+
 std::unique_ptr<Luau::RequireNode> RobloxStringRequireSuggester::getNode(const Luau::ModuleName& name) const
 {
     auto config = std::make_shared<const Luau::Config>(configResolver->getConfig(name, workspaceFolder->limits));
@@ -109,9 +132,11 @@ std::unique_ptr<Luau::RequireNode> RobloxStringRequireSuggester::getNode(const L
     if (auto it = platform->virtualPathsToSourceNodes.find(name); it != platform->virtualPathsToSourceNodes.end())
         return std::make_unique<SourceNodeRequireNode>(it->second, platform->rootSourceNode, std::move(config), workspaceFolder);
 
-    // Fall back to filesystem-based node for modules not in the sourcemap
+    // Fall back to filesystem-based node for modules not in the sourcemap. It still offers `@game`,
+    // which does not depend on the requirer having a node.
     if (auto realUri = platform->resolveToRealPath(name))
-        return std::make_unique<FileRequireNode>(*realUri, realUri->isDirectory(), workspaceFolder, std::move(config));
+        return std::make_unique<SourcemapAwareFileRequireNode>(
+            *realUri, realUri->isDirectory(), platform->rootSourceNode, workspaceFolder, std::move(config));
 
     return nullptr;
 }

--- a/tests/AnalyzeCli.test.cpp
+++ b/tests/AnalyzeCli.test.cpp
@@ -395,4 +395,39 @@ TEST_CASE("analyze_resolves_non_mirrored_relative_requires_with_sourcemap")
     CHECK(analyzeFile(workspace, moduleAPath, ReportFormat::Default, false));
 }
 
+TEST_CASE("analyze_resolves_game_requires_from_file_outside_sourcemap")
+{
+    // `@game` is absolute, so it must resolve from build output that the sourcemap does not cover.
+    TempDir t("analyze_game_requires_outside_sourcemap");
+
+    t.write_child("sourcemap.json", R"({
+        "name": "Game",
+        "className": "DataModel",
+        "children": [
+            {
+                "name": "ReplicatedStorage",
+                "className": "ReplicatedStorage",
+                "children": [
+                    {
+                        "name": "Util",
+                        "className": "ModuleScript",
+                        "filePaths": ["packages/util/Util.luau"]
+                    }
+                ]
+            }
+        ]
+    })");
+    t.write_child("packages/util/Util.luau", "return { value = 42 }");
+    // dist/ has no sourcemap node.
+    t.write_child("dist/main.luau", "local _ = require('@game/ReplicatedStorage/Util')");
+
+    CliClient client;
+    initRobloxCliClient(client);
+    WorkspaceFolder workspace(&client, "CLI", Uri::file(t.path()), std::nullopt);
+    setupCliWorkspace(client, workspace);
+
+    auto mainPath = Uri::file(t.path() + "/dist/main.luau").fsPath();
+    CHECK(analyzeFile(workspace, mainPath, ReportFormat::Default, false));
+}
+
 TEST_SUITE_END();

--- a/tests/Autocomplete.test.cpp
+++ b/tests/Autocomplete.test.cpp
@@ -2287,6 +2287,74 @@ TEST_CASE_FIXTURE(Fixture, "sourcemap_autocomplete_shows_game_alias_children")
     checkFolderCompletionExists(result, "ServerScriptService", "@game/ServerScriptService");
 }
 
+TEST_CASE_FIXTURE(Fixture, "sourcemap_autocomplete_shows_game_alias_children_from_non_sourcemap_file")
+{
+    // Regression test: `@game` is absolute, so a file that the sourcemap does not cover still
+    // completes against the DataModel.
+    client->globalConfig.completion.imports.stringRequires.enabled = true;
+    loadSourcemap(SOURCEMAP_FOR_STRING_REQUIRES);
+
+    auto [source, marker] = sourceWithMarker(R"(
+        --!strict
+        local x = require("@game/|")
+    )");
+
+    auto uri = newDocument(tempDir.write_child("dist/main.luau", source), source);
+
+    lsp::CompletionParams params;
+    params.textDocument = lsp::TextDocumentIdentifier{uri};
+    params.position = marker;
+
+    auto result = workspace.completion(params, nullptr);
+
+    checkFolderCompletionExists(result, "ReplicatedStorage", "@game/ReplicatedStorage");
+    checkFolderCompletionExists(result, "ServerScriptService", "@game/ServerScriptService");
+}
+
+TEST_CASE_FIXTURE(Fixture, "sourcemap_autocomplete_shows_nested_game_alias_children_from_non_sourcemap_file")
+{
+    client->globalConfig.completion.imports.stringRequires.enabled = true;
+    loadSourcemap(SOURCEMAP_FOR_STRING_REQUIRES);
+
+    auto [source, marker] = sourceWithMarker(R"(
+        --!strict
+        local x = require("@game/ReplicatedStorage/Shared/|")
+    )");
+
+    auto uri = newDocument(tempDir.write_child("dist/main.luau", source), source);
+
+    lsp::CompletionParams params;
+    params.textDocument = lsp::TextDocumentIdentifier{uri};
+    params.position = marker;
+
+    auto result = workspace.completion(params, nullptr);
+
+    checkFileCompletionExists(result, "ModuleA", "@game/ReplicatedStorage/Shared/ModuleA");
+    checkFileCompletionExists(result, "ModuleB", "@game/ReplicatedStorage/Shared/ModuleB");
+    checkFolderCompletionExists(result, "Nested", "@game/ReplicatedStorage/Shared/Nested");
+}
+
+TEST_CASE_FIXTURE(Fixture, "sourcemap_autocomplete_offers_game_alias_from_non_sourcemap_file")
+{
+    client->globalConfig.completion.imports.stringRequires.enabled = true;
+    loadSourcemap(SOURCEMAP_FOR_STRING_REQUIRES);
+
+    auto [source, marker] = sourceWithMarker(R"(
+        --!strict
+        local x = require("|")
+    )");
+
+    auto uri = newDocument(tempDir.write_child("dist/main.luau", source), source);
+
+    lsp::CompletionParams params;
+    params.textDocument = lsp::TextDocumentIdentifier{uri};
+    params.position = marker;
+
+    auto result = workspace.completion(params, nullptr);
+
+    CHECK(getItem(result, "@game"));
+}
+
 TEST_CASE_FIXTURE(Fixture, "sourcemap_autocomplete_shows_self_alias_children")
 {
     client->globalConfig.completion.imports.stringRequires.enabled = true;

--- a/tests/WorkspaceFileResolver.test.cpp
+++ b/tests/WorkspaceFileResolver.test.cpp
@@ -787,6 +787,61 @@ TEST_CASE_FIXTURE(Fixture, "sourcemap_game_alias_resolves_nonexistent_path")
     CHECK_EQ(result->name, "game/NonExistent/Module");
 }
 
+TEST_CASE_FIXTURE(Fixture, "sourcemap_game_alias_resolves_from_non_sourcemap_file")
+{
+    // Regression test: `@game` is absolute, so it must resolve from a file that the sourcemap
+    // does not cover, such as build output.
+    client->globalConfig.completion.imports.stringRequires.enabled = true;
+    loadSourcemap(SOURCEMAP_FOR_STRING_REQUIRES);
+
+    auto mainPath = tempDir.touch_child("dist/main.luau");
+
+    Luau::ModuleInfo baseContext{mainPath};
+    auto result = workspace.fileResolver.platform->resolveStringRequire(
+        &baseContext, "@game/ReplicatedStorage/Shared/ModuleA", workspace.limits);
+
+    REQUIRE(result.has_value());
+    CHECK_EQ(result->name, "game/ReplicatedStorage/Shared/ModuleA");
+}
+
+TEST_CASE_FIXTURE(Fixture, "sourcemap_game_alias_from_non_sourcemap_file_respects_user_alias")
+{
+    client->globalConfig.completion.imports.stringRequires.enabled = true;
+    loadSourcemap(SOURCEMAP_FOR_STRING_REQUIRES);
+
+    auto mainPath = tempDir.touch_child("dist/main.luau");
+    auto gameDirModule = tempDir.touch_child("game_alias/MyModule.luau");
+    loadLuaurc(R"(
+    {
+        "aliases": {
+            "game": "game_alias"
+        }
+    }
+    )");
+
+    Luau::ModuleInfo baseContext{mainPath};
+    auto result = workspace.fileResolver.platform->resolveStringRequire(&baseContext, "@game/MyModule", workspace.limits);
+
+    REQUIRE(result.has_value());
+    CHECK_EQ(Uri::file(result->name), Uri::file(gameDirModule));
+}
+
+TEST_CASE_FIXTURE(Fixture, "sourcemap_self_alias_from_non_sourcemap_file_falls_back_to_filesystem")
+{
+    // `@self` needs the requirer, so a file outside the sourcemap keeps the filesystem behaviour.
+    client->globalConfig.completion.imports.stringRequires.enabled = true;
+    loadSourcemap(SOURCEMAP_FOR_STRING_REQUIRES);
+
+    auto mainPath = tempDir.touch_child("standalone/main.luau");
+    auto otherPath = tempDir.touch_child("standalone/other.luau");
+
+    Luau::ModuleInfo baseContext{mainPath};
+    auto result = workspace.fileResolver.platform->resolveStringRequire(&baseContext, "@self/other", workspace.limits);
+
+    REQUIRE(result.has_value());
+    CHECK_EQ(Uri::file(result->name), Uri::file(otherPath));
+}
+
 TEST_CASE_FIXTURE(Fixture, "sourcemap_self_alias_resolves_from_module")
 {
     client->globalConfig.completion.imports.stringRequires.enabled = true;


### PR DESCRIPTION

Require-string autocomplete fails in the same files, through a separate path.

## Cause

Two independent code paths gate `@game` on the requirer having a sourcemap node.
Resolution goes through `resolveStringRequire`. Completion goes through
`RobloxStringRequireSuggester`. Each needs its own fix.

### Resolution

`RobloxPlatform::resolveStringRequire` returns early to the filesystem fallback
when `context->name` is not a virtual path. A file with no sourcemap node keeps
its filesystem module name, so the whole `@` block is skipped. The fallback
finds no `game` alias in `.luaurc` and treats `@game` as a directory name.

The `@game` branch reads the sourcemap root and the require string only. It
reads nothing from the requirer. `@game` is absolute: it is rooted at the
DataModel. The gate is too broad.

The instance-expression form is not gated. `RobloxPlatform::resolveModule`
returns `game` with no context check, so `game.ReplicatedStorage.Packages.fluid`
gives full type information in the same file where `require("@game/...")`
errors. The two spellings mean the same thing and behave differently.

### Autocomplete

`RobloxStringRequireSuggester::getNode` looks the requirer up in
`virtualPathsToSourceNodes` and returns a `FileRequireNode` on a miss. That node
offers filesystem children and `.luaurc` aliases only. It cannot list `@game` or
walk the DataModel, so the same file gets no suggestions inside a `@game/...`
string even though the require resolves once it is fully typed.

## Fix

Resolution: handle `@game` before the context gate, and delete the
now-unreachable branch below it.

Autocomplete: `SourcemapAwareFileRequireNode` subclasses `FileRequireNode`. It
keeps the filesystem behaviour and adds the built-in `@game` alias, which does
not depend on the requirer having a node. `FileRequireNode` members move from
private to protected so a platform can subclass it. Only the requirer node needs
this. Once the path descends into a directory, filesystem children are already
correct.

Three sites now match `@game`, so the alias parsing moves into a shared
`parseAliasRequire` helper.

Behaviour that does not change:

- A user-defined `game` alias in `.luaurc` still wins, for both resolution and
  the suggested alias list.
- `@self` and relative requires from a file outside the sourcemap still resolve
  on the filesystem. They need a filesystem base, so the fallback is correct.
- With no sourcemap loaded, `rootSourceNode` is null and nothing changes.

## Reproduction

```sh
mkdir -p repro/src repro/dist repro/packages && cd repro

cat > packages/fluid.luau <<'EOF'
local fluid = {}
function fluid.create(class: string) return class end
return fluid
EOF

cat > src/a.luau <<'EOF'
local fluid = require('@game/ReplicatedStorage/Packages/fluid')
return fluid.create
EOF
cp src/a.luau dist/a.luau
