### PR TITLE
Fix build against Luau 0.737 after DenseHashSet2/DenseHashMap2 rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-- Sync to upstream Luau 0.735
+- Sync to upstream Luau 0.737
 
 ## [1.69.0] - 2026-07-14
 

--- a/src/DocumentationParser.cpp
+++ b/src/DocumentationParser.cpp
@@ -45,7 +45,7 @@ void parseDocumentation(const std::vector<std::string>& documentationFiles, Luau
                         info.at("code_sample").get_to(codeSample);
                     if (info.contains("keys"))
                     {
-                        Luau::DenseHashMap2<std::string, Luau::DocumentationSymbol> keys{};
+                        Luau::DenseHashMap<std::string, Luau::DocumentationSymbol> keys{};
                         for (auto& [k, v] : info.at("keys").items())
                         {
                             keys[k] = v;
@@ -54,7 +54,7 @@ void parseDocumentation(const std::vector<std::string>& documentationFiles, Luau
                     }
                     else if (info.contains("overloads"))
                     {
-                        Luau::DenseHashMap2<std::string, Luau::DocumentationSymbol> overloads{};
+                        Luau::DenseHashMap<std::string, Luau::DocumentationSymbol> overloads{};
                         for (auto& [sig, sym] : info.at("overloads").items())
                         {
                             overloads[sig] = sym;

--- a/src/LanguageServer.cpp
+++ b/src/LanguageServer.cpp
@@ -922,7 +922,7 @@ void LanguageServer::onDidChangeWorkspaceFolders(const lsp::DidChangeWorkspaceFo
 
 void LanguageServer::onDidChangeWatchedFiles(const lsp::DidChangeWatchedFilesParams& params)
 {
-    Luau::DenseHashMap2<WorkspaceFolderPtr, std::vector<lsp::FileEvent>> workspaceChanges{};
+    Luau::DenseHashMap<WorkspaceFolderPtr, std::vector<lsp::FileEvent>> workspaceChanges{};
 
     for (const auto& change : params.changes)
     {

--- a/src/LuauExt.cpp
+++ b/src/LuauExt.cpp
@@ -322,7 +322,7 @@ std::optional<Luau::Location> lookupTypeLocation(const Luau::Scope& deepScope, c
 }
 
 // Returns [base, property] - base is important during intersections
-static std::vector<PropLookup> lookupProp(const Luau::TypeId& parentType, const Luau::Name& name, Luau::DenseHashSet2<Luau::TypeId>& seenSet)
+static std::vector<PropLookup> lookupProp(const Luau::TypeId& parentType, const Luau::Name& name, Luau::DenseHashSet<Luau::TypeId>& seenSet)
 {
     if (seenSet.contains(parentType))
         return {};
@@ -395,7 +395,7 @@ static std::vector<PropLookup> lookupProp(const Luau::TypeId& parentType, const 
 
 std::vector<PropLookup> lookupProp(const Luau::TypeId& parentType, const Luau::Name& name)
 {
-    Luau::DenseHashSet2<Luau::TypeId> seenSet{};
+    Luau::DenseHashSet<Luau::TypeId> seenSet{};
     return lookupProp(parentType, name, seenSet);
 }
 

--- a/src/Workspace.cpp
+++ b/src/Workspace.cpp
@@ -101,7 +101,7 @@ void WorkspaceFolder::onDidSaveTextDocument(const lsp::DocumentUri& uri, const l
     auto config = client->getConfiguration(rootUri);
     if (isWorkspaceDiagnosticsEnabled(client, config))
     {
-        Luau::DenseHashSet2<Luau::ModuleName> dependents{};
+        Luau::DenseHashSet<Luau::ModuleName> dependents{};
         frontend.traverseDependents(fileResolver.getModuleName(uri),
             [&dependents](Luau::SourceNode& sourceNode)
             {

--- a/src/include/Platform/StringRequireAutoImporter.hpp
+++ b/src/include/Platform/StringRequireAutoImporter.hpp
@@ -49,7 +49,7 @@ struct StringRequireResult
     const char* sortText;    // For completion sorting
 };
 
-using AliasMap = DenseHashMap2<std::string, Luau::Config::AliasInfo>;
+using AliasMap = DenseHashMap<std::string, Luau::Config::AliasInfo>;
 
 std::string requireNameFromModuleName(const Luau::ModuleName& name);
 std::optional<std::string> computeBestAliasedPath(const Uri& to, const AliasMap& availableAliases);

--- a/src/operations/References.cpp
+++ b/src/operations/References.cpp
@@ -32,7 +32,7 @@ static bool isSameTableDirect(const Luau::TypeId a, const Luau::TypeId b)
     return false;
 }
 
-static bool tableIsRelatedViaMetatable(const Luau::TypeId metatableType, const Luau::TypeId targetTable, Luau::DenseHashSet2<Luau::TypeId>& visited)
+static bool tableIsRelatedViaMetatable(const Luau::TypeId metatableType, const Luau::TypeId targetTable, Luau::DenseHashSet<Luau::TypeId>& visited)
 {
     auto mt = Luau::get<Luau::MetatableType>(Luau::follow(metatableType));
     if (!mt)
@@ -73,7 +73,7 @@ static bool isSameTable(const Luau::TypeId a, const Luau::TypeId b)
     if (isSameTableDirect(a, b))
         return true;
 
-    Luau::DenseHashSet2<Luau::TypeId> visited{};
+    Luau::DenseHashSet<Luau::TypeId> visited{};
 
     if (Luau::get<Luau::MetatableType>(Luau::follow(a)))
     {

--- a/src/operations/RequireGraph.cpp
+++ b/src/operations/RequireGraph.cpp
@@ -141,7 +141,7 @@ struct ChunkedWriter
 
 std::string requireGraphToDot(const RequireGraph& requireGraph, const Luau::FileResolver& fileResolver)
 {
-    Luau::DenseHashMap2<Luau::ModuleName, int> nodeIdMap{};
+    Luau::DenseHashMap<Luau::ModuleName, int> nodeIdMap{};
 
     ChunkedWriter writer;
     writer.writeRaw("digraph luau_require_graph {\n");


### PR DESCRIPTION
Fixes the CI failures on #1610.

## Summary

- During the sync to upstream Luau 0.735 (#1589), `DenseHashSet`/`DenseHashMap` were temporarily renamed to `DenseHashSet2`/`DenseHashMap2` upstream (an in-progress migration), and luau-lsp's call sites were updated to match.
- Luau 0.737 finished that migration: the `2`-suffixed names were removed and the final API was renamed back to `DenseHashSet`/`DenseHashMap` (same signature — no sentinel key, `size_t buckets = 0` constructor).
- This broke every build job on #1610 with errors like `'DenseHashSet2' is not a member of 'Luau'; did you mean 'DenseHashSet'?` in `src/Workspace.cpp` and `src/LanguageServer.cpp`.

## Changes

Renamed all remaining `DenseHashSet2`/`DenseHashMap2` usages back to `DenseHashSet`/`DenseHashMap` in:
- `src/Workspace.cpp`
- `src/LanguageServer.cpp`
- `src/LuauExt.cpp`
- `src/DocumentationParser.cpp`
- `src/operations/RequireGraph.cpp`
- `src/operations/References.cpp`
- `src/include/Platform/StringRequireAutoImporter.hpp`

## Test plan

- [x] Built `Luau.LanguageServer.CLI` locally against the updated `luau` submodule (0.737) — compiles cleanly
- [x] Built `Luau.LanguageServer.Test` locally — compiles cleanly
- [x] Ran the full test suite: `860 test cases, 65622 assertions, 0 failed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sDE3kojDswFBiPrn4TqbP

---
_Generated by [Claude Code](https://claude.ai/code/session_012sDE3kojDswFBiPrn4TqbP)_