### PR TITLE
Fix overlapping `{ array }` (rainbow colored) semantic highlighting

### DIFF
--- a/src/operations/SemanticTokens.cpp
+++ b/src/operations/SemanticTokens.cpp
@@ -85,8 +85,9 @@ struct SemanticTokensVisitor : public Luau::AstVisitor
     // We apply visitors in these locations to try and check for synthetic tokens, and mark them as such
     bool visit(Luau::AstTypeTable* table) override
     {
-        // If the indexer location is the same as a result type, the indexer was synthetically added
-        if (table->indexer && table->indexer->indexType->location == table->indexer->resultType->location)
+        // Prevent overlapping tokens for `{ T }` sugar (e.g. `{ string }`): the parser gives the synthetic
+        // `number` index type a zero-width location, which we use to detect and skip it here.
+        if (table->indexer && table->indexer->indexType->location.begin == table->indexer->indexType->location.end)
             syntheticTypes.emplace(table->indexer->indexType);
         return true;
     }

--- a/tests/SemanticTokens.test.cpp
+++ b/tests/SemanticTokens.test.cpp
@@ -141,4 +141,22 @@ TEST_CASE_FIXTURE(Fixture, "semantic_tokens_respects_cancellation")
     CHECK_THROWS_AS(workspace.semanticTokens(lsp::SemanticTokensParams{{{document}}}, cancellationToken), RequestCancelledException);
 }
 
+TEST_CASE_FIXTURE(Fixture, "array_sugar_type_does_not_produce_overlapping_synthetic_token")
+{
+    check(R"(
+local x: { string } = {}
+)");
+
+    auto tokens = getSemanticTokens(workspace.frontend, getMainModule(), getMainSourceModule());
+
+    // The synthetic `number` index type introduced by `{ T }` desugaring must not produce
+    // a semantic token, as it would overlap with the real `string` type reference token.
+    auto synthetic = getSemanticToken(tokens, Luau::Position{1, 9});
+    CHECK(!synthetic);
+
+    auto real = getSemanticToken(tokens, Luau::Position{1, 11});
+    REQUIRE(real);
+    CHECK_EQ(real->tokenType, lsp::SemanticTokenTypes::Type);
+}
+
 TEST_SUITE_END();


### PR DESCRIPTION
Luau arrays such as `{ string }` are just sugar for `{ [number]: string }`. We previously relied on comparing the index type location to the result type location to check if a map table type was actually an array but desugared, but a few months ago a parser change on the Luau side broke that heuristic, triggering the "this is a real map" fallback in all cases, when in the array case no longer has 1:1 source code location positions. This caused overlapping semantic tokens to be partially applied to the inside `string` (or other type) inside an array decl, causing ✨rainbows✨.

Luau's parser now emits the synthetic `[number]` as a zero width location so we can detect that instead for a more accurate way to distinguish arrays from maps. I've applied the fix and added a test `array_sugar_type_does_not_produce_overlapping_synthetic_token` to ensure the new behavior.

Fix contributed from luwu-lsp; lmk if somehow something from luwu that shouldn't be pushed to luau-lsp made it in this PR. 